### PR TITLE
Pre-release v1.5.0-B2107002

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,8 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.5.0-B2107002 (pre-release)
+
 What's changed since pre-release v1.5.0-B2106018:
 
 - New features:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.5.0-B2106018:

- New features:
  - Added `Azure.GA_2021_06` baseline. #822
    - Includes rules released before or during June 2021 for Azure GA features.
    - Marked baseline `Azure.GA_2021_03` as obsolete.
- General improvements:
  - Updated rule help to use docs pages for online version. #824
- Engineering:
  - Bump PSDocs dependency to v1.4.0. #823
  - Bump YamlDotNet dependency to v11.2.1. #821

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
