### PR TITLE
Upgraded to Pester v5.3.0

### DIFF
--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -153,10 +153,10 @@ task NuGet {
 
 # Synopsis: Install Pester module
 task Pester NuGet, {
-    if ($Null -eq (Get-InstalledModule -Name Pester -RequiredVersion 5.2.2 -ErrorAction Ignore)) {
-        Install-Module -Name Pester -RequiredVersion 5.2.2 -Scope CurrentUser -Force -SkipPublisherCheck;
+    if ($Null -eq (Get-InstalledModule -Name Pester -RequiredVersion 5.3.0 -ErrorAction Ignore)) {
+        Install-Module -Name Pester -RequiredVersion 5.3.0 -Scope CurrentUser -Force -SkipPublisherCheck;
     }
-    Import-Module -Name Pester -RequiredVersion 5.2.2 -Verbose:$False;
+    Import-Module -Name Pester -RequiredVersion 5.3.0 -Verbose:$False;
 }
 
 # Synopsis: Install PSScriptAnalyzer module


### PR DESCRIPTION
## PR Summary

Upgraded to latest Pester 5.3.0 version which is stable.

https://github.com/pester/Pester/releases/tag/5.3.0

Had to make some tweaks to module scoping in `Cmdlet.Common.Tests.ps1` but other than that quite a straightforward upgrade. The benefit of upgrading is now CI errors are red in the build log, and has a bunch of handy new features in that release I added 😄 . 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [ ] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [x] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
