### PR TITLE
Pre-release v1.7.0-B2108020

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,10 +7,16 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.7.0-B2108020 (pre-release)
+
 What's changed since v1.6.0:
 
+- New rules:
+  - Azure Kubernetes Service:
+    - Check clusters use auto-scale node pools. [#218](https://github.com/Azure/PSRule.Rules.Azure/issues/218)
 - Updated rules:
-  - Excluded `AzureFirewallManagementSubnet` from `Azure.VNET.UseNSGs`. [#869](https://github.com/Azure/PSRule.Rules.Azure/issues/869)
+  - Virtual Network:
+    - Excluded `AzureFirewallManagementSubnet` from `Azure.VNET.UseNSGs`. [#869](https://github.com/Azure/PSRule.Rules.Azure/issues/869)
 - Engineering:
   - Bump PSRule dependency to v1.6.0. [#871](https://github.com/Azure/PSRule.Rules.Azure/issues/871)
 

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -13,7 +13,7 @@ What's changed since v1.6.0:
 
 - New rules:
   - Azure Kubernetes Service:
-    - Check clusters use auto-scale node pools. [#218](https://github.com/Azure/PSRule.Rules.Azure/issues/218)
+    - Check clusters use auto-scale node pools. Thanks [@ArmaanMcleod](https://github.com/ArmaanMcleod). [#218](https://github.com/Azure/PSRule.Rules.Azure/issues/218)
 - Updated rules:
   - Virtual Network:
     - Excluded `AzureFirewallManagementSubnet` from `Azure.VNET.UseNSGs`. [#869](https://github.com/Azure/PSRule.Rules.Azure/issues/869)


### PR DESCRIPTION
## PR Summary

What's changed since v1.6.0:

- New rules:
  - Azure Kubernetes Service:
    - Check clusters use auto-scale node pools. #218
- Updated rules:
  - Virtual Network:
    - Excluded `AzureFirewallManagementSubnet` from `Azure.VNET.UseNSGs`. #869
- Engineering:
  - Bump PSRule dependency to v1.6.0. #871

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
