### PR TITLE
Enable AKS autoscaler rule

### DIFF
--- a/docs/en/baselines/Azure.All.md
+++ b/docs/en/baselines/Azure.All.md
@@ -4,7 +4,7 @@ Includes all Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.All`. This baseline includes a total of 212 rules.
+The following rules are included within `Azure.All`. This baseline includes a total of 213 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -19,6 +19,7 @@ Name | Synopsis | Severity
 [Azure.ACR.Retention](../rules/Azure.ACR.Retention.md) | Use a retention policy to cleanup untagged manifests. | Important
 [Azure.ACR.Usage](../rules/Azure.ACR.Usage.md) | Regularly remove deprecated and unneeded images to reduce storage usage. | Important
 [Azure.AKS.AuthorizedIPs](../rules/Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
+[Azure.AKS.AutoScaling](../rules/Azure.AKS.AutoScaling.md) | Use Autoscaling to ensure AKS clusters deployed with virtual machine scale sets are running efficiently with the right number of nodes for the workloads present. | Important
 [Azure.AKS.AutoUpgrade](../rules/Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
 [Azure.AKS.AzurePolicyAddOn](../rules/Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
 [Azure.AKS.AzureRBAC](../rules/Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important

--- a/docs/en/baselines/Azure.Default.md
+++ b/docs/en/baselines/Azure.Default.md
@@ -4,7 +4,7 @@ Default baseline for Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.Default`. This baseline includes a total of 208 rules.
+The following rules are included within `Azure.Default`. This baseline includes a total of 209 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -17,6 +17,7 @@ Name | Synopsis | Severity
 [Azure.ACR.Name](../rules/Azure.ACR.Name.md) | Container registry names should meet naming requirements. | Awareness
 [Azure.ACR.Usage](../rules/Azure.ACR.Usage.md) | Regularly remove deprecated and unneeded images to reduce storage usage. | Important
 [Azure.AKS.AuthorizedIPs](../rules/Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
+[Azure.AKS.AutoScaling](../rules/Azure.AKS.AutoScaling.md) | Use Autoscaling to ensure AKS clusters deployed with virtual machine scale sets are running efficiently with the right number of nodes for the workloads present. | Important
 [Azure.AKS.AzurePolicyAddOn](../rules/Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
 [Azure.AKS.AzureRBAC](../rules/Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important
 [Azure.AKS.DNSPrefix](../rules/Azure.AKS.DNSPrefix.md) | Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.Preview.md
+++ b/docs/en/baselines/Azure.Preview.md
@@ -4,7 +4,7 @@ Includes Azure features in preview.
 
 ## Rules
 
-The following rules are included within `Azure.Preview`. This baseline includes a total of 212 rules.
+The following rules are included within `Azure.Preview`. This baseline includes a total of 213 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -19,6 +19,7 @@ Name | Synopsis | Severity
 [Azure.ACR.Retention](../rules/Azure.ACR.Retention.md) | Use a retention policy to cleanup untagged manifests. | Important
 [Azure.ACR.Usage](../rules/Azure.ACR.Usage.md) | Regularly remove deprecated and unneeded images to reduce storage usage. | Important
 [Azure.AKS.AuthorizedIPs](../rules/Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
+[Azure.AKS.AutoScaling](../rules/Azure.AKS.AutoScaling.md) | Use Autoscaling to ensure AKS clusters deployed with virtual machine scale sets are running efficiently with the right number of nodes for the workloads present. | Important
 [Azure.AKS.AutoUpgrade](../rules/Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
 [Azure.AKS.AzurePolicyAddOn](../rules/Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
 [Azure.AKS.AzureRBAC](../rules/Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important

--- a/docs/en/rules/Azure.AKS.AutoScaling.md
+++ b/docs/en/rules/Azure.AKS.AutoScaling.md
@@ -1,0 +1,141 @@
+---
+severity: Important
+pillar: Performance Efficiency
+category: Performance
+resource: Azure Kubernetes Service
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AKS.AutoScaling/
+---
+
+# Enable AKS cluster autoscaler
+
+## SYNOPSIS
+
+Use Autoscaling to ensure AKS clusters deployed with virtual machine scale sets are running efficiently with the right number of nodes for the workloads present.
+
+## DESCRIPTION
+
+In addition to perform manual scaling, AKS clusters support autoscaling.
+Autoscaling reduces manual intervention required to scale a cluster to keep up with application demands.
+
+## RECOMMENDATION
+
+Consider enabling autoscaling for AKS clusters deployed with virtual machine scale sets.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To set enable autoscaling for an AKS cluster:
+
+- Set `properties.agentPoolProfiles[*].enableAutoScaling` to `true`.
+- Set `properties.agentPoolProfiles[*].type` to `VirtualMachineScaleSets`.
+
+For example:
+
+```json
+{
+    "comments": "Azure Kubernetes Cluster",
+    "apiVersion": "2020-12-01",
+    "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
+    ],
+    "type": "Microsoft.ContainerService/managedClusters",
+    "location": "[parameters('location')]",
+    "name": "[parameters('clusterName')]",
+    "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+            "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]": {}
+        }
+    },
+    "properties": {
+        "kubernetesVersion": "[parameters('kubernetesVersion')]",
+        "disableLocalAccounts": true,
+        "enableRBAC": true,
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": [
+            {
+                "name": "system",
+                "osDiskSizeGB": 32,
+                "count": 3,
+                "minCount": 3,
+                "maxCount": 10,
+                "enableAutoScaling": true,
+                "maxPods": 50,
+                "vmSize": "Standard_D2s_v3",
+                "osType": "Linux",
+                "type": "VirtualMachineScaleSets",
+                "vnetSubnetID": "[variables('clusterSubnetId')]",
+                "mode": "System",
+                "osDiskType": "Ephemeral",
+                "scaleSetPriority": "Regular"
+            }
+        ],
+        "aadProfile": {
+            "managed": true,
+            "enableAzureRBAC": true,
+            "adminGroupObjectIDs": "[parameters('clusterAdmins')]",
+            "tenantID": "[subscription().tenantId]"
+        },
+        "networkProfile": {
+            "networkPlugin": "azure",
+            "networkPolicy": "azure",
+            "loadBalancerSku": "Standard",
+            "serviceCidr": "192.168.0.0/16",
+            "dnsServiceIP": "192.168.0.4",
+            "dockerBridgeCidr": "172.17.0.1/16"
+        },
+        "autoUpgradeProfile": {
+            "upgradeChannel": "stable"
+        },
+        "addonProfiles": {
+            "azurepolicy": {
+                "enabled": true,
+                "config": {
+                    "version": "v2"
+                }
+            },
+            "omsagent": {
+                "enabled": true,
+                "config": {
+                    "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
+                }
+            },
+            "kubeDashboard": {
+                "enabled": false
+            }
+        }
+    }
+}
+```
+
+### Configure with Azure CLI
+
+#### Enable cluster autoscaler
+
+```bash
+az aks update \
+  --name '<name>' \
+  --resource-group '<resource_group>' \
+  --enable-cluster-autoscaler \
+  --min-count '<min_count>' \
+  --max-count '<max_count>'
+```
+
+#### Enable cluster nodepool autoscaler
+
+```bash
+az aks nodepool update \
+  --name '<name>' \
+  --resource-group '<resource_group>' \
+  --cluster-name '<cluster_name>' \
+  --enable-cluster-autoscaler \
+  --min-count '<min_count>' \
+  --max-count '<max_count>'
+```
+
+## LINKS
+
+- [Automatically scale a cluster to meet application demands on Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/cluster-autoscaler)
+- [Scaling options for applications in Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/concepts-scale)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters)

--- a/docs/en/rules/module.md
+++ b/docs/en/rules/module.md
@@ -167,6 +167,7 @@ Name | Synopsis | Severity
 
 Name | Synopsis | Severity
 ---- | -------- | --------
+[Azure.AKS.AutoScaling](Azure.AKS.AutoScaling.md) | Use Autoscaling to ensure AKS clusters deployed with virtual machine scale sets are running efficiently with the right number of nodes for the workloads present. | Important
 [Azure.VM.AcceleratedNetworking](Azure.VM.AcceleratedNetworking.md) | Use accelerated networking for supported operating systems and VM types. | Important
 [Azure.VM.DiskCaching](Azure.VM.DiskCaching.md) | Check disk caching is configured correctly for the workload. | Important
 

--- a/docs/en/rules/resource.md
+++ b/docs/en/rules/resource.md
@@ -128,6 +128,7 @@ Name | Synopsis | Severity
 Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.AKS.AuthorizedIPs](Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
+[Azure.AKS.AutoScaling](Azure.AKS.AutoScaling.md) | Use Autoscaling to ensure AKS clusters deployed with virtual machine scale sets are running efficiently with the right number of nodes for the workloads present. | Important
 [Azure.AKS.AutoUpgrade](Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
 [Azure.AKS.AzurePolicyAddOn](Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
 [Azure.AKS.AzureRBAC](Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -9,6 +9,7 @@
     AKSVersion = "The Kubernetes version is v{0}."
     AKSNodePoolType = "The agent pool ({0}) is not using scale sets."
     AKSNodePoolVersion = "The agent pool ({0}) is running v{1}."
+    AKSAutoScaling = "The agent pool ({0}) is not using autoscaling."
     SubnetNSGNotConfigured = "The subnet ({0}) has no NSG associated."
     ServiceUrlNotHttps = "The service URL for '{0}' is not a HTTPS endpoint."
     BackendUrlNotHttps = "The backend URL for '{0}' is not a HTTPS endpoint."

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -139,7 +139,7 @@ Rule 'Azure.AKS.AzureRBAC' -Type 'Microsoft.ContainerService/managedClusters' -T
 }
 
 # Synopsis: Use Autoscaling to ensure AKS cluster is running efficiently with the right number of nodes for the workloads present.
-Rule 'Azure.AKS.AutoScaling' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; ruleSet = '2021_09'; } {
+Rule 'Azure.AKS.AutoScaling' -Type 'Microsoft.ContainerService/managedClusters', 'Microsoft.ContainerService/managedClusters/agentPools' -Tag @{ release = 'GA'; ruleSet = '2021_09'; } {
     $agentPools = @(GetAgentPoolProfiles);
 
     if ($agentPools.Length -eq 0) {
@@ -151,6 +151,9 @@ Rule 'Azure.AKS.AutoScaling' -Type 'Microsoft.ContainerService/managedClusters' 
         # Autoscaling only available on virtual machine scale sets
         if ($Assert.HasFieldValue($agentPool, 'type', 'VirtualMachineScaleSets')) {
             $Assert.HasFieldValue($agentPool, 'enableAutoScaling', $True).Reason($LocalizedData.AKSAutoScaling, $agentPool.name);
+        }
+        else {
+            $Assert.Pass()
         }
     }
 }
@@ -179,6 +182,7 @@ function global:GetAgentPoolProfiles {
                 type = $TargetObject.properties.type
                 maxPods = $TargetObject.properties.maxPods
                 orchestratorVersion = $TargetObject.properties.orchestratorVersion
+                enableAutoScaling = $TargetObject.properties.enableAutoScaling
             }
         }
     }

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -149,7 +149,7 @@ Rule 'Azure.AKS.AutoScaling' -Type 'Microsoft.ContainerService/managedClusters',
     foreach ($agentPool in $agentPools) {
 
         # Autoscaling only available on virtual machine scale sets
-        if ($Assert.HasFieldValue($agentPool, 'type', 'VirtualMachineScaleSets')) {
+        if ($Assert.HasFieldValue($agentPool, 'type', 'VirtualMachineScaleSets').Result) {
             $Assert.HasFieldValue($agentPool, 'enableAutoScaling', $True).Reason($LocalizedData.AKSAutoScaling, $agentPool.name);
         }
         else {
@@ -173,6 +173,7 @@ function global:GetAgentPoolProfiles {
                     type = $_.type
                     maxPods = $_.properties.maxPods
                     orchestratorVersion = $_.properties.orchestratorVersion
+                    enableAutoScaling = $_.properties.enableAutoScaling
                 }
             });
         }

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -170,7 +170,7 @@ function global:GetAgentPoolProfiles {
             @(GetSubResources -ResourceType 'Microsoft.ContainerService/managedClusters/agentPools' | ForEach-Object {
                 [PSCustomObject]@{
                     name = $_.name
-                    type = $_.type
+                    type = $_.properties.type
                     maxPods = $_.properties.maxPods
                     orchestratorVersion = $_.properties.orchestratorVersion
                     enableAutoScaling = $_.properties.enableAutoScaling

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -421,8 +421,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD';
         }
 
         It 'Azure.AKS.PoolVersion' {
@@ -431,8 +431,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'clusterA';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterD';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -453,8 +453,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD';
         }
 
         It 'Azure.AKS.NodeMinPods' {
@@ -469,8 +469,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD';
         }
 
         It 'Azure.AKS.ManagedIdentity' {
@@ -483,8 +483,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterD';
         }
 
         It 'Azure.AKS.StandardLB' {
@@ -497,8 +497,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterD';
         }
 
         It 'Azure.AKS.AzurePolicyAddOn' {
@@ -507,8 +507,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'clusterB';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -529,8 +529,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'clusterB';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD';
         }
 
         It 'Azure.AKS.AutoUpgrade' {
@@ -545,8 +545,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'clusterB';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD';
         }
 
         It 'Azure.AKS.AutoScaling' {
@@ -555,8 +555,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 2
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterC/agentpool3'
+            $ruleResult | Should -HaveCount 3
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterC/agentpool3', 'clusterD'
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -577,8 +577,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'clusterB';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD';
         }
 
         It 'Azure.AKS.LocalAccounts' {
@@ -593,8 +593,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'clusterB';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD';
         }
 
         It 'Azure.AKS.AzureRBAC' {
@@ -609,8 +609,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'clusterB';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -236,14 +236,14 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 4
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D';
+            $ruleResult | Should -HaveCount 2;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 2
-            $ruleResult.TargetName | Should -BeIn 'system', 'cluster-F'
+            $ruleResult | Should -HaveCount 4;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'system', 'cluster-F';
         }
 
         It 'Azure.AKS.AuthorizedIPs' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -230,6 +230,22 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult.TargetName | Should -BeIn 'cluster-F';
         }
 
+        It 'Azure.AKS.AutoScaling' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AutoScaling' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult | Should -HaveCount 4
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult | Should -HaveCount 2
+            $ruleResult.TargetName | Should -BeIn 'system', 'cluster-F'
+        }
+
         It 'Azure.AKS.AuthorizedIPs' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AuthorizedIPs' };
 
@@ -531,6 +547,22 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -BeIn 'clusterB';
+        }
+
+        It 'Azure.AKS.AutoScaling' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AutoScaling' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult | Should -HaveCount 2
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterC/agentpool3'
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult | Should -HaveCount 2
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool4'
         }
 
         It 'Azure.AKS.AuthorizedIPs' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -105,7 +105,8 @@
                 "maxPods": 30,
                 "type": "AvailabilitySet",
                 "orchestratorVersion": "1.11.5",
-                "osType": "Linux"
+                "osType": "Linux",
+                "enableAutoScaling": false
             }
         },
         {
@@ -128,7 +129,8 @@
                         "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-01')]",
                         "maxPods": 50,
                         "type": "VirtualMachineScaleSets",
-                        "osType": "Linux"
+                        "osType": "Linux",
+                        "enableAutoScaling": true
                     }
                 ],
                 "servicePrincipalProfile": {
@@ -243,7 +245,8 @@
                 "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-04')]",
                 "maxPods": 50,
                 "type": "VirtualMachineScaleSets",
-                "osType": "Linux"
+                "osType": "Linux",
+                "enableAutoScaling": true
             }
         }
     ]

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -49,7 +49,8 @@
                         "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-01')]",
                         "maxPods": 50,
                         "type": "VirtualMachineScaleSets",
-                        "osType": "Linux"
+                        "osType": "Linux",
+                        "enableAutoScaling": false
                     }
                 ],
                 "servicePrincipalProfile": {
@@ -228,7 +229,8 @@
                 "maxPods": 50,
                 "type": "VirtualMachineScaleSets",
                 "orchestratorVersion": "1.20.5",
-                "osType": "Linux"
+                "osType": "Linux",
+                "enableAutoScaling": false
             }
         },
         {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -14,6 +14,10 @@
             "defaultValue": "clusterC",
             "type": "string"
         },
+        "clusterName4": {
+            "defaultValue": "clusterD",
+            "type": "string"
+        },
         "clusterLocation": {
             "defaultValue": "[resourceGroup().location]",
             "type": "string"
@@ -250,6 +254,130 @@
                 "osType": "Linux",
                 "enableAutoScaling": true
             }
+        },
+        {
+            "type": "Microsoft.ContainerService/managedClusters",
+            "apiVersion": "2020-12-01",
+            "name": "[parameters('clusterName4')]",
+            "location": "[parameters('clusterLocation')]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "kubernetesVersion": "1.20.5",
+                "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
+                "agentPoolProfiles": [
+                    {
+                        "name": "agentpool1",
+                        "count": 3,
+                        "vmSize": "Standard_B2ms",
+                        "osDiskSizeGB": 100,
+                        "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-01')]",
+                        "maxPods": 50,
+                        "type": "VirtualMachineScaleSets",
+                        "osType": "Linux",
+                        "enableAutoScaling": true
+                    }
+                ],
+                "servicePrincipalProfile": {
+                    "clientId": "00000000-0000-0000-0000-000000000000"
+                },
+                "addonProfiles": {
+                    "aciConnectorLinux": {
+                        "enabled": true,
+                        "config": {
+                            "SubnetName": "subnet-aci"
+                        }
+                    },
+                    "azurePolicy": {
+                        "enabled": false
+                    },
+                    "httpApplicationRouting": {
+                        "enabled": true
+                    },
+                    "kubeDashboard": {
+                        "enabled": true
+                    },
+                    "omsagent": {
+                        "enabled": true,
+                        "config": {
+                            "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
+                        }
+                    },
+                    "azureKeyvaultSecretsProvider": {
+                        "enabled": true,
+                        "config": {
+                            "enableSecretRotation": "false"
+                        }
+                    },
+                    "openServiceMesh": {
+                        "enabled": true
+                    }
+                },
+                "aadProfile": {
+                    "managed": true,
+                    "enableAzureRBAC": true,
+                    "adminGroupObjectIDs": [],
+                    "tenantID": "[subscription().tenantId]"
+                },
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "rapid"
+                },
+                "autoScalerProfile": {
+                    "balance-similar-node-groups": "false",
+                    "expander": "random",
+                    "max-empty-bulk-delete": "10",
+                    "max-graceful-termination-sec": "600",
+                    "max-total-unready-percentage": "45",
+                    "new-pod-scale-up-delay": "0s",
+                    "ok-total-unready-count": "3",
+                    "scale-down-delay-after-add": "10m",
+                    "scale-down-delay-after-delete": "10s",
+                    "scale-down-delay-after-failure": "3m",
+                    "scale-down-unneeded-time": "10m",
+                    "scale-down-unready-time": "20m",
+                    "scale-down-utilization-threshold": "0.5",
+                    "scan-interval": "10s",
+                    "skip-nodes-with-local-storage": "false",
+                    "skip-nodes-with-system-pods": "true"
+                },
+                "disableLocalAccounts": true,
+                "enableRBAC": true,
+                "enablePodSecurityPolicy": false,
+                "networkProfile": {
+                    "networkPlugin": "azure",
+                    "networkPolicy": "azure",
+                    "loadBalancerSku": "Standard",
+                    "serviceCidr": "192.168.0.0/16",
+                    "dnsServiceIP": "192.168.0.4",
+                    "dockerBridgeCidr": "172.17.0.1/16"
+                },
+                "apiServerAccessProfile": {
+                    "authorizedIpRanges": [
+                        "0.0.0.0/32"
+                    ]
+                }
+            },
+            "resources": [
+                {
+                    "type": "Microsoft.ContainerService/managedClusters/agentPools",
+                    "apiVersion": "2019-10-01",
+                    "name": "[concat(parameters('clusterName4'), '/agentpool2')]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName4'))]"
+                    ],
+                    "properties": {
+                        "count": 3,
+                        "vmSize": "Standard_B2ms",
+                        "osDiskSizeGB": 100,
+                        "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-04')]",
+                        "maxPods": 50,
+                        "type": "VirtualMachineScaleSets",
+                        "osType": "Linux",
+                        "enableAutoScaling": false
+                    }
+                }
+            ]
         }
     ]
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -19,7 +19,8 @@
                     "maxPods": 30,
                     "type": "AvailabilitySet",
                     "orchestratorVersion": "1.20.5",
-                    "osType": "Linux"
+                    "osType": "Linux",
+                    "enableAutoScaling": false
                 }
             ],
             "servicePrincipalProfile": {
@@ -82,7 +83,8 @@
                     "maxPods": 30,
                     "type": "AvailabilitySet",
                     "orchestratorVersion": "1.11.4",
-                    "osType": "Linux"
+                    "osType": "Linux",
+                    "enableAutoScaling": false
                 }
             ],
             "servicePrincipalProfile": {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -152,7 +152,8 @@
                     "type": "VirtualMachineScaleSets",
                     "provisioningState": "Succeeded",
                     "orchestratorVersion": "1.20.5",
-                    "osType": "Linux"
+                    "osType": "Linux",
+                    "enableAutoScaling": false
                 }
             ],
             "servicePrincipalProfile": {
@@ -237,7 +238,8 @@
                     "nodeLabels": {},
                     "mode": "System",
                     "osType": "Linux",
-                    "nodeImageVersion": "AKSUbuntu:1604:2020.05.13"
+                    "nodeImageVersion": "AKSUbuntu:1604:2020.05.13",
+                    "enableAutoScaling": false
                 }
             ],
             "windowsProfile": {


### PR DESCRIPTION
## PR Summary

Fix #218

Added a `Azure.AKS.AutoScaling` rule for release `GA` and baseline `2021_09`. 

The rule checks boths the following types:

- `Microsoft.ContainerService/managedClusters`
- `Microsoft.ContainerService/managedClusters/agentPools`

Also only checks agent pools of type `VirtualMachineScaleSets`, and agent pools that are any other type(such as `AvailabilitySets` just pass. Correct me if this needs to be handled differently. 

Also let me know if I should provide more detail in `docs/en/rules/Azure.AKS.AutoScaling.md`.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
