### PR TITLE
Pester v5 migration

### DIFF
--- a/tests/Bicep/Bicep.Tests.ps1
+++ b/tests/Bicep/Bicep.Tests.ps1
@@ -8,18 +8,20 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
-
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
 
 Describe 'Bicep' -Tag 'Bicep' {
     Context 'Azure.ExpandBicep convention' {

--- a/tests/Integration/QuickStartTemplate.Tests.ps1
+++ b/tests/Integration/QuickStartTemplate.Tests.ps1
@@ -15,47 +15,50 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
-}
+BeforeDiscovery {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$clonePath = Join-Path -Path $rootPath -ChildPath out/tests/quickstart/;
-$exportPath = Join-Path -Path $clonePath -ChildPath azure-quickstart-templates-master/;
-$cloneDownload = Join-Path -Path $rootPath -ChildPath quickstart.zip;
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
 
-# Download and unpack files
-if (!(Test-Path -Path $cloneDownload)) {
-    $Null = Invoke-WebRequest -Uri 'https://github.com/Azure/azure-quickstart-templates/archive/master.zip' -OutFile $cloneDownload -UseBasicParsing;
-}
-if (!(Test-Path -Path $clonePath)) {
-    $Null = New-Item -Path $clonePath -ItemType Directory -Force;
-    $Null = Expand-Archive -Path $cloneDownload -DestinationPath $clonePath;
-}
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $clonePath = Join-Path -Path $rootPath -ChildPath out/tests/quickstart/;
+    $exportPath = Join-Path -Path $clonePath -ChildPath azure-quickstart-templates-master/;
+    $cloneDownload = Join-Path -Path $rootPath -ChildPath quickstart.zip;
 
-function Get-Sample {
-    [CmdletBinding()]
-    [OutputType([PSObject])]
-    param (
-        [Parameter(Mandatory = $True)]
-        [String]$Path
-    )
-    process {
-        Get-ChildItem -Path $Path/azure-quickstart-templates-master -Directory | ForEach-Object -Process {
-            $directory = $_;
-            $templateFile = Join-Path -Path $directory.FullName -ChildPath 'azuredeploy.json';
-            $parametersFile = Join-Path -Path $directory.FullName -ChildPath 'azuredeploy.parameters.json';
-            if (Test-Path -Path $templateFile -PathType Leaf) {
-                [PSCustomObject]@{
-                    Name = $directory.Name;
-                    TemplateFile = $templateFile;
-                    ParametersFile = $parametersFile;
+    # Download and unpack files
+    if (!(Test-Path -Path $cloneDownload)) {
+        $Null = Invoke-WebRequest -Uri 'https://github.com/Azure/azure-quickstart-templates/archive/master.zip' -OutFile $cloneDownload -UseBasicParsing;
+    }
+    if (!(Test-Path -Path $clonePath)) {
+        $Null = New-Item -Path $clonePath -ItemType Directory -Force;
+        $Null = Expand-Archive -Path $cloneDownload -DestinationPath $clonePath;
+    }
+
+    function Get-Sample {
+        [CmdletBinding()]
+        [OutputType([PSObject])]
+        param (
+            [Parameter(Mandatory = $True)]
+            [String]$Path
+        )
+        process {
+            Get-ChildItem -Path $Path/azure-quickstart-templates-master -Directory | ForEach-Object -Process {
+                $directory = $_;
+                $templateFile = Join-Path -Path $directory.FullName -ChildPath 'azuredeploy.json';
+                $parametersFile = Join-Path -Path $directory.FullName -ChildPath 'azuredeploy.parameters.json';
+                if (Test-Path -Path $templateFile -PathType Leaf) {
+                    [PSCustomObject]@{
+                        Name = $directory.Name;
+                        TemplateFile = $templateFile;
+                        ParametersFile = $parametersFile;
+                    }
                 }
             }
         }
@@ -64,50 +67,47 @@ function Get-Sample {
 
 Describe 'Azure Quickstart Templates' -Tag integration {
     Context 'Export template data' {
-        # Skips templates because they are not complete
-        $skipTemplates = @(
-            "100-blank-template"
-            # "101-hdinsight-custom-ambari-db"
-            # "101-sql-vm-aglistener-setup"
-            # "101-sql-vm-ag-setup"
-            # "101-vm-windows-copy-datadisks"
-            # "201-api-management-logs-oms-integration"
-            # "201-data-factory-ftp-hive-blob"
-            # "201-list-storage-keys-windows-vm"
-            # "201-vm-msi"
-            # "201-vm-win-iis-app-ssl"
-            # "201-vmss-win-iis-app-ssl"
-            # "301-custom-images-at-scale"
-            # "301-drupal8-vmss-glusterfs-mysql"
-            # "301-jenkins-aptly-spinnaker-vmss"
-            # "301-vm-sql-full-autobackup-autopatching-keyvault"
-            # "blockchain"
-            # "chef-ha-cluster"
-            # "couchbase"
-            # "hdinsight-genomics-adam"
-            # "hdinsight-linux-run-script-action"
-            # "intel-lustre-client-server"
-            # "sql-server-2014-alwayson-existing-vnet-and-ad"
-            # "kemp-loadmaster-multinic"
-            # "memcached-multi-vm-ubuntu"
-            # "oms-azure-storage-analytics-solution"
-            # "openedx-devstack-ubuntu"
-            # "opensis-cluster-ubuntu"
-            # "rhel-3tier-iaas"
-            # "slurm-on-sles12-hpc"
-            # "traffic-manager-demo-setup"
-            # "vsts-fullbuild-redhat-vm"
-            # "vsts-fullbuild-ubuntu-vm"
-            # "vsts-minbuildjava-ubuntu-vm"
-        )
-        foreach ($sample in (Get-Sample -Path $clonePath)) {
-            if ($sample.Name -in $skipTemplates) {
-                continue;
-            }
-            It "$($sample.Name)" {
-                $result = Export-AzRuleTemplateData -TemplateFile $sample.TemplateFile -ParameterFile $sample.ParametersFile -OutputPath $exportPath;
-                $result | Should -Not -BeNullOrEmpty;
-            }
+        BeforeDiscovery {
+            # Skips templates because they are not complete
+            $skipTemplates = @(
+                "100-blank-template"
+                # "101-hdinsight-custom-ambari-db"
+                # "101-sql-vm-aglistener-setup"
+                # "101-sql-vm-ag-setup"
+                # "101-vm-windows-copy-datadisks"
+                # "201-api-management-logs-oms-integration"
+                # "201-data-factory-ftp-hive-blob"
+                # "201-list-storage-keys-windows-vm"
+                # "201-vm-msi"
+                # "201-vm-win-iis-app-ssl"
+                # "201-vmss-win-iis-app-ssl"
+                # "301-custom-images-at-scale"
+                # "301-drupal8-vmss-glusterfs-mysql"
+                # "301-jenkins-aptly-spinnaker-vmss"
+                # "301-vm-sql-full-autobackup-autopatching-keyvault"
+                # "blockchain"
+                # "chef-ha-cluster"
+                # "couchbase"
+                # "hdinsight-genomics-adam"
+                # "hdinsight-linux-run-script-action"
+                # "intel-lustre-client-server"
+                # "sql-server-2014-alwayson-existing-vnet-and-ad"
+                # "kemp-loadmaster-multinic"
+                # "memcached-multi-vm-ubuntu"
+                # "oms-azure-storage-analytics-solution"
+                # "openedx-devstack-ubuntu"
+                # "opensis-cluster-ubuntu"
+                # "rhel-3tier-iaas"
+                # "slurm-on-sles12-hpc"
+                # "traffic-manager-demo-setup"
+                # "vsts-fullbuild-redhat-vm"
+                # "vsts-fullbuild-ubuntu-vm"
+                # "vsts-minbuildjava-ubuntu-vm"
+            )
+        }
+        It '<_.Name>' -ForEach (Get-Sample -Path $clonePath | Where-Object { $_.Name -notin $skipTemplates }) {
+            $result = Export-AzRuleTemplateData -TemplateFile $_.TemplateFile -ParameterFile $_.ParametersFile -OutputPath $exportPath;
+            $result | Should -Not -BeNullOrEmpty;
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
@@ -10,31 +10,34 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.ACR' -Tag 'ACR' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.ACR.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
-            Outcome = 'All'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+                Outcome = 'All'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.ACR.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
 
         It 'Azure.ACR.AdminUser' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.ACR.AdminUser' };
@@ -188,48 +191,49 @@ Describe 'Azure.ACR' -Tag 'ACR' {
     }
 
     Context 'Resource name' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $testObject = [PSCustomObject]@{
+                Name = ''
+                ResourceType = 'Microsoft.ContainerRegistry/registries'
+            }
         }
-        $validNames = @(
-            'registry1'
-            'REGISTRY001'
-        )
-        $invalidNames = @(
-            '_registry1'
-            '-registry1'
-            'registry1_'
-            'registry1-'
-            'registry-1'
-            'acr1'
-            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-        )
-        $testObject = [PSCustomObject]@{
-            Name = ''
-            ResourceType = 'Microsoft.ContainerRegistry/registries'
+
+        BeforeDiscovery {
+            $validNames = @(
+                'registry1'
+                'REGISTRY001'
+            )
+            $invalidNames = @(
+                '_registry1'
+                '-registry1'
+                'registry1_'
+                'registry1-'
+                'registry-1'
+                'acr1'
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            )
         }
 
         # Pass
-        foreach ($name in $validNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.ACR.Name';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Pass';
-            }
+        It '<_>' -ForEach $validNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.ACR.Name';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Pass';
         }
 
         # Fail
-        foreach ($name in $invalidNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.ACR.Name';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Fail';
-            }
+        It '<_>' -ForEach $invalidNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.ACR.Name';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Fail';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
@@ -8,30 +8,33 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.AppConfig' -Tag 'AppConfig' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.AppConfig.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.AppConfig.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
 
         It 'Azure.AppConfig.SKU' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppConfig.SKU' };
@@ -51,44 +54,45 @@ Describe 'Azure.AppConfig' -Tag 'AppConfig' {
     }
 
     Context 'Resource name' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $testObject = [PSCustomObject]@{
+                Name = ''
+                ResourceType = 'Microsoft.AppConfiguration/configurationStores'
+            }
         }
-        $validNames = @(
-            'config-1'
-            '1-Config'
-        )
-        $invalidNames = @(
-            'config_1'
-            'cfg1'
-            'config.1'
-        )
-        $testObject = [PSCustomObject]@{
-            Name = ''
-            ResourceType = 'Microsoft.AppConfiguration/configurationStores'
+
+        BeforeDiscovery {
+            $validNames = @(
+                'config-1'
+                '1-Config'
+            )
+            $invalidNames = @(
+                'config_1'
+                'cfg1'
+                'config.1'
+            )
         }
 
         # Pass
-        foreach ($name in $validNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.AppConfig.Name';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Pass';
-            }
+        It '<_>' -ForEach $validNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.AppConfig.Name';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Pass';
         }
 
         # Fail
-        foreach ($name in $invalidNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.AppConfig.Name';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Fail';
-            }
+        It '<_>' -ForEach $invalidNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.AppConfig.Name';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Fail';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppGw.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppGw.Tests.ps1
@@ -8,30 +8,33 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.AppGw.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.AppGw.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All;
 
         It 'Azure.AppGw.MinInstance' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppGw.MinInstance' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppInsights.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppInsights.Tests.ps1
@@ -8,30 +8,33 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.AppInsights' -Tag 'AppInsights' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.AppInsights.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.AppInsights.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
 
         It 'Azure.AppInsights.Workspace' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppInsights.Workspace' };
@@ -51,16 +54,18 @@ Describe 'Azure.AppInsights' -Tag 'AppInsights' {
     }
 
     Context 'With Template' {
-        $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.AppInsights.json;
-        $templatePath = Join-Path -Path $here -ChildPath 'Resources.AppInsights.Template.json';
-        Export-AzRuleTemplateData -TemplateFile $templatePath -OutputPath $outputFile;
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.AppInsights.json;
+            $templatePath = Join-Path -Path $here -ChildPath 'Resources.AppInsights.Template.json';
+            Export-AzRuleTemplateData -TemplateFile $templatePath -OutputPath $outputFile;
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $result = Invoke-PSRule @invokeParams -InputPath $outputFile -Outcome All;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $outputFile -Outcome All;
 
         It 'Azure.AppInsights.Workspace' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppInsights.Workspace' };
@@ -78,50 +83,52 @@ Describe 'Azure.AppInsights' -Tag 'AppInsights' {
     }
 
     Context 'Resource name - Azure.AppInsights.Name' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeDiscovery {
+            $validNames = @(
+                'app-1'
+                '1-App'
+                'app_1'
+                'app.1'
+                'app(1)'
+                '..app1'
+                '--app1'
+                '__app1'
+            )
+            $invalidNames = @(
+                'app1.'
+                'app[1]'
+                'app1?'
+            )
         }
-        $validNames = @(
-            'app-1'
-            '1-App'
-            'app_1'
-            'app.1'
-            'app(1)'
-            '..app1'
-            '--app1'
-            '__app1'
-        )
-        $invalidNames = @(
-            'app1.'
-            'app[1]'
-            'app1?'
-        )
-        $testObject = [PSCustomObject]@{
-            Name = ''
-            ResourceType = 'microsoft.insights/components'
+
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+
+            $testObject = [PSCustomObject]@{
+                Name = ''
+                ResourceType = 'microsoft.insights/components'
+            }
         }
 
         # Pass
-        foreach ($name in $validNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.AppInsights.Name';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Pass';
-            }
+        It '<_>' -ForEach $validNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.AppInsights.Name';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Pass';
         }
 
         # Fail
-        foreach ($name in $invalidNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.AppInsights.Name';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Fail';
-            }
+        It '<_>' -ForEach $invalidNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.AppInsights.Name';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Fail';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Automation.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Automation.Tests.ps1
@@ -10,24 +10,27 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.Automation' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.Automation.json';
-
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
+        BeforeAll {
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.Automation.json';
+            $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
+        }
 
         It 'Azure.Automation.EncryptVariables' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Automation.EncryptVariables' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
@@ -8,30 +8,33 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Baselines' -Tag Baseline {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.Resource.json';
-
     Context 'Binding' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.Resource.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All;
 
         It 'TargetType' {
             $result.TargetType | Should -Not -BeIn 'System.Management.Automation.PSCustomObject';

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Convention.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Convention.Tests.ps1
@@ -8,18 +8,20 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
-
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
 
 Describe 'Azure.ExpandTemplate' -Tag 'Convention' {
     Context 'Convention' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.DataFactory.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.DataFactory.Tests.ps1
@@ -10,30 +10,33 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.DataFactory' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.DataFactory.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.DataFactory.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
 
         It 'Azure.DataFactory.Version' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.DataFactory.Version' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.LogicApp.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.LogicApp.Tests.ps1
@@ -10,30 +10,33 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.LogicApp' -Tag 'LogicApp' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.LogicApp.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.LogicApp.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All;
 
         It 'Azure.LogicApp.LimitHTTPTrigger' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.LogicApp.LimitHTTPTrigger' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
@@ -8,30 +8,33 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.MySQL' -Tag 'MySql' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.MySQL.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.MySQL.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
 
         It 'Azure.MySQL.UseSSL' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.MySQL.UseSSL' };
@@ -117,47 +120,50 @@ Describe 'Azure.MySQL' -Tag 'MySql' {
     }
 
     Context 'Resource name - Azure.MySQL.ServerName' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+
+            $testObject = [PSCustomObject]@{
+                Name = ''
+                ResourceType = 'Microsoft.DBforMySQL/servers'
+            }
         }
-        $validNames = @(
-            'sqlserver1'
-            'sqlserver-1'
-            '1sqlserver'
-        )
-        $invalidNames = @(
-            '-sqlserver1'
-            'sqlserver1-'
-            'sqlserver.1'
-            'sqlserver_1'
-            'SQLServer1'
-        )
-        $testObject = [PSCustomObject]@{
-            Name = ''
-            ResourceType = 'Microsoft.DBforMySQL/servers'
+
+        BeforeDiscovery {
+            $validNames = @(
+                'sqlserver1'
+                'sqlserver-1'
+                '1sqlserver'
+            )
+
+            $invalidNames = @(
+                '-sqlserver1'
+                'sqlserver1-'
+                'sqlserver.1'
+                'sqlserver_1'
+                'SQLServer1'
+            )
         }
 
         # Pass
-        foreach ($name in $validNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.MySQL.ServerName';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Pass';
-            }
+        It '<_>' -ForEach $validNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.MySQL.ServerName';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Pass';
         }
 
         # Fail
-        foreach ($name in $invalidNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.MySQL.ServerName';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Fail';
-            }
+        It '<_>' -ForEach $invalidNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.MySQL.ServerName';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Fail';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Policy.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Policy.Tests.ps1
@@ -8,30 +8,33 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.Policy' -Tag Policy {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.Policy.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.Policy.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
 
         It 'Azure.Policy.Descriptors' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Policy.Descriptors' };
@@ -115,11 +118,13 @@ Describe 'Azure.Policy' -Tag Policy {
     }
 
     Context 'With Template' {
-        $templatePath = Join-Path -Path $here -ChildPath 'Resources.Policy.Template.json';
-        $parameterPath = Join-Path -Path $here -ChildPath 'Resources.Policy.Parameters.json';
-        $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.Policy.json;
-        Export-AzRuleTemplateData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
+        BeforeAll {
+            $templatePath = Join-Path -Path $here -ChildPath 'Resources.Policy.Template.json';
+            $parameterPath = Join-Path -Path $here -ChildPath 'Resources.Policy.Parameters.json';
+            $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.Policy.json;
+            Export-AzRuleTemplateData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
+            $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
+        }
 
         It 'Azure.Policy.Descriptors' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Policy.Descriptors' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.PostgreSQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.PostgreSQL.Tests.ps1
@@ -8,30 +8,33 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.PostgreSQL' -Tag 'PostgreSQL' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.PostgreSQL.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.PostgreSQL.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
 
         It 'Azure.PostgreSQL.UseSSL' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.PostgreSQL.UseSSL' };
@@ -117,47 +120,50 @@ Describe 'Azure.PostgreSQL' -Tag 'PostgreSQL' {
     }
 
     Context 'Resource name - Azure.PostgreSQL.ServerName' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+
+            $testObject = [PSCustomObject]@{
+                Name = ''
+                ResourceType = 'Microsoft.DBforPostgreSQL/servers'
+            }
         }
-        $validNames = @(
-            'sqlserver1'
-            'sqlserver-1'
-            '1sqlserver'
-        )
-        $invalidNames = @(
-            '-sqlserver1'
-            'sqlserver1-'
-            'sqlserver.1'
-            'sqlserver_1'
-            'SQLServer1'
-        )
-        $testObject = [PSCustomObject]@{
-            Name = ''
-            ResourceType = 'Microsoft.DBforPostgreSQL/servers'
+
+        BeforeDiscovery {
+            $validNames = @(
+                'sqlserver1'
+                'sqlserver-1'
+                '1sqlserver'
+            )
+
+            $invalidNames = @(
+                '-sqlserver1'
+                'sqlserver1-'
+                'sqlserver.1'
+                'sqlserver_1'
+                'SQLServer1'
+            )
         }
 
         # Pass
-        foreach ($name in $validNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.PostgreSQL.ServerName';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Pass';
-            }
+        It '<_>' -ForEach $validNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.PostgreSQL.ServerName';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Pass';
         }
 
         # Fail
-        foreach ($name in $invalidNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.PostgreSQL.ServerName';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Fail';
-            }
+        It '<_>' -ForEach $invalidNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.PostgreSQL.ServerName';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Fail';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Redis.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Redis.Tests.ps1
@@ -10,30 +10,33 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.Redis' -Tag 'Redis' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.Redis.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.Redis.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
 
         It 'Azure.Redis.NonSslPort' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Redis.NonSslPort' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.SQLMI.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.SQLMI.Tests.ps1
@@ -8,63 +8,67 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.SQLMI' -Tag 'SQLMI' {
-
     Context 'Resource name - Azure.SQLMI.Name' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+
+            $testObject = [PSCustomObject]@{
+                Name = ''
+                ResourceType = 'Microsoft.Sql/managedInstances'
+            }
         }
-        $validNames = @(
-            'sqlserver1'
-            'sqlserver-1'
-            '1sqlserver'
-        )
-        $invalidNames = @(
-            '-sqlserver1'
-            'sqlserver1-'
-            'sqlserver.1'
-            'sqlserver_1'
-            'SQLServer1'
-        )
-        $testObject = [PSCustomObject]@{
-            Name = ''
-            ResourceType = 'Microsoft.Sql/managedInstances'
+
+        BeforeDiscovery {
+            $validNames = @(
+                'sqlserver1'
+                'sqlserver-1'
+                '1sqlserver'
+            )
+
+            $invalidNames = @(
+                '-sqlserver1'
+                'sqlserver1-'
+                'sqlserver.1'
+                'sqlserver_1'
+                'SQLServer1'
+            )
         }
 
         # Pass
-        foreach ($name in $validNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.SQLMI.Name';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Pass';
-            }
+        It '<_>' -ForEach $validNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.SQLMI.Name';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Pass';
         }
 
         # Fail
-        foreach ($name in $invalidNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.SQLMI.Name';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Fail';
-            }
+        It '<_>' -ForEach $invalidNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.SQLMI.Name';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Fail';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ServiceFabric.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ServiceFabric.Tests.ps1
@@ -8,30 +8,33 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.ServiceFabric' -Tag 'ServiceFabric' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.ServiceFabric.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.ServiceFabric.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All;
 
         It 'Azure.ServiceFabric.AAD' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.ServiceFabric.AAD' };
@@ -51,11 +54,13 @@ Describe 'Azure.ServiceFabric' -Tag 'ServiceFabric' {
     }
 
     Context 'With template' {
-        $templatePath = Join-Path -Path $here -ChildPath 'Resources.ServiceFabric.Template.json';
-        $parameterPath = Join-Path -Path $here -ChildPath 'Resources.ServiceFabric.Parameters.json';
-        $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.ServiceFabric.json;
-        Export-AzRuleTemplateData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
+        BeforeAll {
+            $templatePath = Join-Path -Path $here -ChildPath 'Resources.ServiceFabric.Template.json';
+            $parameterPath = Join-Path -Path $here -ChildPath 'Resources.ServiceFabric.Parameters.json';
+            $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.ServiceFabric.json;
+            Export-AzRuleTemplateData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
+            $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
+        }
 
         It 'Azure.ServiceFabric.AAD' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.ServiceFabric.AAD' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.SignalR.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.SignalR.Tests.ps1
@@ -10,63 +10,68 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
-
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
 
 Describe 'Azure.SignalR' -Tag 'SignalR' {
     # $dataPath = Join-Path -Path $here -ChildPath 'Resources.SignalR.json';
 
     Context 'Resource name' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+
+            $testObject = [PSCustomObject]@{
+                Name = ''
+                ResourceType = 'Microsoft.SignalRService/signalR'
+            }
         }
-        $validNames = @(
-            'service1'
-            'SERVICE-1'
-        )
-        $invalidNames = @(
-            '_service1'
-            '-service1'
-            '1service'
-            'se'
-            's'
-        )
-        $testObject = [PSCustomObject]@{
-            Name = ''
-            ResourceType = 'Microsoft.SignalRService/signalR'
+
+        BeforeDiscovery {
+            $validNames = @(
+                'service1'
+                'SERVICE-1'
+            )
+
+            $invalidNames = @(
+                '_service1'
+                '-service1'
+                '1service'
+                'se'
+                's'
+            )
         }
 
         # Pass
-        foreach ($name in $validNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.SignalR.Name';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Pass';
-            }
+        It '<_>' -ForEach $validNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.SignalR.Name';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Pass';
         }
 
         # Fail
-        foreach ($name in $invalidNames) {
-            It $name {
-                $testObject.Name = $name;
-                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.SignalR.Name';
-                $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Outcome | Should -Be 'Fail';
-            }
+        It '<_>' -ForEach $invalidNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.SignalR.Name';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Fail';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Subscription.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Subscription.Tests.ps1
@@ -8,30 +8,33 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
+    $dataPath = Join-Path -Path $here -ChildPath 'Resources.Subscription.json';
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.RBAC' -Tag 'Subscription', 'RBAC' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.Subscription.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
 
         It 'Azure.RBAC.UseGroups' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.RBAC.UseGroups' };
@@ -132,16 +135,16 @@ Describe 'Azure.RBAC' -Tag 'Subscription', 'RBAC' {
 }
 
 Describe 'Azure.SecurityCenter' -Tag 'Subscription', 'SecurityCenter' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.Subscription.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
 
         It 'Azure.SecurityCenter.Contact' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.SecurityCenter.Contact' };
@@ -179,16 +182,16 @@ Describe 'Azure.SecurityCenter' -Tag 'Subscription', 'SecurityCenter' {
 
 
 Describe 'Azure.Monitor' -Tag 'Subscription', 'Monitor' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.Subscription.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
 
         It 'Azure.Monitor.ServiceHealth' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Monitor.ServiceHealth' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
@@ -8,26 +8,30 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
-
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
 
 Describe 'Azure.Template' -Tag 'Template' {
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'SilentlyContinue'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'SilentlyContinue'
+                ErrorAction = 'Stop'
+            }
         }
 
         It 'Azure.Template.TemplateFile' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.TrafficManager.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.TrafficManager.Tests.ps1
@@ -10,30 +10,33 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'Azure.TrafficManager' -Tag 'TrafficManager' {
-    $dataPath = Join-Path -Path $here -ChildPath 'Resources.TrafficManager.json';
-
     Context 'Conditions' {
-        $invokeParams = @{
-            Baseline = 'Azure.All'
-            Module = 'PSRule.Rules.Azure'
-            WarningAction = 'Ignore'
-            ErrorAction = 'Stop'
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.TrafficManager.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All; 
         }
-        $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All;
 
         It 'Azure.TrafficManager.Endpoints' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.TrafficManager.Endpoints' };

--- a/tests/PSRule.Rules.Azure.Tests/Module.PSGallery.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Module.PSGallery.Tests.ps1
@@ -10,17 +10,19 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    $modulePath = Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure;
 }
-
-# Setup tests paths
-$rootPath = $PWD;
-$modulePath = Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure;
 
 Describe 'PSRule.Rules.Azure' -Tag 'PowerShellGallery' {
     Context 'Module' {
@@ -30,8 +32,10 @@ Describe 'PSRule.Rules.Azure' -Tag 'PowerShellGallery' {
     }
 
     Context 'Manifest' {
-        $manifestPath = (Join-Path -Path $modulePath -ChildPath PSRule.Rules.Azure.psd1);
-        $result = Test-ModuleManifest -Path $manifestPath;
+        BeforeAll {
+            $manifestPath = (Join-Path -Path $modulePath -ChildPath PSRule.Rules.Azure.psd1);
+            $result = Test-ModuleManifest -Path $manifestPath;
+        }
 
         It 'Has required fields' {
             $result.Name | Should -Be 'PSRule.Rules.Azure';

--- a/tests/PSRule.Rules.Azure.Tests/Rule.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Rule.Common.Tests.ps1
@@ -8,63 +8,69 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'SupportsTags' -Tag 'Common', 'Filters', 'SupportsTags' {
-    $invokeParams = @{
-        Baseline = 'Azure.All'
-        Module = 'PSRule.Rules.Azure'
-        WarningAction = 'Ignore'
-        ErrorAction = 'Stop'
-    }
-    $tempResource = [PSCustomObject]@{
-        Type = 'None'
+    BeforeAll {
+        $invokeParams = @{
+            Baseline = 'Azure.All'
+            Module = 'PSRule.Rules.Azure'
+            WarningAction = 'Ignore'
+            ErrorAction = 'Stop'
+        }
+        $tempResource = [PSCustomObject]@{
+            Type = 'None'
+        }
     }
 
     Context 'Supports tags' {
-        # Supported types
-        $resourceTypes = @(
-            'Microsoft.ContainerRegistry/registries'
-            'Microsoft.Network/networkSecurityGroups'
-            'Microsoft.Network/routeTables'
-            'Microsoft.Resources/resourceGroups'
-            'Microsoft.CostManagement/Connectors'
-        )
-        foreach ($resourceType in $resourceTypes) {
-            It $resourceType {
-                $tempResource.Type = $resourceType;
-                $result = $tempResource | Invoke-PSRule @invokeParams -Name 'Azure.Resource.UseTags' -Outcome All;
-                $result.Outcome | Should -Be 'Fail';
-            }
+        BeforeDiscovery {
+            # Supported types
+            $resourceTypes = @(
+                'Microsoft.ContainerRegistry/registries'
+                'Microsoft.Network/networkSecurityGroups'
+                'Microsoft.Network/routeTables'
+                'Microsoft.Resources/resourceGroups'
+                'Microsoft.CostManagement/Connectors'
+            )
+        }
+
+        It '<_>' -ForEach $resourceTypes {
+            $tempResource.Type = $_;
+            $result = $tempResource | Invoke-PSRule @invokeParams -Name 'Azure.Resource.UseTags' -Outcome All;
+            $result.Outcome | Should -Be 'Fail';
         }
     }
 
     Context 'Does not support tags' {
-        $resourceTypes = @(
-            'Microsoft.Authorization/policyDefinitions'
-            'Microsoft.Authorization/policySetDefinitions'
-            'Microsoft.Authorization/policyAssignments'
-            'microsoft.insights/diagnosticSettings'
-            'Microsoft.KeyVault/vaults/providers/diagnosticSettings'
-            'Microsoft.CostManagement/budgets'
-        )
-        foreach ($resourceType in $resourceTypes) {
-            It $resourceType {
-                $tempResource.Type = $resourceType;
-                $result = $tempResource | Invoke-PSRule @invokeParams -Name 'Azure.Resource.UseTags' -Outcome All;
-                $result.Outcome | Should -Be 'None';
-            }
+        BeforeDiscovery {
+            $resourceTypes = @(
+                'Microsoft.Authorization/policyDefinitions'
+                'Microsoft.Authorization/policySetDefinitions'
+                'Microsoft.Authorization/policyAssignments'
+                'microsoft.insights/diagnosticSettings'
+                'Microsoft.KeyVault/vaults/providers/diagnosticSettings'
+                'Microsoft.CostManagement/budgets'
+            )
+        }
+
+        It '<_>' -ForEach $resourceTypes {
+            $tempResource.Type = $_;
+            $result = $tempResource | Invoke-PSRule @invokeParams -Name 'Azure.Resource.UseTags' -Outcome All;
+            $result.Outcome | Should -Be 'None';
         }
     }
 }


### PR DESCRIPTION
## PR Summary

Fix #395

Converted `*.Tests.ps1` to be compatible with Pester V5. Updated CI pipeline to use 5.2.2, which is the latest stable release from Pester. 

<img width="575" alt="Pester" src="https://user-images.githubusercontent.com/20082136/128626953-fb7f6fbf-9277-4e39-b102-37da90f94286.PNG">

As shown in the screenshot above, tests run fine locally using 5.2.2. Will just need to check if this behaves with CI. 

I mainly had to change v4 tests to use `BeforeAll/BeforeDiscovery` scoping, and some other things to get them to work with v5. Test behavior remains the same. Unfortunately v5 brought a lot of breaking changes, so this work is quite cumbersome 😄. 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [ ] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
