### PR TITLE
Updated Azure.VNET.UseNSGs #869

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,11 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since v1.6.0:
+
+- Updated rules:
+  - Excluded `AzureFirewallManagementSubnet` from `Azure.VNET.UseNSGs`. [#869](https://github.com/Azure/PSRule.Rules.Azure/issues/869)
+
 ## v1.6.0
 
 What's changed since v1.5.1:
@@ -150,7 +155,7 @@ What's changed since v1.3.2:
     - Check clusters have an auto-upgrade channel set (preview). [#787](https://github.com/Azure/PSRule.Rules.Azure/issues/787)
     - Check clusters limit access network access to the API server. [#788](https://github.com/Azure/PSRule.Rules.Azure/issues/788)
     - Check clusters used Azure RBAC for Kubernetes authorization. [#789](https://github.com/Azure/PSRule.Rules.Azure/issues/789)
-- Updated rules
+- Updated rules:
   - Azure Kubernetes Service:
     - Updated `Azure.AKS.Version` to 1.20.5. [#767](https://github.com/Azure/PSRule.Rules.Azure/issues/767)
 - General improvements:
@@ -182,7 +187,7 @@ What's changed since pre-release v1.4.0-B2105050:
     - Check clusters have an auto-upgrade channel set (preview). [#787](https://github.com/Azure/PSRule.Rules.Azure/issues/787)
     - Check clusters limit access network access to the API server. [#788](https://github.com/Azure/PSRule.Rules.Azure/issues/788)
     - Check clusters used Azure RBAC for Kubernetes authorization. [#789](https://github.com/Azure/PSRule.Rules.Azure/issues/789)
-- Updated rules
+- Updated rules:
   - Azure Kubernetes Service:
     - Updated `Azure.AKS.Version` to 1.20.5. [#767](https://github.com/Azure/PSRule.Rules.Azure/issues/767)
 - Engineering:

--- a/docs/en/baselines/Azure.All.md
+++ b/docs/en/baselines/Azure.All.md
@@ -214,7 +214,7 @@ Name | Synopsis | Severity
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
 [Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
-[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Subnets should have NSGs assigned. | Critical
+[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness
 [Azure.VNG.ERLegacySKU](../rules/Azure.VNG.ERLegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of ExpressRoute (ER) gateways. | Important
 [Azure.VNG.Name](../rules/Azure.VNG.Name.md) | Virtual Network Gateway (VNG) names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.Default.md
+++ b/docs/en/baselines/Azure.Default.md
@@ -210,7 +210,7 @@ Name | Synopsis | Severity
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
 [Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
-[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Subnets should have NSGs assigned. | Critical
+[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness
 [Azure.VNG.ERLegacySKU](../rules/Azure.VNG.ERLegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of ExpressRoute (ER) gateways. | Important
 [Azure.VNG.Name](../rules/Azure.VNG.Name.md) | Virtual Network Gateway (VNG) names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2020_06.md
+++ b/docs/en/baselines/Azure.GA_2020_06.md
@@ -142,7 +142,7 @@ Name | Synopsis | Severity
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
 [Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
-[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Subnets should have NSGs assigned. | Critical
+[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness
 [Azure.VNG.ERLegacySKU](../rules/Azure.VNG.ERLegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of ExpressRoute (ER) gateways. | Important
 [Azure.VNG.Name](../rules/Azure.VNG.Name.md) | Virtual Network Gateway (VNG) names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2020_09.md
+++ b/docs/en/baselines/Azure.GA_2020_09.md
@@ -158,7 +158,7 @@ Name | Synopsis | Severity
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
 [Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
-[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Subnets should have NSGs assigned. | Critical
+[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness
 [Azure.VNG.ERLegacySKU](../rules/Azure.VNG.ERLegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of ExpressRoute (ER) gateways. | Important
 [Azure.VNG.Name](../rules/Azure.VNG.Name.md) | Virtual Network Gateway (VNG) names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2020_12.md
+++ b/docs/en/baselines/Azure.GA_2020_12.md
@@ -182,7 +182,7 @@ Name | Synopsis | Severity
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
 [Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
-[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Subnets should have NSGs assigned. | Critical
+[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness
 [Azure.VNG.ERLegacySKU](../rules/Azure.VNG.ERLegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of ExpressRoute (ER) gateways. | Important
 [Azure.VNG.Name](../rules/Azure.VNG.Name.md) | Virtual Network Gateway (VNG) names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2021_03.md
+++ b/docs/en/baselines/Azure.GA_2021_03.md
@@ -197,7 +197,7 @@ Name | Synopsis | Severity
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
 [Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
-[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Subnets should have NSGs assigned. | Critical
+[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness
 [Azure.VNG.ERLegacySKU](../rules/Azure.VNG.ERLegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of ExpressRoute (ER) gateways. | Important
 [Azure.VNG.Name](../rules/Azure.VNG.Name.md) | Virtual Network Gateway (VNG) names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2021_06.md
+++ b/docs/en/baselines/Azure.GA_2021_06.md
@@ -209,7 +209,7 @@ Name | Synopsis | Severity
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
 [Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
-[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Subnets should have NSGs assigned. | Critical
+[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness
 [Azure.VNG.ERLegacySKU](../rules/Azure.VNG.ERLegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of ExpressRoute (ER) gateways. | Important
 [Azure.VNG.Name](../rules/Azure.VNG.Name.md) | Virtual Network Gateway (VNG) names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.Preview.md
+++ b/docs/en/baselines/Azure.Preview.md
@@ -214,7 +214,7 @@ Name | Synopsis | Severity
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
 [Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
-[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Subnets should have NSGs assigned. | Critical
+[Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness
 [Azure.VNG.ERLegacySKU](../rules/Azure.VNG.ERLegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of ExpressRoute (ER) gateways. | Important
 [Azure.VNG.Name](../rules/Azure.VNG.Name.md) | Virtual Network Gateway (VNG) names should meet naming requirements. | Awareness

--- a/docs/en/rules/Azure.VNET.UseNSGs.md
+++ b/docs/en/rules/Azure.VNET.UseNSGs.md
@@ -10,19 +10,143 @@ online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VNET.U
 
 ## SYNOPSIS
 
-Subnets should have NSGs assigned.
+Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned.
 
 ## DESCRIPTION
 
-Virtual network subnets should have a network security group (NSG) assigned.
-NSGs are a basic stateful firewall that can be assigned to a virtual machine network interface or a subnets.
+Each VNET subnet should have a network security group (NSG) assigned.
+NSGs are basic stateful firewalls that provide network isolation and security within a VNET.
+A key benefit of NSGS is that they provide network segmentation between and within a subnet.
+
+NSGs can be assigned to a virtual machine network interface or a subnet.
+When assigning NSGs to a subnet, all network traffic within the subnet is subject to the NSG rules.
+
+There is a small subset of special purpose subnets that do not support NSGs.
+These subnets are:
+
+- `GatewaySubnet` - used for hybrid connectivity with VPN and ExpressRoute gateways.
+- `AzureFirewallSubnet` and `AzureFirewallManagementSubnet` - are for Azure Firewall.
+  Azure Firewall includes an intrinsic NSG that is not directly manageable or visible.
 
 ## RECOMMENDATION
 
-The GatewaySubnet and AzureFirewallSubnet are special named subnets which does not support NSGs.
-For all other subnets, define and assign a NSG.
+For virtual network subnets, ensure that a network security groups (NSGs) are assigned.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy virtual networks subnets that pass this rule:
+
+- Set the `properties.networkSecurityGroup.id` property for each supported subnet to a NSG resource id.
+
+For example:
+
+```json
+{
+    "type": "Microsoft.Network/virtualNetworks",
+    "apiVersion": "2021-02-01",
+    "name": "vnet-001",
+    "location": "[parameters('location')]",
+    "properties": {
+        "addressSpace": {
+            "addressPrefixes": [
+                "10.0.0.0/16"
+            ]
+        },
+        "dhcpOptions": {
+            "dnsServers": [
+                "10.0.1.4",
+                "10.0.1.5"
+            ]
+        },
+        "subnets": [
+            {
+                "name": "GatewaySubnet",
+                "properties": {
+                    "addressPrefix": "10.0.0.0/24"
+                }
+            },
+            {
+                "name": "snet-001",
+                "properties": {
+                    "addressPrefix": "10.0.1.0/24",
+                    "networkSecurityGroup": {
+                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-001')]"
+                    }
+                }
+            }
+        ]
+    },
+    "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-001')]"
+    ]
+}
+```
+
+### Configure with Bicep
+
+To deploy virtual network subnets that pass this rule:
+
+- Set the `properties.networkSecurityGroup.id` property for each supported subnet to a NSG resource id.
+
+For example:
+
+```bicep
+resource vnet 'Microsoft.Network/virtualNetworks@2021-02-01' = {
+  name: 'vnet-001'
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+    dhcpOptions: {
+      dnsServers: [
+        '10.0.1.4'
+        '10.0.1.5'
+      ]
+    }
+    subnets: [
+      {
+        name: 'GatewaySubnet'
+        properties: {
+          addressPrefix: '10.0.0.0/24'
+        }
+      }
+      {
+        name: 'snet-001'
+        properties: {
+          addressPrefix: '10.0.1.0/24'
+          networkSecurityGroup: {
+            id: nsg.id
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+### Configure with Azure CLI
+
+```bash
+az network vnet subnet update -n '<subnet>' -g '<resource_group>' --vnet-name '<vnet_name>' --network-security-group '<nsg_name>`
+```
+
+### Configure with Azure PowerShell
+
+```powershell
+$vnet = Get-AzVirtualNetwork -Name '<vnet_name>' -ResourceGroupName '<resource_group>'
+$nsg = Get-AzNetworkSecurityGroup -Name '<nsg_name>' -ResourceGroupName '<resource_group>'
+Set-AzVirtualNetworkSubnetConfig -Name '<subnet>' -VirtualNetwork $vnet -AddressPrefix '10.0.1.0/24' -NetworkSecurityGroup $nsg
+```
 
 ## LINKS
 
+- [Implement network segmentation patterns on Azure](https://docs.microsoft.com/azure/architecture/framework/security/design-network-segmentation)
 - [Network Security Best Practices](https://docs.microsoft.com/azure/security/fundamentals/network-best-practices#logically-segment-subnets)
 - [Azure Firewall FAQ](https://docs.microsoft.com/azure/firewall/firewall-faq#are-network-security-groups-nsgs-supported-on-the-azure-firewall-subnet)
+- [Forced tunneling configuration](https://docs.microsoft.com/azure/firewall/forced-tunneling#forced-tunneling-configuration)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.network/virtualnetworks?tabs=json)

--- a/docs/en/rules/module.md
+++ b/docs/en/rules/module.md
@@ -324,7 +324,7 @@ Name | Synopsis | Severity
 [Azure.SQL.AllowAzureAccess](Azure.SQL.AllowAzureAccess.md) | Determine if access from Azure services is required. | Important
 [Azure.SQL.FirewallIPRange](Azure.SQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.SQL.FirewallRuleCount](Azure.SQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
-[Azure.VNET.UseNSGs](Azure.VNET.UseNSGs.md) | Subnets should have NSGs assigned. | Critical
+[Azure.VNET.UseNSGs](Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 
 ### Optimize
 

--- a/docs/en/rules/resource.md
+++ b/docs/en/rules/resource.md
@@ -392,7 +392,7 @@ Name | Synopsis | Severity
 [Azure.VNET.PeerState](Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
 [Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
-[Azure.VNET.UseNSGs](Azure.VNET.UseNSGs.md) | Subnets should have NSGs assigned. | Critical
+[Azure.VNET.UseNSGs](Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 
 ## Virtual Network Gateway
 

--- a/docs/examples.bicep
+++ b/docs/examples.bicep
@@ -48,3 +48,39 @@ resource appGw 'Microsoft.Network/applicationGateways@2021-02-01' = {
     }
   }
 }
+
+// An example VNET with NSG configured
+resource vnet 'Microsoft.Network/virtualNetworks@2021-02-01' = {
+  name: 'vnet-001'
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+    dhcpOptions: {
+      dnsServers: [
+        '10.0.1.4'
+        '10.0.1.5'
+      ]
+    }
+    subnets: [
+      {
+        name: 'GatewaySubnet'
+        properties: {
+          addressPrefix: '10.0.0.0/24'
+        }
+      }
+      {
+        name: 'snet-001'
+        properties: {
+          addressPrefix: '10.0.1.0/24'
+          networkSecurityGroup: {
+            id: nsg.id
+          }
+        }
+      }
+    ]
+  }
+}

--- a/docs/examples.json
+++ b/docs/examples.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.412.5873",
-      "templateHash": "1973047202237601172"
+      "version": "0.4.613.9944",
+      "templateHash": "17396019564585598091"
     }
   },
   "parameters": {
@@ -61,6 +61,45 @@
           "ruleSetVersion": "3.0"
         }
       }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2021-02-01",
+      "name": "vnet-001",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        },
+        "dhcpOptions": {
+          "dnsServers": [
+            "10.0.1.4",
+            "10.0.1.5"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "GatewaySubnet",
+            "properties": {
+              "addressPrefix": "10.0.0.0/24"
+            }
+          },
+          {
+            "name": "snet-001",
+            "properties": {
+              "addressPrefix": "10.0.1.0/24",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-001')]"
+              }
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-001')]"
+      ]
     }
   ]
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.VNET.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VNET.Rule.ps1
@@ -7,17 +7,17 @@
 
 #region Virtual Network
 
-# Synopsis: Subnets should have NSGs assigned, except for the GatewaySubnet
+# Synopsis: Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned.
 Rule 'Azure.VNET.UseNSGs' -Type 'Microsoft.Network/virtualNetworks', 'Microsoft.Network/virtualNetworks/subnets' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $subnet = @($TargetObject);
     if ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks') {
         # Get subnets
-        $subnet = @($TargetObject.properties.subnets | Where-Object { $_.Name -notin 'GatewaySubnet', 'AzureFirewallSubnet' });
+        $subnet = @($TargetObject.properties.subnets | Where-Object { $_.Name -notin 'GatewaySubnet', 'AzureFirewallSubnet', 'AzureFirewallManagementSubnet' });
         if ($subnet.Length -eq 0) {
             return $Assert.Pass();
         }
     }
-    elseif ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks/subnets' -and $PSRule.TargetName -in 'GatewaySubnet', 'AzureFirewallSubnet') {
+    elseif ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks/subnets' -and $PSRule.TargetName -in 'GatewaySubnet', 'AzureFirewallSubnet', 'AzureFirewallManagementSubnet') {
         return $Assert.Pass();
     }
     foreach ($sn in $subnet) {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
@@ -125,6 +125,26 @@
                         "delegations": []
                     },
                     "type": "Microsoft.Network/virtualNetworks/subnets"
+                },
+                {
+                    "name": "AzureFirewallSubnet",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/AzureFirewallSubnet",
+                    "properties": {
+                        "addressPrefix": "10.1.0.128/26",
+                        "serviceEndpoints": [],
+                        "delegations": []
+                    },
+                    "type": "Microsoft.Network/virtualNetworks/subnets"
+                },
+                {
+                    "name": "AzureFirewallManagementSubnet",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/AzureFirewallManagementSubnet",
+                    "properties": {
+                        "addressPrefix": "10.1.0.192/26",
+                        "serviceEndpoints": [],
+                        "delegations": []
+                    },
+                    "type": "Microsoft.Network/virtualNetworks/subnets"
                 }
             ],
             "virtualNetworkPeerings": [


### PR DESCRIPTION
## PR Summary

- Excluded `AzureFirewallManagementSubnet` from `Azure.VNET.UseNSGs`. #869

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
