### PR TITLE
Use parameter file metadata link #846

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,16 +333,18 @@ The following commands exist in the `PSRule.Rules.Azure` module:
 
 The following conceptual topics exist in the `PSRule.Rules.Azure` module:
 
-- [Azure metadata link](docs/concepts/about_PSRule_Azure_Metadata_Link.md)
-- [Configuration](docs/concepts/about_PSRule_Azure_Configuration.md)
-  - [Azure_AKSMinimumVersion](docs/concepts/about_PSRule_Azure_Configuration.md#azure_aksminimumversion)
-  - [Azure_AKSNodeMinimumMaxPods](docs/concepts/about_PSRule_Azure_Configuration.md#azure_aksnodeminimummaxpods)
-  - [Azure_AllowedRegions](docs/concepts/about_PSRule_Azure_Configuration.md#azure_allowedregions)
-  - [Azure_MinimumCertificateLifetime](docs/concepts/about_PSRule_Azure_Configuration.md#azure_minimumcertificatelifetime)
-  - [AZURE_PARAMETER_FILE_EXPANSION](docs/concepts/about_PSRule_Azure_Configuration.md#azure_parameter_file_expansion)
-  - [AZURE_POLICY_WAIVER_MAX_EXPIRY](docs/concepts/about_PSRule_Azure_Configuration.md#azure_policy_waiver_max_expiry)
-  - [AZURE_RESOURCE_GROUP](docs/concepts/about_PSRule_Azure_Configuration.md#azure_resource_group)
-  - [AZURE_SUBSCRIPTION](docs/concepts/about_PSRule_Azure_Configuration.md#azure_subscription)
+- [Using metadata](https://azure.github.io/PSRule.Rules.Azure/using-metadata/)
+- [Configuration](https://azure.github.io/PSRule.Rules.Azure/setup/configuring-options/)
+  - [Azure_AKSMinimumVersion](https://azure.github.io/PSRule.Rules.Azure/setup/configuring-rules/#aksminimumkubernetesversion)
+  - [Azure_AKSNodeMinimumMaxPods](https://azure.github.io/PSRule.Rules.Azure/setup/configuring-rules/#aksminimummaxpods)
+  - [Azure_AllowedRegions](https://azure.github.io/PSRule.Rules.Azure/setup/configuring-rules/#allowedresourceregions)
+  - [Azure_MinimumCertificateLifetime](https://azure.github.io/PSRule.Rules.Azure/setup/configuring-rules/#minimumcertificatelifetime)
+  - [AZURE_BICEP_FILE_EXPANSION](https://azure.github.io/PSRule.Rules.Azure/setup/configuring-expansion/#bicepsourceexpansion)
+  - [AZURE_PARAMETER_FILE_EXPANSION](https://azure.github.io/PSRule.Rules.Azure/setup/configuring-expansion/#parameterfileexpansion)
+  - [AZURE_PARAMETER_FILE_METADATA_LINK](https://azure.github.io/PSRule.Rules.Azure/setup/configuring-expansion/#requiretemplatemetadatalink)
+  - [AZURE_POLICY_WAIVER_MAX_EXPIRY](https://azure.github.io/PSRule.Rules.Azure/setup/configuring-rules/#azurepolicymaximumwavier)
+  - [AZURE_RESOURCE_GROUP](https://azure.github.io/PSRule.Rules.Azure/setup/configuring-expansion/#deploymentresourcegroup)
+  - [AZURE_SUBSCRIPTION](https://azure.github.io/PSRule.Rules.Azure/setup/configuring-expansion/#deploymentsubscription)
 
 ## Related projects
 

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -10,6 +10,9 @@ See [troubleshooting guide] for a workaround to this issue.
 What's changed since pre-release v1.7.0-B2108020:
 
 - New rules:
+  - All resources:
+    - Check template parameter files use metadata links. [#846](https://github.com/Azure/PSRule.Rules.Azure/issues/846)
+      - Configure the `AZURE_PARAMETER_FILE_METADATA_LINK` option to enable this rule.
   - Storage Account:
     - Check Storage Accounts only accept explicitly allowed network traffic. [#884](https://github.com/Azure/PSRule.Rules.Azure/issues/884)
 

--- a/docs/en/baselines/Azure.All.md
+++ b/docs/en/baselines/Azure.All.md
@@ -4,7 +4,7 @@ Includes all Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.All`. This baseline includes a total of 214 rules.
+The following rules are included within `Azure.All`. This baseline includes a total of 215 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -174,6 +174,7 @@ Name | Synopsis | Severity
 [Azure.Template.DefineParameters](../rules/Azure.Template.DefineParameters.md) | Each Azure Resource Manager (ARM) template file should contain a minimal number of parameters. | Awareness
 [Azure.Template.LocationDefault](../rules/Azure.Template.LocationDefault.md) | Set the default value for the location parameter within an ARM template to resource group location. | Awareness
 [Azure.Template.LocationType](../rules/Azure.Template.LocationType.md) | Location parameters should use a string value. | Important
+[Azure.Template.MetadataLink](../rules/Azure.Template.MetadataLink.md) | Configure a metadata link for each parameter file. | Important
 [Azure.Template.ParameterDataTypes](../rules/Azure.Template.ParameterDataTypes.md) | Set the parameter default value to a value of the same type. | Important
 [Azure.Template.ParameterFile](../rules/Azure.Template.ParameterFile.md) | Use ARM template parameter files that are valid. | Important
 [Azure.Template.ParameterMetadata](../rules/Azure.Template.ParameterMetadata.md) | Set metadata descriptions in Azure Resource Manager (ARM) template for each parameter. | Awareness

--- a/docs/en/baselines/Azure.Default.md
+++ b/docs/en/baselines/Azure.Default.md
@@ -4,7 +4,7 @@ Default baseline for Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.Default`. This baseline includes a total of 210 rules.
+The following rules are included within `Azure.Default`. This baseline includes a total of 211 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -170,6 +170,7 @@ Name | Synopsis | Severity
 [Azure.Template.DefineParameters](../rules/Azure.Template.DefineParameters.md) | Each Azure Resource Manager (ARM) template file should contain a minimal number of parameters. | Awareness
 [Azure.Template.LocationDefault](../rules/Azure.Template.LocationDefault.md) | Set the default value for the location parameter within an ARM template to resource group location. | Awareness
 [Azure.Template.LocationType](../rules/Azure.Template.LocationType.md) | Location parameters should use a string value. | Important
+[Azure.Template.MetadataLink](../rules/Azure.Template.MetadataLink.md) | Configure a metadata link for each parameter file. | Important
 [Azure.Template.ParameterDataTypes](../rules/Azure.Template.ParameterDataTypes.md) | Set the parameter default value to a value of the same type. | Important
 [Azure.Template.ParameterFile](../rules/Azure.Template.ParameterFile.md) | Use ARM template parameter files that are valid. | Important
 [Azure.Template.ParameterMetadata](../rules/Azure.Template.ParameterMetadata.md) | Set metadata descriptions in Azure Resource Manager (ARM) template for each parameter. | Awareness

--- a/docs/en/baselines/Azure.Preview.md
+++ b/docs/en/baselines/Azure.Preview.md
@@ -4,7 +4,7 @@ Includes Azure features in preview.
 
 ## Rules
 
-The following rules are included within `Azure.Preview`. This baseline includes a total of 214 rules.
+The following rules are included within `Azure.Preview`. This baseline includes a total of 215 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -174,6 +174,7 @@ Name | Synopsis | Severity
 [Azure.Template.DefineParameters](../rules/Azure.Template.DefineParameters.md) | Each Azure Resource Manager (ARM) template file should contain a minimal number of parameters. | Awareness
 [Azure.Template.LocationDefault](../rules/Azure.Template.LocationDefault.md) | Set the default value for the location parameter within an ARM template to resource group location. | Awareness
 [Azure.Template.LocationType](../rules/Azure.Template.LocationType.md) | Location parameters should use a string value. | Important
+[Azure.Template.MetadataLink](../rules/Azure.Template.MetadataLink.md) | Configure a metadata link for each parameter file. | Important
 [Azure.Template.ParameterDataTypes](../rules/Azure.Template.ParameterDataTypes.md) | Set the parameter default value to a value of the same type. | Important
 [Azure.Template.ParameterFile](../rules/Azure.Template.ParameterFile.md) | Use ARM template parameter files that are valid. | Important
 [Azure.Template.ParameterMetadata](../rules/Azure.Template.ParameterMetadata.md) | Set metadata descriptions in Azure Resource Manager (ARM) template for each parameter. | Awareness

--- a/docs/en/rules/Azure.Template.MetadataLink.md
+++ b/docs/en/rules/Azure.Template.MetadataLink.md
@@ -1,0 +1,61 @@
+---
+severity: Important
+pillar: Operational Excellence
+category: Release engineering
+resource: All resources
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Template.MetadataLink/
+---
+
+# Use parameter file metadata link
+
+## SYNOPSIS
+
+Configure a metadata link for each parameter file.
+
+## DESCRIPTION
+
+A parameter file can include an additional metadata.
+This metadata provides additional context for use of the parameter file.
+
+PSRule for Azure uses the `metadata.template` property within parameter files to store a metadata link.
+A metadata link, is an explicit association between a parameter file it's intended template file.
+
+This rule is disabled by default but can be enabled by configuring `AZURE_PARAMETER_FILE_METADATA_LINK`.
+Enable this rule to ensure that each parameter file has a metadata link to a valid template file.
+
+## RECOMMENDATION
+
+Consider setting metadata for each parameter file linking to the deployment template.
+
+## EXAMPLES
+
+### Configure parameter file
+
+To create parameter files that pass this rule:
+
+- Set the `metadata.template` property to a valid template file path.
+
+For example:
+
+```json
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "template": "templates/storage/v1/template.json"
+    },
+    "parameters": {
+        "storageAccountName": {
+            "value": "..."
+        }
+    }
+}
+```
+
+## NOTES
+
+Enable this rule by setting the `AZURE_PARAMETER_FILE_METADATA_LINK` option to `true`.
+
+## LINKS
+
+- [Using templates](https://azure.github.io/PSRule.Rules.Azure/using-templates/)

--- a/docs/en/rules/module.md
+++ b/docs/en/rules/module.md
@@ -75,6 +75,7 @@ Name | Synopsis | Severity
 [Azure.Template.DebugDeployment](Azure.Template.DebugDeployment.md) | Use default deployment detail level for nested deployments. | Awareness
 [Azure.Template.DefineParameters](Azure.Template.DefineParameters.md) | Each Azure Resource Manager (ARM) template file should contain a minimal number of parameters. | Awareness
 [Azure.Template.LocationType](Azure.Template.LocationType.md) | Location parameters should use a string value. | Important
+[Azure.Template.MetadataLink](Azure.Template.MetadataLink.md) | Configure a metadata link for each parameter file. | Important
 [Azure.Template.ParameterDataTypes](Azure.Template.ParameterDataTypes.md) | Set the parameter default value to a value of the same type. | Important
 [Azure.Template.ParameterFile](Azure.Template.ParameterFile.md) | Use ARM template parameter files that are valid. | Important
 [Azure.Template.ParameterMetadata](Azure.Template.ParameterMetadata.md) | Set metadata descriptions in Azure Resource Manager (ARM) template for each parameter. | Awareness

--- a/docs/en/rules/resource.md
+++ b/docs/en/rules/resource.md
@@ -12,6 +12,7 @@ Name | Synopsis | Severity
 [Azure.Template.DefineParameters](Azure.Template.DefineParameters.md) | Each Azure Resource Manager (ARM) template file should contain a minimal number of parameters. | Awareness
 [Azure.Template.LocationDefault](Azure.Template.LocationDefault.md) | Set the default value for the location parameter within an ARM template to resource group location. | Awareness
 [Azure.Template.LocationType](Azure.Template.LocationType.md) | Location parameters should use a string value. | Important
+[Azure.Template.MetadataLink](Azure.Template.MetadataLink.md) | Configure a metadata link for each parameter file. | Important
 [Azure.Template.ParameterDataTypes](Azure.Template.ParameterDataTypes.md) | Set the parameter default value to a value of the same type. | Important
 [Azure.Template.ParameterFile](Azure.Template.ParameterFile.md) | Use ARM template parameter files that are valid. | Important
 [Azure.Template.ParameterMetadata](Azure.Template.ParameterMetadata.md) | Set metadata descriptions in Azure Resource Manager (ARM) template for each parameter. | Awareness

--- a/docs/setup/configuring-expansion.md
+++ b/docs/setup/configuring-expansion.md
@@ -79,6 +79,40 @@ configuration:
   AZURE_BICEP_FILE_EXPANSION: true
 ```
 
+### Require template metadata link
+
+:octicons-milestone-24: v1.7.0
+
+This configuration option determines if Azure template parameter files require a metadata link.
+When configured to `true`, the `Azure.Template.MetadataLink` rule is enabled.
+Any Azure template parameter files that do not include a metadata link will report a fail for this rule.
+
+The rule `Azure.Template.MetadataLink` is not enabled by default.
+Additionally, when enabled this rule can still be excluded or suppressed like all other rules.
+
+Syntax:
+
+```yaml
+configuration:
+  AZURE_PARAMETER_FILE_METADATA_LINK: bool
+```
+
+Default:
+
+```yaml
+# YAML: The default AZURE_PARAMETER_FILE_METADATA_LINK configuration option
+configuration:
+  AZURE_PARAMETER_FILE_METADATA_LINK: false
+```
+
+Example:
+
+```yaml
+# YAML: Set the AZURE_PARAMETER_FILE_METADATA_LINK configuration option to enable expansion
+configuration:
+  AZURE_PARAMETER_FILE_METADATA_LINK: true
+```
+
 ### Deployment resource group
 
 :octicons-milestone-24: v1.1.0

--- a/docs/using-templates.md
+++ b/docs/using-templates.md
@@ -36,6 +36,8 @@ PSRule for Azure uses links to achieve this.
     It is not enabled by default to preserve the default behavior prior to PSRule for Azure v1.4.0.
     [Creating your pipeline][1] covers how to enable this in a CI pipeline.
 
+  [1]: creating-your-pipeline.md#expandtemplateparameterfiles
+
 ### Feature support
 
 Expansion of Azure template parameter files works with Azure Resource Manager (ARM) features.
@@ -143,6 +145,14 @@ Additional benefits you get by using metadata links include:
 - You can discover all the deployments using a specific template by reading metadata.
   PSRule for Azure includes the `Get-AzRuleTemplateLink` cmdlet to list parameter file links.
 
+!!! Tip
+    By default, metadata links are not required.
+    By configuring the `AZURE_PARAMETER_FILE_METADATA_LINK` option to `true`, this can be enforced.
+    When configured, PSRule for Azure will fail parameter files that do not contain a metadata link.
+    For details on `AZURE_PARAMETER_FILE_METADATA_LINK` see [Configuring expansion][2].
+
+  [2]: setup/configuring-expansion.md#requiretemplatemetadatalink
+
 ### Naming convention
 
 When metadata links are not set, PSRule for Azure will use a naming convention to link to template files.
@@ -152,7 +162,6 @@ When linking using naming convention, the template and the parameter file must b
 !!! Example
     A parameter file named `azuredeploy.parameters.json` links to the template file named `azuredeploy.json`.
 
-  [1]: creating-your-pipeline.md#expandtemplateparameterfiles
 
 *[WAF]: Well-Architected Framework
 *[ARM]: Azure Resource Manager

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateLinkHelper.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateLinkHelper.cs
@@ -68,6 +68,14 @@ namespace PSRule.Rules.Azure.Data.Template
             return templateLink;
         }
 
+        internal static string GetMetadataLinkPath(string parameterFile, string templateFile)
+        {
+            templateFile = TrimSlash(templateFile);
+            var pathBase = IsRelative(templateFile) ? Path.GetDirectoryName(parameterFile) : PSRuleOption.GetWorkingPath();
+            templateFile = Path.GetFullPath(Path.Combine(pathBase, templateFile));
+            return templateFile;
+        }
+
         private static JObject ReadFile(string path)
         {
             if (string.IsNullOrEmpty(path) || !File.Exists(path))
@@ -132,9 +140,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 return false;
             }
 
-            templateFile = TrimSlash(templateFile);
-            var pathBase = IsRelative(templateFile) ? Path.GetDirectoryName(parameterFile) : PSRuleOption.GetWorkingPath();
-            templateFile = Path.GetFullPath(Path.Combine(pathBase, templateFile));
+            templateFile = GetMetadataLinkPath(parameterFile, templateFile);
 
             // Template file must be within working path
             if (!templateFile.StartsWith(PSRuleOption.GetRootedBasePath(""), StringComparison.Ordinal))

--- a/src/PSRule.Rules.Azure/Runtime/Helper.cs
+++ b/src/PSRule.Rules.Azure/Runtime/Helper.cs
@@ -48,6 +48,11 @@ namespace PSRule.Rules.Azure.Runtime
             return bicep.ProcessFile(bicepFile);
         }
 
+        public static string GetMetadataLinkPath(string parameterFile, string templateFile)
+        {
+            return TemplateLinkHelper.GetMetadataLinkPath(parameterFile, templateFile);
+        }
+
         public static INetworkSecurityGroupEvaluator GetNetworkSecurityGroup(PSObject[] securityRules)
         {
             var builder = new NetworkSecurityGroupEvaluator();

--- a/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
@@ -26,6 +26,7 @@ spec:
       resourceGroupName: [ 'ResourceGroupName' ]
   configuration:
     AZURE_PARAMETER_FILE_EXPANSION: false
+    AZURE_PARAMETER_FILE_METADATA_LINK: false
     AZURE_BICEP_FILE_EXPANSION: false
   convention:
     include:

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
@@ -403,5 +403,25 @@ Describe 'Azure.Template' -Tag 'Template' {
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -BeLike "*Resources.Parameters.json";
         }
+
+        It 'Azure.Template.MetadataLink' {
+            $dataPath = Join-Path -Path $here -ChildPath '*.Parameters.json';
+            $options = @{
+                'Configuration.AZURE_PARAMETER_FILE_METADATA_LINK' = $True
+            }
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Option $options -Format File -Name 'Azure.Template.MetadataLink';
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Template.MetadataLink' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'tests/PSRule.Rules.Azure.Tests/Resources.ServiceFabric.Parameters.json';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 7;
+        }
     }
 }


### PR DESCRIPTION
## PR Summary

- Check template parameter files use metadata links. #846
- Configure the `AZURE_PARAMETER_FILE_METADATA_LINK` option to enable this rule.

Fixes #846

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
