### PR TITLE
AKS Azure AvailabilityZone Rule

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,5 +60,8 @@
         "text",
         "yaml",
         "yml"
-    ]
+    ],
+    "[csharp]": { 
+        "editor.formatOnSave": true
+    }
 }

--- a/data/providers.json
+++ b/data/providers.json
@@ -7991,6 +7991,136 @@
           "Switzerland North",
           "Germany West Central",
           "Norway East"
+        ],
+        "zoneMappings": [
+          {
+            "location": "East US 2",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "Central US",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "West Europe",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "France Central",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "Southeast Asia",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "West US 2",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "North Europe",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "East US",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "UK South",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "Japan East",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "Australia East",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "South Central US",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "Canada Central",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "Germany West Central",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "Brazil South",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          },
+          {
+            "location": "West US 3",
+            "zones": [
+              "2",
+              "3",
+              "1"
+            ]
+          }
         ]
       },
       "locations/logAnalytics": {

--- a/docs/en/baselines/Azure.All.md
+++ b/docs/en/baselines/Azure.All.md
@@ -4,7 +4,7 @@ Includes all Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.All`. This baseline includes a total of 221 rules.
+The following rules are included within `Azure.All`. This baseline includes a total of 222 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -21,6 +21,7 @@ Name | Synopsis | Severity
 [Azure.AKS.AuthorizedIPs](../rules/Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
 [Azure.AKS.AutoScaling](../rules/Azure.AKS.AutoScaling.md) | Use Autoscaling to ensure AKS clusters deployed with virtual machine scale sets are running efficiently with the right number of nodes for the workloads present. | Important
 [Azure.AKS.AutoUpgrade](../rules/Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
+[Azure.AKS.AvailabilityZone](../rules/Azure.AKS.AvailabilityZone.md) | AKS clusters deployed with virtual machine scale sets should use availability zones in supported regions for high availability. | Important
 [Azure.AKS.AzurePolicyAddOn](../rules/Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
 [Azure.AKS.AzureRBAC](../rules/Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important
 [Azure.AKS.CNISubnetSize](../rules/Azure.AKS.CNISubnetSize.md) | AKS clusters using Azure CNI should use large subnets to reduce IP exhaustion issues. | Important

--- a/docs/en/baselines/Azure.Default.md
+++ b/docs/en/baselines/Azure.Default.md
@@ -4,7 +4,7 @@ Default baseline for Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.Default`. This baseline includes a total of 217 rules.
+The following rules are included within `Azure.Default`. This baseline includes a total of 218 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -18,6 +18,7 @@ Name | Synopsis | Severity
 [Azure.ACR.Usage](../rules/Azure.ACR.Usage.md) | Regularly remove deprecated and unneeded images to reduce storage usage. | Important
 [Azure.AKS.AuthorizedIPs](../rules/Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
 [Azure.AKS.AutoScaling](../rules/Azure.AKS.AutoScaling.md) | Use Autoscaling to ensure AKS clusters deployed with virtual machine scale sets are running efficiently with the right number of nodes for the workloads present. | Important
+[Azure.AKS.AvailabilityZone](../rules/Azure.AKS.AvailabilityZone.md) | AKS clusters deployed with virtual machine scale sets should use availability zones in supported regions for high availability. | Important
 [Azure.AKS.AzurePolicyAddOn](../rules/Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
 [Azure.AKS.AzureRBAC](../rules/Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important
 [Azure.AKS.CNISubnetSize](../rules/Azure.AKS.CNISubnetSize.md) | AKS clusters using Azure CNI should use large subnets to reduce IP exhaustion issues. | Important

--- a/docs/en/baselines/Azure.Preview.md
+++ b/docs/en/baselines/Azure.Preview.md
@@ -4,7 +4,7 @@ Includes Azure features in preview.
 
 ## Rules
 
-The following rules are included within `Azure.Preview`. This baseline includes a total of 221 rules.
+The following rules are included within `Azure.Preview`. This baseline includes a total of 222 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -21,6 +21,7 @@ Name | Synopsis | Severity
 [Azure.AKS.AuthorizedIPs](../rules/Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
 [Azure.AKS.AutoScaling](../rules/Azure.AKS.AutoScaling.md) | Use Autoscaling to ensure AKS clusters deployed with virtual machine scale sets are running efficiently with the right number of nodes for the workloads present. | Important
 [Azure.AKS.AutoUpgrade](../rules/Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
+[Azure.AKS.AvailabilityZone](../rules/Azure.AKS.AvailabilityZone.md) | AKS clusters deployed with virtual machine scale sets should use availability zones in supported regions for high availability. | Important
 [Azure.AKS.AzurePolicyAddOn](../rules/Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
 [Azure.AKS.AzureRBAC](../rules/Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important
 [Azure.AKS.CNISubnetSize](../rules/Azure.AKS.CNISubnetSize.md) | AKS clusters using Azure CNI should use large subnets to reduce IP exhaustion issues. | Important

--- a/docs/en/rules/Azure.AKS.AvailabilityZone.md
+++ b/docs/en/rules/Azure.AKS.AvailabilityZone.md
@@ -1,0 +1,151 @@
+---
+severity: Important
+pillar: Reliability
+category: Design
+resource: Azure Kubernetes Service
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AKS.AvailabilityZone/
+---
+
+# AKS clusters should use Availability zones in supported regions
+
+## SYNOPSIS
+
+AKS clusters deployed with virtual machine scale sets should use availability zones in supported regions for high availability.
+
+## DESCRIPTION
+
+AKS clusters using availability zones improve reliability and ensure availability during failure scenarios affecting a data center within a region.
+Nodes in one availability zone are physically separated from nodes defined in another availability zone.
+By spreading node pools across multiple zones, nodes in one node pool will continue running even if another zone has gone down.
+
+## RECOMMENDATION
+
+Consider using availability zones for AKS clusters deployed with virtual machine scale sets.
+
+## NOTES
+
+This rule applies when analyzing resources deployed to Azure using *pre-flight* and *in-flight* data.
+
+This rule fails when `"availabilityZones": null` is set in the template and there are supported availability zones for a given region.
+
+Configure `AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST` to set additional availability zones that need to be supported which are not in the existing [providers](https://github.com/Azure/PSRule.Rules.Azure/blob/main/data/providers.json) for namespace `Microsoft.Compute` and resource type `virtualMachineScaleSets`.
+
+```yaml
+# YAML: The default AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST configuration option
+configuration:
+  AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST: []
+```
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To set availability zones for an AKS cluster
+
+- Set `properties.agentPoolProfiles[*].availabilityZones` to any or all of `['1', '2', '3']`.
+- Set `properties.agentPoolProfiles[*].type` to `VirtualMachineScaleSets`.
+
+For example:
+
+```json
+{
+    "comments": "Azure Kubernetes Cluster",
+    "apiVersion": "2020-12-01",
+    "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
+    ],
+    "type": "Microsoft.ContainerService/managedClusters",
+    "location": "[parameters('location')]",
+    "name": "[parameters('clusterName')]",
+    "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+            "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]": {}
+        }
+    },
+    "properties": {
+        "kubernetesVersion": "[parameters('kubernetesVersion')]",
+        "disableLocalAccounts": true,
+        "enableRBAC": true,
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": [
+            {
+                "name": "system",
+                "osDiskSizeGB": 32,
+                "count": 3,
+                "minCount": 3,
+                "maxCount": 10,
+                "enableAutoScaling": true,
+                "maxPods": 50,
+                "vmSize": "Standard_D2s_v3",
+                "osType": "Linux",
+                "type": "VirtualMachineScaleSets",
+                "vnetSubnetID": "[variables('clusterSubnetId')]",
+                "mode": "System",
+                "osDiskType": "Ephemeral",
+                "scaleSetPriority": "Regular",
+                "availabilityZones": [
+                    "1",
+                    "2",
+                    "3"
+                ]
+            }
+        ],
+        "aadProfile": {
+            "managed": true,
+            "enableAzureRBAC": true,
+            "adminGroupObjectIDs": "[parameters('clusterAdmins')]",
+            "tenantID": "[subscription().tenantId]"
+        },
+        "networkProfile": {
+            "networkPlugin": "azure",
+            "networkPolicy": "azure",
+            "loadBalancerSku": "Standard",
+            "serviceCidr": "192.168.0.0/16",
+            "dnsServiceIP": "192.168.0.4",
+            "dockerBridgeCidr": "172.17.0.1/16"
+        },
+        "autoUpgradeProfile": {
+            "upgradeChannel": "stable"
+        },
+        "addonProfiles": {
+            "azurepolicy": {
+                "enabled": true,
+                "config": {
+                    "version": "v2"
+                }
+            },
+            "omsagent": {
+                "enabled": true,
+                "config": {
+                    "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
+                }
+            },
+            "kubeDashboard": {
+                "enabled": false
+            }
+        }
+    }
+}
+```
+
+### Configure with Azure CLI
+
+#### Create AKS Cluster in Zone 1, 2 and 3
+
+```bash
+az aks create \
+  --resource-group '<resource_group>' \
+  --name '<cluster_name>' \
+  --generate-ssh-keys \
+  --vm-set-type VirtualMachineScaleSets \
+  --load-balancer-sku standard \
+  --node-count '<node_count>' \
+  --zones 1 2 3
+```
+
+## LINKS
+
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters?tabs=json)
+- [Create an Azure Kubernetes Service (AKS) cluster that uses availability zones](https://docs.microsoft.com/azure/aks/availability-zones)
+- [Use zone-aware services](https://docs.microsoft.com/azure/architecture/framework/resiliency/design-best-practices#use-zone-aware-services)

--- a/docs/en/rules/Azure.AKS.AvailabilityZone.md
+++ b/docs/en/rules/Azure.AKS.AvailabilityZone.md
@@ -42,7 +42,7 @@ configuration:
 
 To set availability zones for an AKS cluster
 
-- Set `properties.agentPoolProfiles[*].availabilityZones` to any or all of `['1', '2', '3']`.
+- Set `properties.agentPoolProfiles[*].availabilityZones` to any or all of `["1", "2", "3"]`.
 - Set `properties.agentPoolProfiles[*].type` to `VirtualMachineScaleSets`.
 
 For example:

--- a/docs/en/rules/Azure.AKS.AvailabilityZone.md
+++ b/docs/en/rules/Azure.AKS.AvailabilityZone.md
@@ -26,7 +26,7 @@ Consider using availability zones for AKS clusters deployed with virtual machine
 
 This rule applies when analyzing resources deployed to Azure using *pre-flight* and *in-flight* data.
 
-This rule fails when `"availabilityZones": null` is set in the template and there are supported availability zones for a given region.
+This rule fails when `"availabilityZones"` is `null`, `[]` or not set when the AKS cluster is deployed to a virtual machine scale set and there are supported availability zones for the given region.
 
 Configure `AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST` to set additional availability zones that need to be supported which are not in the existing [providers](https://github.com/Azure/PSRule.Rules.Azure/blob/main/data/providers.json) for namespace `Microsoft.Compute` and resource type `virtualMachineScaleSets`.
 

--- a/docs/en/rules/module.md
+++ b/docs/en/rules/module.md
@@ -212,6 +212,7 @@ Name | Synopsis | Severity
 Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.AKS.AutoUpgrade](Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
+[Azure.AKS.AvailabilityZone](Azure.AKS.AvailabilityZone.md) | AKS clusters deployed with virtual machine scale sets should use availability zones in supported regions for high availability. | Important
 [Azure.AKS.PoolVersion](Azure.AKS.PoolVersion.md) | AKS node pools should match Kubernetes control plane version. | Important
 [Azure.AKS.Version](Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important
 

--- a/docs/en/rules/resource.md
+++ b/docs/en/rules/resource.md
@@ -136,6 +136,7 @@ Name | Synopsis | Severity
 [Azure.AKS.AuthorizedIPs](Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
 [Azure.AKS.AutoScaling](Azure.AKS.AutoScaling.md) | Use Autoscaling to ensure AKS clusters deployed with virtual machine scale sets are running efficiently with the right number of nodes for the workloads present. | Important
 [Azure.AKS.AutoUpgrade](Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
+[Azure.AKS.AvailabilityZone](Azure.AKS.AvailabilityZone.md) | AKS clusters deployed with virtual machine scale sets should use availability zones in supported regions for high availability. | Important
 [Azure.AKS.AzurePolicyAddOn](Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
 [Azure.AKS.AzureRBAC](Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important
 [Azure.AKS.CNISubnetSize](Azure.AKS.CNISubnetSize.md) | AKS clusters using Azure CNI should use large subnets to reduce IP exhaustion issues. | Important

--- a/docs/setup/configuring-rules.md
+++ b/docs/setup/configuring-rules.md
@@ -218,14 +218,14 @@ configuration:
   AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST:
   - location: 'Australia Southeast'
     zones:
-      - 1
-      - 2
-      - 3
+      - "1"
+      - "2"
+      - "3"
   - location: 'Norway East'
     zones:
-      - 1
-      - 2
-      - 3
+      - "1"
+      - "2"
+      - "3"
 ```
 
 The above example, both these forms of location are accepted:

--- a/docs/setup/configuring-rules.md
+++ b/docs/setup/configuring-rules.md
@@ -190,3 +190,50 @@ Example:
 configuration:
   AZURE_AKS_CNI_MINIMUM_CLUSTER_SUBNET_SIZE: 26
 ```
+
+### Azure AKS additional region availability zone list
+
+This configuration option adds availability zones that are not included in the existing [providers](https://github.com/Azure/PSRule.Rules.Azure/blob/main/data/providers.json) for namespace `Microsoft.Compute` and resource type `virtualMachineScaleSets`.
+
+Syntax:
+
+```yaml
+configuration:
+  AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST: array
+```
+
+Default:
+
+```yaml
+# YAML: The default AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST configuration option
+configuration:
+  AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST: []
+```
+
+Example:
+
+```yaml
+# YAML: Set the AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST configuration option to Australia Southeast and Norway East, with zones 1, 2, 3.
+configuration:
+  AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST:
+  - location: 'Australia Southeast'
+    zones:
+      - 1
+      - 2
+      - 3
+  - location: 'Norway East'
+    zones:
+      - 1
+      - 2
+      - 3
+```
+
+The above example, both these forms of location are accepted:
+
+* `Australia Southeast` or `australiasoutheast`
+* `Norway East` or `norwayeast`
+
+The `Azure.AKS.AvailabilityZone` rule normalizes these location formats so either is accepted in the configuration.
+
+**Note:** The above locations in the example do **not** support availability zones currently. 
+They are just added as an example of some regions that could be added if they did support availability zones and the module didn't have them included in the providers list.

--- a/docs/setup/configuring-rules.md
+++ b/docs/setup/configuring-rules.md
@@ -235,5 +235,6 @@ The above example, both these forms of location are accepted:
 
 The `Azure.AKS.AvailabilityZone` rule normalizes these location formats so either is accepted in the configuration.
 
-**Note:** The above locations in the example do **not** support availability zones currently. 
-They are just added as an example of some regions that could be added if they did support availability zones and the module didn't have them included in the providers list.
+!!! Note
+    The above locations in the example do **not** currently support availability zones.
+    If they do in the future, you can configure this option to add them prior to PSRule for Azure support.

--- a/src/PSRule.Rules.Azure/Data/Template/Models.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Models.cs
@@ -44,6 +44,13 @@ namespace PSRule.Rules.Azure.Data.Template
         public string[] Locations { get; set; }
 
         public string[] ApiVersions { get; set; }
+        public AvailabilityZoneMapping[] ZoneMappings { get; set; }
+    }
+
+    public sealed class AvailabilityZoneMapping
+    {
+        public string Location { get; set; }
+        public string[] Zones { get; set; }
     }
 
     public sealed class CloudEnvironment

--- a/src/PSRule.Rules.Azure/Data/Template/ResourceProviderHelper.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ResourceProviderHelper.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using System.Linq;
+
+namespace PSRule.Rules.Azure.Data.Template
+{
+    internal sealed class ResourceProviderHelper {
+        private readonly string AssemblyPath = Path.GetDirectoryName(typeof(ResourceProviderHelper).Assembly.Location);
+        private const string DATAFILE_PROVIDERS = "providers.json";
+        private Dictionary<string, ResourceProvider> _Providers;
+
+        public ResourceProviderHelper()
+        {
+            _Providers = ReadProviders();
+        }
+
+        internal Dictionary<string, T> ReadDataFile<T>(string fileName)
+        {
+            var sourcePath = Path.Combine(AssemblyPath, fileName);
+            if (!File.Exists(sourcePath))
+                return null;
+
+            var json = File.ReadAllText(sourcePath);
+            var settings = new JsonSerializerSettings();
+            settings.Converters.Add(new ResourceProviderConverter());
+            var result = JsonConvert.DeserializeObject<Dictionary<string, T>>(json, settings);
+            return result;
+        }
+
+        private Dictionary<string, ResourceProvider> ReadProviders()
+        {
+            return ReadDataFile<ResourceProvider>(DATAFILE_PROVIDERS);
+        }
+
+        internal ResourceProviderType[] GetResourceType(string providerNamespace, string resourceType)
+        {
+            if (_Providers == null || _Providers.Count == 0 || !_Providers.TryGetValue(providerNamespace, out ResourceProvider provider))
+                return Array.Empty<ResourceProviderType>();
+
+            if (resourceType == null)
+                return provider.Types.Values.ToArray();
+
+            if (!provider.Types.ContainsKey(resourceType))
+                return Array.Empty<ResourceProviderType>();
+
+            return new ResourceProviderType[] { provider.Types[resourceType] };
+        }
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Template/ResourceProviderHelper.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ResourceProviderHelper.cs
@@ -9,7 +9,8 @@ using System.Linq;
 
 namespace PSRule.Rules.Azure.Data.Template
 {
-    internal sealed class ResourceProviderHelper {
+    internal sealed class ResourceProviderHelper
+    {
         private readonly string AssemblyPath = Path.GetDirectoryName(typeof(ResourceProviderHelper).Assembly.Location);
         private const string DATAFILE_PROVIDERS = "providers.json";
         private Dictionary<string, ResourceProvider> _Providers;

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PSRule.Rules.Azure.Configuration;
 using PSRule.Rules.Azure.Pipeline;
@@ -9,7 +8,6 @@ using PSRule.Rules.Azure.Resources;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading;
 

--- a/src/PSRule.Rules.Azure/Runtime/Helper.cs
+++ b/src/PSRule.Rules.Azure/Runtime/Helper.cs
@@ -8,6 +8,11 @@ using PSRule.Rules.Azure.Data.Template;
 using PSRule.Rules.Azure.Pipeline;
 using PSRule.Rules.Azure.Pipeline.Output;
 using System.Management.Automation;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using System.Linq;
+using System;
 
 namespace PSRule.Rules.Azure.Runtime
 {
@@ -16,6 +21,10 @@ namespace PSRule.Rules.Azure.Runtime
     /// </summary>
     public static class Helper
     {
+        private readonly static string AssemblyPath = Path.GetDirectoryName(typeof(Helper).Assembly.Location);
+        private const string DATAFILE_PROVIDERS = "providers.json";
+        private static Dictionary<string, ResourceProvider> _Providers;
+
         public static string CompressExpression(string expression)
         {
             if (!IsTemplateExpression(expression))
@@ -67,6 +76,41 @@ namespace PSRule.Rules.Azure.Runtime
             var option = PSRuleOption.FromFileOrDefault(PSRuleOption.GetWorkingPath());
             var context = new PipelineContext(option, commandRuntime != null ? new PSPipelineWriter(option, commandRuntime) : null);
             return context;
+        }
+
+        private static Dictionary<string, T> ReadDataFile<T>(string fileName)
+        {
+            var sourcePath = Path.Combine(AssemblyPath, fileName);
+            if (!File.Exists(sourcePath))
+                return null;
+
+            var json = File.ReadAllText(sourcePath);
+            var settings = new JsonSerializerSettings();
+            settings.Converters.Add(new ResourceProviderConverter());
+            var result = JsonConvert.DeserializeObject<Dictionary<string, T>>(json, settings);
+            return result;
+        }
+
+        private static Dictionary<string, ResourceProvider> ReadProviders()
+        {
+            return ReadDataFile<ResourceProvider>(DATAFILE_PROVIDERS);
+        }
+
+        public static ResourceProviderType[] GetResourceType(string providerNamespace, string resourceType)
+        {
+            if (_Providers == null)
+                _Providers = ReadProviders();
+
+            if (_Providers == null || _Providers.Count == 0 || !_Providers.TryGetValue(providerNamespace, out ResourceProvider provider))
+                return Array.Empty<ResourceProviderType>();
+
+            if (resourceType == null)
+                return provider.Types.Values.ToArray();
+
+            if (!provider.Types.ContainsKey(resourceType))
+                return Array.Empty<ResourceProviderType>();
+
+            return new ResourceProviderType[] { provider.Types[resourceType] };
         }
 
         #endregion Helper methods

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -11,6 +11,7 @@
     AKSNodePoolVersion = "The agent pool ({0}) is running v{1}."
     AKSAutoScaling = "The agent pool ({0}) is not using autoscaling."
     AKSAzureCNI = "The subnet ({0}) should be using a minimum size of /{1}."
+    AKSAvailabilityZone = "The agent pool ({0}) deployed to region ({1}) should use following availability zones [{2}]"
     SubnetNSGNotConfigured = "The subnet ({0}) has no NSG associated."
     ServiceUrlNotHttps = "The service URL for '{0}' is not a HTTPS endpoint."
     BackendUrlNotHttps = "The backend URL for '{0}' is not a HTTPS endpoint."

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -177,7 +177,7 @@ Rule 'Azure.AKS.CNISubnetSize' -Type 'Microsoft.ContainerService/managedClusters
 Rule 'Azure.AKS.AvailabilityZone' -Type 'Microsoft.ContainerService/managedClusters', 'Microsoft.ContainerService/managedClusters/agentPools' -Tag @{ release = 'GA'; ruleSet = '2021_09'; } {
     $agentPools = @(GetAgentPoolProfiles);
 
-    if ($agentPools.Length -eq 0) {
+    if ($agentPools.Length -eq 0 -or [string]::IsNullOrEmpty($TargetObject.Location)) {
         return $Assert.Pass();
     }
 
@@ -198,7 +198,7 @@ Rule 'Azure.AKS.AvailabilityZone' -Type 'Microsoft.ContainerService/managedClust
     | Where-Object { (GetNormalLocation -Location $_.Location) -eq $location } 
     | Select-Object -ExpandProperty Zones -First 1;
 
-    if (!$locationAvailabilityZones) {
+    if (-not $locationAvailabilityZones) {
         return $Assert.Pass();
     }
 

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -173,6 +173,50 @@ Rule 'Azure.AKS.CNISubnetSize' -Type 'Microsoft.ContainerService/managedClusters
     }
 } -Configure @{ AZURE_AKS_CNI_MINIMUM_CLUSTER_SUBNET_SIZE = 23 }
 
+# Synopsis: AKS clusters deployed with virtual machine scale sets should use availability zones in supported regions for high availability.
+Rule 'Azure.AKS.AvailabilityZone' -Type 'Microsoft.ContainerService/managedClusters', 'Microsoft.ContainerService/managedClusters/agentPools' -Tag @{ release = 'GA'; ruleSet = '2021_09'; } {
+    $agentPools = @(GetAgentPoolProfiles);
+
+    if ($agentPools.Length -eq 0) {
+        return $Assert.Pass();
+    }
+
+    $configurationZones = $Configuration.AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST;
+
+    $virtualMachineScaleSetProvider = [PSRule.Rules.Azure.Runtime.Helper]::GetResourceType('Microsoft.Compute', 'virtualMachineScaleSets');
+
+    if ($configurationZones.Length -gt 0) {
+        $availabilityZones = @($configurationZones) + $virtualMachineScaleSetProvider.ZoneMappings;
+    }
+    else {
+        $availabilityZones = $virtualMachineScaleSetProvider.ZoneMappings;
+    }
+
+    $location = GetNormalLocation -Location $TargetObject.Location;
+
+    $locationAvailabilityZones = $availabilityZones 
+    | Where-Object { (GetNormalLocation -Location $_.Location) -eq $location } 
+    | Select-Object -ExpandProperty Zones -First 1;
+
+    if (!$locationAvailabilityZones) {
+        return $Assert.Pass();
+    }
+
+    $joinedZoneString = $locationAvailabilityZones -join ', ';
+
+    foreach ($agentPool in $agentPools) {
+
+        # Availability zones only available on virtual machine scale sets
+        if ($Assert.HasFieldValue($agentPool, 'type', 'VirtualMachineScaleSets').Result) {
+            $validZone = $Assert.HasField($agentPool, 'availabilityZones').Result -and -not $Assert.NullOrEmpty($agentPool, 'availabilityZones').Result;
+            $Assert.Create($validZone, ($LocalizedData.AKSAvailabilityZone -f $agentPool.name, $location, $joinedZoneString));
+        }
+        else {
+            $Assert.Pass();
+        }
+    }
+} -Configure @{ AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST = @() }
+
 #region Helper functions
 
 function global:GetAgentPoolProfiles {
@@ -189,6 +233,7 @@ function global:GetAgentPoolProfiles {
                     maxPods = $_.properties.maxPods
                     orchestratorVersion = $_.properties.orchestratorVersion
                     enableAutoScaling = $_.properties.enableAutoScaling
+                    availabilityZones = $_.properties.availabilityZones
                 }
             });
         }
@@ -199,6 +244,7 @@ function global:GetAgentPoolProfiles {
                 maxPods = $TargetObject.properties.maxPods
                 orchestratorVersion = $TargetObject.properties.orchestratorVersion
                 enableAutoScaling = $TargetObject.properties.enableAutoScaling
+                availabilityZones = $TargetObject.properties.availabilityZones
             }
         }
     }

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -174,7 +174,7 @@ Rule 'Azure.AKS.CNISubnetSize' -Type 'Microsoft.ContainerService/managedClusters
 } -Configure @{ AZURE_AKS_CNI_MINIMUM_CLUSTER_SUBNET_SIZE = 23 }
 
 # Synopsis: AKS clusters deployed with virtual machine scale sets should use availability zones in supported regions for high availability.
-Rule 'Azure.AKS.AvailabilityZone' -Type 'Microsoft.ContainerService/managedClusters', 'Microsoft.ContainerService/managedClusters/agentPools' -Tag @{ release = 'GA'; ruleSet = '2021_09'; } {
+Rule 'Azure.AKS.AvailabilityZone' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; ruleSet = '2021_09'; } {
     $agentPools = @(GetAgentPoolProfiles);
 
     if ($agentPools.Length -eq 0 -or [string]::IsNullOrEmpty($TargetObject.Location)) {
@@ -206,8 +206,7 @@ Rule 'Azure.AKS.AvailabilityZone' -Type 'Microsoft.ContainerService/managedClust
 
         # Availability zones only available on virtual machine scale sets
         if ($Assert.HasFieldValue($agentPool, 'type', 'VirtualMachineScaleSets').Result) {
-            $validZone = $Assert.HasField($agentPool, 'availabilityZones').Result -and -not $Assert.NullOrEmpty($agentPool, 'availabilityZones').Result;
-            $Assert.Create($validZone, ($LocalizedData.AKSAvailabilityZone -f $agentPool.name, $location, $joinedZoneString));
+            $Assert.HasFieldValue($agentPool, 'availabilityZones').Reason($LocalizedData.AKSAvailabilityZone, $agentPool.name, $location, $joinedZoneString);
         }
         else {
             $Assert.Pass();

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -186,7 +186,10 @@ Rule 'Azure.AKS.AvailabilityZone' -Type 'Microsoft.ContainerService/managedClust
     $virtualMachineScaleSetProvider = [PSRule.Rules.Azure.Runtime.Helper]::GetResourceType('Microsoft.Compute', 'virtualMachineScaleSets');
 
     if ($configurationZones.Length -gt 0) {
-        $availabilityZones = @($configurationZones) + $virtualMachineScaleSetProvider.ZoneMappings;
+
+        # Merge configuration options and default zone mappings together
+        # We put configuration options at the beginning so they are processed first
+        $availabilityZones = @($configurationZones) + @($virtualMachineScaleSetProvider.ZoneMappings);
     }
     else {
         $availabilityZones = $virtualMachineScaleSetProvider.ZoneMappings;
@@ -206,7 +209,8 @@ Rule 'Azure.AKS.AvailabilityZone' -Type 'Microsoft.ContainerService/managedClust
 
         # Availability zones only available on virtual machine scale sets
         if ($Assert.HasFieldValue($agentPool, 'type', 'VirtualMachineScaleSets').Result) {
-            $Assert.HasFieldValue($agentPool, 'availabilityZones').Reason($LocalizedData.AKSAvailabilityZone, $agentPool.name, $location, $joinedZoneString);
+            $Assert.HasFieldValue($agentPool, 'availabilityZones').
+                Reason($LocalizedData.AKSAvailabilityZone, $agentPool.name, $location, $joinedZoneString);
         }
         else {
             $Assert.Pass();

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -194,9 +194,7 @@ Rule 'Azure.AKS.AvailabilityZone' -Type 'Microsoft.ContainerService/managedClust
 
     $location = GetNormalLocation -Location $TargetObject.Location;
 
-    $locationAvailabilityZones = $availabilityZones 
-    | Where-Object { (GetNormalLocation -Location $_.Location) -eq $location } 
-    | Select-Object -ExpandProperty Zones -First 1;
+    $locationAvailabilityZones = $availabilityZones | Where-Object { (GetNormalLocation -Location $_.Location) -eq $location } | Select-Object -ExpandProperty Zones -First 1;
 
     if (-not $locationAvailabilityZones) {
         return $Assert.Pass();

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -50,8 +50,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-G', 'cluster-H';
         }
 
         It 'Azure.AKS.Version' {
@@ -66,8 +66,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'system';
+            $ruleResult.Length | Should -Be 7;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'system', 'cluster-G', 'cluster-H';
         }
 
         It 'Azure.AKS.PoolVersion' {
@@ -82,8 +82,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H';
         }
 
         It 'Azure.AKS.UseRBAC' {
@@ -98,8 +98,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H';
         }
 
         It 'Azure.AKS.NetworkPolicy' {
@@ -108,8 +108,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-G', 'cluster-H';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -130,8 +130,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-F', 'system';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-F', 'system', 'cluster-G', 'cluster-H';
         }
 
         It 'Azure.AKS.NodeMinPods' {
@@ -140,8 +140,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-G', 'cluster-H';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -156,8 +156,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-G', 'cluster-H';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -172,8 +172,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-G', 'cluster-H';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -188,8 +188,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-G', 'cluster-H';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -204,8 +204,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-G', 'cluster-H';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -220,8 +220,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -236,8 +236,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 2;
-            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D';
+            $ruleResult | Should -HaveCount 4;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -252,8 +252,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -268,8 +268,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -284,8 +284,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -306,8 +306,24 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult | Should -HaveCount 5;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-F', 'cluster-G', 'cluster-H';
+        }
+
+        It 'Azure.AKS.AvailabilityZone' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AvailabilityZone' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult | Should -HaveCount 3;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-F';
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-G', 'cluster-H';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult | Should -HaveCount 5;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'system', 'cluster-D', 'cluster-F';
         }
     }
 
@@ -437,8 +453,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD', 'clusterE';
         }
 
         It 'Azure.AKS.PoolVersion' {
@@ -447,8 +463,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterD';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterD', 'clusterE';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -469,8 +485,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD', 'clusterE';
         }
 
         It 'Azure.AKS.NodeMinPods' {
@@ -485,8 +501,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD', 'clusterE';
         }
 
         It 'Azure.AKS.ManagedIdentity' {
@@ -499,8 +515,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterD';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterD', 'clusterE';
         }
 
         It 'Azure.AKS.StandardLB' {
@@ -513,8 +529,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterD';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterD', 'clusterE';
         }
 
         It 'Azure.AKS.AzurePolicyAddOn' {
@@ -523,8 +539,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -545,8 +561,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE';
         }
 
         It 'Azure.AKS.AutoUpgrade' {
@@ -561,8 +577,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE';
         }
 
         It 'Azure.AKS.AutoScaling' {
@@ -571,14 +587,14 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 3
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterC/agentpool3', 'clusterD'
+            $ruleResult | Should -HaveCount 4;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterC/agentpool3', 'clusterD', 'clusterE';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 2
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool4'
+            $ruleResult | Should -HaveCount 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool4';
         }
 
         It 'Azure.AKS.AuthorizedIPs' {
@@ -593,8 +609,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE';
         }
 
         It 'Azure.AKS.LocalAccounts' {
@@ -609,8 +625,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE';
         }
 
         It 'Azure.AKS.AzureRBAC' {
@@ -625,8 +641,24 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE';
+        }
+
+        It 'Azure.AKS.AvailabilityZone' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AvailabilityZone' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult | Should -HaveCount 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterE';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult | Should -HaveCount 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -50,8 +50,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
         }
 
         It 'Azure.AKS.Version' {
@@ -66,8 +66,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 7;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'system', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 9;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'system', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
         }
 
         It 'Azure.AKS.PoolVersion' {
@@ -82,8 +82,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 8;
+            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
         }
 
         It 'Azure.AKS.UseRBAC' {
@@ -98,8 +98,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 8;
+            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
         }
 
         It 'Azure.AKS.NetworkPolicy' {
@@ -108,8 +108,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -130,8 +130,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-F', 'system', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 8;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-F', 'system', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
         }
 
         It 'Azure.AKS.NodeMinPods' {
@@ -140,8 +140,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -156,8 +156,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 7;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -172,8 +172,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 7;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -188,8 +188,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -204,8 +204,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 7;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -220,8 +220,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 8;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -236,8 +236,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 4;
-            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H';
+            $ruleResult | Should -HaveCount 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -252,8 +252,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 8;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -268,8 +268,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 8;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -284,8 +284,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H';
+            $ruleResult.Length | Should -Be 8;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -306,8 +306,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 5;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-F', 'cluster-G', 'cluster-H';
+            $ruleResult | Should -HaveCount 7;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
         }
 
         It 'Azure.AKS.AvailabilityZone' {
@@ -322,8 +322,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 4;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-D', 'cluster-F';
+            $ruleResult | Should -HaveCount 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-D', 'cluster-F', 'cluster-I', 'cluster-J';
         }
     }
 
@@ -659,6 +659,65 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult | Should -HaveCount 1;
             $ruleResult.TargetName | Should -BeIn 'clusterD';
+        }
+    }
+
+    Context 'With Configuration Option' {
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.AKS.json';
+            $configPath = Join-Path -Path $here -ChildPath 'ps-rule-options.yaml';
+        }
+
+        It 'Azure.AKS.AvailabilityZone - HashTable option' {
+            $option = @{
+                'Configuration.AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST' = @(
+                    [PSCustomObject]@{
+                        Location = 'Australia Southeast'
+                        Zones = @("1", "2", "3")
+                    }
+                    [PSCustomObject]@{
+                        Location = 'Norway East'
+                        Zones = @("1", "2", "3")
+                    }
+                )
+            }
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Option $option
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AvailabilityZone' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult | Should -HaveCount 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult | Should -HaveCount 3;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-D';
+        }
+
+        It 'Azure.AKS.AvailabilityZone - YAML file option' {
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Option $configPath
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AvailabilityZone' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult | Should -HaveCount 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult | Should -HaveCount 3;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-D';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -322,8 +322,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 5;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'system', 'cluster-D', 'cluster-F';
+            $ruleResult | Should -HaveCount 4;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-D', 'cluster-F';
         }
     }
 
@@ -657,8 +657,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 3;
-            $ruleResult.TargetName | Should -BeIn 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD';
+            $ruleResult | Should -HaveCount 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterD';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -507,9 +507,9 @@
                 {
                     "type": "Microsoft.ContainerService/managedClusters/agentPools",
                     "apiVersion": "2019-10-01",
-                    "name": "[concat(parameters('clusterName4'), '/agentpool2')]",
+                    "name": "[concat(parameters('clusterName5'), '/agentpool2')]",
                     "dependsOn": [
-                        "[resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName4'))]"
+                        "[resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName5'))]"
                     ],
                     "properties": {
                         "count": 3,

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -18,6 +18,10 @@
             "defaultValue": "clusterD",
             "type": "string"
         },
+        "clusterName5": {
+            "defaultValue": "clusterE",
+            "type": "string"
+        },
         "clusterLocation": {
             "defaultValue": "[resourceGroup().location]",
             "type": "string"
@@ -54,7 +58,8 @@
                         "maxPods": 50,
                         "type": "VirtualMachineScaleSets",
                         "osType": "Linux",
-                        "enableAutoScaling": false
+                        "enableAutoScaling": false,
+                        "availabilityZones": null
                     }
                 ],
                 "servicePrincipalProfile": {
@@ -135,7 +140,8 @@
                         "maxPods": 50,
                         "type": "VirtualMachineScaleSets",
                         "osType": "Linux",
-                        "enableAutoScaling": true
+                        "enableAutoScaling": true,
+                        "availabilityZones": []
                     }
                 ],
                 "servicePrincipalProfile": {
@@ -276,7 +282,12 @@
                         "maxPods": 50,
                         "type": "VirtualMachineScaleSets",
                         "osType": "Linux",
-                        "enableAutoScaling": true
+                        "enableAutoScaling": true,
+                        "availabilityZones": [
+                            "1",
+                            "2",
+                            "3"
+                        ]
                     }
                 ],
                 "servicePrincipalProfile": {
@@ -374,7 +385,142 @@
                         "maxPods": 50,
                         "type": "VirtualMachineScaleSets",
                         "osType": "Linux",
-                        "enableAutoScaling": false
+                        "enableAutoScaling": false,
+                        "availabilityZones": [
+                            "1",
+                            "2",
+                            "3"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "type": "Microsoft.ContainerService/managedClusters",
+            "apiVersion": "2020-12-01",
+            "name": "[parameters('clusterName5')]",
+            "location": "[parameters('clusterLocation')]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "kubernetesVersion": "1.20.5",
+                "dnsPrefix": "[concat('dns-', parameters('clusterName5'))]",
+                "agentPoolProfiles": [
+                    {
+                        "name": "agentpool1",
+                        "count": 3,
+                        "vmSize": "Standard_B2ms",
+                        "osDiskSizeGB": 100,
+                        "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-01')]",
+                        "maxPods": 50,
+                        "type": "VirtualMachineScaleSets",
+                        "osType": "Linux",
+                        "enableAutoScaling": true,
+                        "availabilityZones": [
+                            "1",
+                            "2",
+                            "3"
+                        ]
+                    }
+                ],
+                "servicePrincipalProfile": {
+                    "clientId": "00000000-0000-0000-0000-000000000000"
+                },
+                "addonProfiles": {
+                    "aciConnectorLinux": {
+                        "enabled": true,
+                        "config": {
+                            "SubnetName": "subnet-aci"
+                        }
+                    },
+                    "azurePolicy": {
+                        "enabled": false
+                    },
+                    "httpApplicationRouting": {
+                        "enabled": true
+                    },
+                    "kubeDashboard": {
+                        "enabled": true
+                    },
+                    "omsagent": {
+                        "enabled": true,
+                        "config": {
+                            "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
+                        }
+                    },
+                    "azureKeyvaultSecretsProvider": {
+                        "enabled": true,
+                        "config": {
+                            "enableSecretRotation": "false"
+                        }
+                    },
+                    "openServiceMesh": {
+                        "enabled": true
+                    }
+                },
+                "aadProfile": {
+                    "managed": true,
+                    "enableAzureRBAC": true,
+                    "adminGroupObjectIDs": [],
+                    "tenantID": "[subscription().tenantId]"
+                },
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "rapid"
+                },
+                "autoScalerProfile": {
+                    "balance-similar-node-groups": "false",
+                    "expander": "random",
+                    "max-empty-bulk-delete": "10",
+                    "max-graceful-termination-sec": "600",
+                    "max-total-unready-percentage": "45",
+                    "new-pod-scale-up-delay": "0s",
+                    "ok-total-unready-count": "3",
+                    "scale-down-delay-after-add": "10m",
+                    "scale-down-delay-after-delete": "10s",
+                    "scale-down-delay-after-failure": "3m",
+                    "scale-down-unneeded-time": "10m",
+                    "scale-down-unready-time": "20m",
+                    "scale-down-utilization-threshold": "0.5",
+                    "scan-interval": "10s",
+                    "skip-nodes-with-local-storage": "false",
+                    "skip-nodes-with-system-pods": "true"
+                },
+                "disableLocalAccounts": true,
+                "enableRBAC": true,
+                "enablePodSecurityPolicy": false,
+                "networkProfile": {
+                    "networkPlugin": "azure",
+                    "networkPolicy": "azure",
+                    "loadBalancerSku": "Standard",
+                    "serviceCidr": "192.168.0.0/16",
+                    "dnsServiceIP": "192.168.0.4",
+                    "dockerBridgeCidr": "172.17.0.1/16"
+                },
+                "apiServerAccessProfile": {
+                    "authorizedIpRanges": [
+                        "0.0.0.0/32"
+                    ]
+                }
+            },
+            "resources": [
+                {
+                    "type": "Microsoft.ContainerService/managedClusters/agentPools",
+                    "apiVersion": "2019-10-01",
+                    "name": "[concat(parameters('clusterName4'), '/agentpool2')]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName4'))]"
+                    ],
+                    "properties": {
+                        "count": 3,
+                        "vmSize": "Standard_B2ms",
+                        "osDiskSizeGB": 100,
+                        "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-04')]",
+                        "maxPods": 50,
+                        "type": "VirtualMachineScaleSets",
+                        "osType": "Linux",
+                        "enableAutoScaling": false,
+                        "availabilityZones": null
                     }
                 }
             ]

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -2,7 +2,7 @@
     {
         "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-A",
         "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-A",
-        "Location": "region",
+        "Location": "Australia East",
         "ResourceName": "cluster-A",
         "Name": "cluster-A",
         "Properties": {
@@ -20,7 +20,8 @@
                     "type": "AvailabilitySet",
                     "orchestratorVersion": "1.20.5",
                     "osType": "Linux",
-                    "enableAutoScaling": false
+                    "enableAutoScaling": false,
+                    "availabilityZones": null
                 }
             ],
             "servicePrincipalProfile": {
@@ -67,7 +68,7 @@
     {
         "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-B",
         "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-B",
-        "Location": "region",
+        "Location": "auatraliaeast",
         "ResourceName": "cluster-B",
         "Name": "cluster-B",
         "Properties": {
@@ -168,7 +169,7 @@
         "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-C",
         "Identity": null,
         "Kind": null,
-        "Location": "region",
+        "Location": "australiaeast",
         "ManagedBy": null,
         "ResourceName": "cluster-C",
         "Name": "cluster-C",
@@ -285,7 +286,7 @@
             "UserAssignedIdentities": null
         },
         "Kind": null,
-        "Location": "region",
+        "Location": "australiaeast",
         "ManagedBy": null,
         "ResourceName": "cluster-D",
         "Name": "cluster-D",
@@ -312,7 +313,12 @@
                     "mode": "System",
                     "osType": "Linux",
                     "nodeImageVersion": "AKSUbuntu:1604:2020.05.13",
-                    "enableAutoScaling": false
+                    "enableAutoScaling": false,
+                    "availabilityZones": [
+                        "1",
+                        "2",
+                        "3"
+                    ]
                 }
             ],
             "windowsProfile": {
@@ -463,7 +469,7 @@
         "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-E/agentPools/system",
         "Identity": null,
         "Kind": null,
-        "Location": null,
+        "Location": "australiasoutheast",
         "ManagedBy": null,
         "ResourceName": "system",
         "Name": "system",
@@ -488,7 +494,8 @@
             "nodeLabels": {},
             "mode": "System",
             "osType": "Linux",
-            "nodeImageVersion": "AKSUbuntu-1804containerd-2021.01.28"
+            "nodeImageVersion": "AKSUbuntu-1804containerd-2021.01.28",
+            "availabilityZones": null
         },
         "ResourceGroupName": "test-rg",
         "Type": "Microsoft.ContainerService/managedClusters/agentPools",
@@ -543,7 +550,7 @@
             "UserAssignedIdentities": null
         },
         "Kind": null,
-        "Location": "region",
+        "Location": "Australia Southeast",
         "ManagedBy": null,
         "ResourceName": "cluster-F",
         "Name": "cluster-F",
@@ -578,7 +585,8 @@
                     "nodeLabels": {},
                     "mode": "System",
                     "osType": "Linux",
-                    "nodeImageVersion": "AKSUbuntu-1804containerd-2021.04.27"
+                    "nodeImageVersion": "AKSUbuntu-1804containerd-2021.04.27",
+                    "availabilityZones": []
                 }
             ],
             "windowsProfile": {
@@ -772,5 +780,137 @@
                 "SubscriptionId": null
             }
         ]
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-G",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-G",
+        "Location": "Australia East",
+        "ResourceName": "cluster-G",
+        "Name": "cluster-G",
+        "Properties": {
+            "kubernetesVersion": "1.20.5",
+            "dnsPrefix": "cluster-G",
+            "fqdn": "cluster-G-00000000.nnn.region.azmk8s.io",
+            "agentPoolProfiles": [
+                {
+                    "name": "agentpool",
+                    "count": 3,
+                    "vmSize": "Standard_F2s_v2",
+                    "osDiskSizeGB": 30,
+                    "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
+                    "maxPods": 30,
+                    "type": "VirtualMachineScaleSets",
+                    "orchestratorVersion": "1.20.5",
+                    "osType": "Linux",
+                    "enableAutoScaling": false,
+                    "availabilityZones": null
+                }
+            ],
+            "servicePrincipalProfile": {
+                "clientId": "00000000-0000-0000-0000-000000000000"
+            },
+            "addonProfiles": {
+                "aciconnectorlinux": {
+                    "enabled": true,
+                    "config": {
+                        "subnetname": "subnet-A"
+                    }
+                },
+                "httpapplicationrouting": {
+                    "enabled": true,
+                    "config": {
+                        "httpapplicationroutingzonename": "test-dns-zone.region.aksapp.io"
+                    }
+                },
+                "omsagent": {
+                    "enabled": true,
+                    "config": {
+                        "loganalyticsworkspaceresourceid": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-region/providers/microsoft.operationalinsights/workspaces/defaultworkspace-00000000-0000-0000-0000-000000000000-region"
+                    }
+                }
+            },
+            "nodeResourceGroup": "MC_test-rg_cluster-G_region",
+            "enableRBAC": true,
+            "networkProfile": {
+                "networkPlugin": "azure",
+                "loadBalancerSku": "Basic",
+                "serviceCidr": "10.4.1.0/24",
+                "dnsServiceIP": "10.4.1.10",
+                "dockerBridgeCidr": "172.17.0.1/16"
+            },
+            "maxAgentPools": 1
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.ContainerService/managedClusters",
+        "ResourceType": "Microsoft.ContainerService/managedClusters",
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "resources": []
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-H",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-H",
+        "Location": "australiaeast",
+        "ResourceName": "cluster-H",
+        "Name": "cluster-H",
+        "Properties": {
+            "kubernetesVersion": "1.20.5",
+            "dnsPrefix": "cluster-H",
+            "fqdn": "cluster-H-00000000.nnn.region.azmk8s.io",
+            "agentPoolProfiles": [
+                {
+                    "name": "agentpool",
+                    "count": 3,
+                    "vmSize": "Standard_F2s_v2",
+                    "osDiskSizeGB": 30,
+                    "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
+                    "maxPods": 30,
+                    "type": "VirtualMachineScaleSets",
+                    "orchestratorVersion": "1.20.5",
+                    "osType": "Linux",
+                    "enableAutoScaling": false,
+                    "availabilityZones": []
+                }
+            ],
+            "servicePrincipalProfile": {
+                "clientId": "00000000-0000-0000-0000-000000000000"
+            },
+            "addonProfiles": {
+                "aciconnectorlinux": {
+                    "enabled": true,
+                    "config": {
+                        "subnetname": "subnet-A"
+                    }
+                },
+                "httpapplicationrouting": {
+                    "enabled": true,
+                    "config": {
+                        "httpapplicationroutingzonename": "test-dns-zone.region.aksapp.io"
+                    }
+                },
+                "omsagent": {
+                    "enabled": true,
+                    "config": {
+                        "loganalyticsworkspaceresourceid": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-region/providers/microsoft.operationalinsights/workspaces/defaultworkspace-00000000-0000-0000-0000-000000000000-region"
+                    }
+                }
+            },
+            "nodeResourceGroup": "MC_test-rg_cluster-H_region",
+            "enableRBAC": true,
+            "networkProfile": {
+                "networkPlugin": "azure",
+                "loadBalancerSku": "Basic",
+                "serviceCidr": "10.4.1.0/24",
+                "dnsServiceIP": "10.4.1.10",
+                "dockerBridgeCidr": "172.17.0.1/16"
+            },
+            "maxAgentPools": 1
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.ContainerService/managedClusters",
+        "ResourceType": "Microsoft.ContainerService/managedClusters",
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "resources": []
     }
 ]

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -912,5 +912,137 @@
         "Tags": null,
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
         "resources": []
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-I",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-I",
+        "Location": "australiasoutheast",
+        "ResourceName": "cluster-I",
+        "Name": "cluster-I",
+        "Properties": {
+            "kubernetesVersion": "1.20.5",
+            "dnsPrefix": "cluster-I",
+            "fqdn": "cluster-I-00000000.nnn.region.azmk8s.io",
+            "agentPoolProfiles": [
+                {
+                    "name": "agentpool",
+                    "count": 3,
+                    "vmSize": "Standard_F2s_v2",
+                    "osDiskSizeGB": 30,
+                    "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
+                    "maxPods": 30,
+                    "type": "VirtualMachineScaleSets",
+                    "orchestratorVersion": "1.20.5",
+                    "osType": "Linux",
+                    "enableAutoScaling": false,
+                    "availabilityZones": null
+                }
+            ],
+            "servicePrincipalProfile": {
+                "clientId": "00000000-0000-0000-0000-000000000000"
+            },
+            "addonProfiles": {
+                "aciconnectorlinux": {
+                    "enabled": true,
+                    "config": {
+                        "subnetname": "subnet-A"
+                    }
+                },
+                "httpapplicationrouting": {
+                    "enabled": true,
+                    "config": {
+                        "httpapplicationroutingzonename": "test-dns-zone.region.aksapp.io"
+                    }
+                },
+                "omsagent": {
+                    "enabled": true,
+                    "config": {
+                        "loganalyticsworkspaceresourceid": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-region/providers/microsoft.operationalinsights/workspaces/defaultworkspace-00000000-0000-0000-0000-000000000000-region"
+                    }
+                }
+            },
+            "nodeResourceGroup": "MC_test-rg_cluster-I_region",
+            "enableRBAC": true,
+            "networkProfile": {
+                "networkPlugin": "azure",
+                "loadBalancerSku": "Basic",
+                "serviceCidr": "10.4.1.0/24",
+                "dnsServiceIP": "10.4.1.10",
+                "dockerBridgeCidr": "172.17.0.1/16"
+            },
+            "maxAgentPools": 1
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.ContainerService/managedClusters",
+        "ResourceType": "Microsoft.ContainerService/managedClusters",
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "resources": []
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-J",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-J",
+        "Location": "norwayeast",
+        "ResourceName": "cluster-J",
+        "Name": "cluster-J",
+        "Properties": {
+            "kubernetesVersion": "1.20.5",
+            "dnsPrefix": "cluster-J",
+            "fqdn": "cluster-J-00000000.nnn.region.azmk8s.io",
+            "agentPoolProfiles": [
+                {
+                    "name": "agentpool",
+                    "count": 3,
+                    "vmSize": "Standard_F2s_v2",
+                    "osDiskSizeGB": 30,
+                    "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
+                    "maxPods": 30,
+                    "type": "VirtualMachineScaleSets",
+                    "orchestratorVersion": "1.20.5",
+                    "osType": "Linux",
+                    "enableAutoScaling": false,
+                    "availabilityZones": null
+                }
+            ],
+            "servicePrincipalProfile": {
+                "clientId": "00000000-0000-0000-0000-000000000000"
+            },
+            "addonProfiles": {
+                "aciconnectorlinux": {
+                    "enabled": true,
+                    "config": {
+                        "subnetname": "subnet-A"
+                    }
+                },
+                "httpapplicationrouting": {
+                    "enabled": true,
+                    "config": {
+                        "httpapplicationroutingzonename": "test-dns-zone.region.aksapp.io"
+                    }
+                },
+                "omsagent": {
+                    "enabled": true,
+                    "config": {
+                        "loganalyticsworkspaceresourceid": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-region/providers/microsoft.operationalinsights/workspaces/defaultworkspace-00000000-0000-0000-0000-000000000000-region"
+                    }
+                }
+            },
+            "nodeResourceGroup": "MC_test-rg_cluster-J_region",
+            "enableRBAC": true,
+            "networkProfile": {
+                "networkPlugin": "azure",
+                "loadBalancerSku": "Basic",
+                "serviceCidr": "10.4.1.0/24",
+                "dnsServiceIP": "10.4.1.10",
+                "dockerBridgeCidr": "172.17.0.1/16"
+            },
+            "maxAgentPools": 1
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.ContainerService/managedClusters",
+        "ResourceType": "Microsoft.ContainerService/managedClusters",
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "resources": []
     }
 ]

--- a/tests/PSRule.Rules.Azure.Tests/ps-rule-options.yaml
+++ b/tests/PSRule.Rules.Azure.Tests/ps-rule-options.yaml
@@ -13,3 +13,14 @@ configuration:
       env: 'prod'
     properties:
       provisioningState: 'Succeeded'
+  AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST:
+  - location: 'Australia Southeast'
+    zones:
+      - "1"
+      - "2"
+      - "3"
+  - location: 'Norway East'
+    zones:
+      - "1"
+      - "2"
+      - "3"


### PR DESCRIPTION
## PR Summary

Fix #880

Added a `Azure.AKS.AvailabilityZone` option for the following types:

- Microsoft.ContainerService/managedClusters

Added the zone mappings from https://docs.microsoft.com/en-us/rest/api/resources/providers/list to `providers.json` with the regions that support availability zones. Rule configures extra zones with the `AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST` configuration option

Also did a bit of refactoring and made a `ResourceProviderHelper` class to share those common methods to read the `providers.json` file. Let me know if you'd like this to be different. I didn't want to copy the methods over to the `Helper` class since it seems like these methods could be reused a lot if interacting with `provders.json` data. 

Also added some tests but can add more to avoid regression in the future. There is a couple of edge cases where the zones passed in from the custom configuration could be incorrect, but didn't know how this should be handled. I can probably add a check to make sure valid zones are being passed in.

Let me know what you think of this so far 🙂 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] Change is not breaking
- [ ] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
