### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,31 @@
 
 ## Unreleased
 
+## v0.5.0
+
+What's changed since v0.4.0:
+
+- New rules:
+  - Virtual machines:
+    - Added rule to verify Windows automatic updates are enabled. [#132](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/132)
+    - Added rule to verify VM agent is automatically provisioned. [#131](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/131)
+- Updated rules:
+  - Azure Kubernetes Services:
+    - Updated `Azure.AKS.Version` to 1.14.6. [#130](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/130)
+- General improvements:
+  - Shorten rule names for virtual machined to `Azure.VM.*` to improve output display. [#119](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/119)
+    - **Breaking change**: Rules have been renamed from `Azure.VirtualMachine.*` to `Azure.VM.*`.
+
+What's changed since pre-release v0.5.0-B1910004:
+
+- No additional changes.
+
 ## v0.5.0-B1910004 (pre-release)
 
 - Added rule to verify Windows automatic updates are enabled. [#132](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/132)
 - Added rule to verify VM agent is automatically provisioned. [#131](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/131)
 - Updated `Azure.AKS.Version` to 1.14.6. [#130](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/130)
-- **Breaking change**: Renamed `Azure.VirtualMachine.*` rules to `Azure.VM.*` [#119](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/119)
+- **Breaking change**: Renamed `Azure.VirtualMachine.*` rules to `Azure.VM.*`. [#119](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/119)
 
 ## v0.4.0
 


### PR DESCRIPTION
## PR Summary

What's changed since v0.4.0:

- New rules:
  - Virtual machines:
    - Added rule to verify Windows automatic updates are enabled. #132
    - Added rule to verify VM agent is automatically provisioned. #131
- Updated rules:
  - Azure Kubernetes Services:
    - Updated `Azure.AKS.Version` to 1.14.6. #130
- General improvements:
  - Shorten rule names for virtual machined to `Azure.VM.*` to improve output display. #119
    - **Breaking change**: Rules have been renamed from `Azure.VirtualMachine.*` to `Azure.VM.*`.

What's changed since pre-release v0.5.0-B1910004:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
