### PR TITLE
Fixed parameter value failing on empty value #901

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -8,7 +8,7 @@ See [troubleshooting guide] for a workaround to this issue.
 ## Unreleased
 
 - Bug fixes:
-  - Fixed `Azure.Template.ParameterValue` failing on empty value [#901](https://github.com/Azure/PSRule.Rules.Azure/issues/901)
+  - Fixed `Azure.Template.ParameterValue` failing on empty value. [#901](https://github.com/Azure/PSRule.Rules.Azure/issues/901)
 
 ## v1.7.0-B2108049 (pre-release)
 

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,9 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+- Bug fixes:
+  - Fixed `Azure.Template.ParameterValue` failing on empty value [#901](https://github.com/Azure/PSRule.Rules.Azure/issues/901)
+
 ## v1.7.0-B2108049 (pre-release)
 
 What's changed since pre-release v1.7.0-B2108040:

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -43,4 +43,5 @@
     ParameterInvalidDefaultValue = "The default value for the parameter '{0}' is '{1}'."
     ExpressionInTemplate = "The expression '{0}' was found in the template."
     SubResourceNotFound = "A sub-resource of type '{0}' has not been specified."
+    ParameterValueNotSet = "The parameter '{0}' must have a value or Key Vault reference set."
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.Template.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Template.Rule.ps1
@@ -270,9 +270,11 @@ Rule 'Azure.Template.ParameterValue' -Type '.json' -If { (IsParameterFile) } -Ta
         return $Assert.Pass();
     }
     foreach ($parameter in $parameters) {
-        AnyOf {
-            $Assert.HasFieldValue($parameter.Value, 'value');
-            $Assert.HasFieldValue($parameter.Value, 'reference');
+        if ($Assert.HasField($parameter.Value, 'value').Result -or $Assert.HasFieldValue($parameter.Value, 'reference').Result) {
+            $Assert.Pass();
+        }
+        else {
+            $Assert.Fail($LocalizedData.ParameterValueNotSet, $parameter.Name);
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
@@ -497,6 +497,7 @@ Describe 'Azure.Template' -Tag 'Template' {
             $ruleResult.Length | Should -Be 1;
             $targetNames = $ruleResult | ForEach-Object { $_.TargetName.Split([char[]]@('\', '/'))[-1] };
             $targetNames | Should -BeIn 'Resources.ParameterFile.Fail5.json';
+            $ruleResult[0].Reason | Should -Be 'The parameter ''vnetName'' must have a value or Key Vault reference set.';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VPN.Parameters2.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VPN.Parameters2.json
@@ -17,6 +17,9 @@
         "subnetId": {
             "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/GatewaySubnet"
         },
+        "connections": {
+            "value": []
+        },
         "sharedKey": {
             "reference": {
                 "keyVault": {},


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.Template.ParameterValue` failing on empty value. #901

Fixes #901 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
