### PR TITLE
Pre-release v1.8.0-B2109020

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,12 +7,14 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.8.0-B2109020 (pre-release)
+
 What's changed since pre-release v1.8.0-B2108026:
 
 - New rules:
   - Azure Kubernetes Service:
-    - Check clusters have control plane audit logs enabled. [#882](https://github.com/Azure/PSRule.Rules.Azure/issues/882)
-    - Check clusters have control plane diagnostics enabled. [#922](https://github.com/Azure/PSRule.Rules.Azure/issues/922)
+    - Check clusters have control plane audit logs enabled. Thanks [@ArmaanMcleod](https://github.com/ArmaanMcleod). [#882](https://github.com/Azure/PSRule.Rules.Azure/issues/882)
+    - Check clusters have control plane diagnostics enabled. Thanks [@ArmaanMcleod](https://github.com/ArmaanMcleod). [#922](https://github.com/Azure/PSRule.Rules.Azure/issues/922)
 - Engineering:
   - Bump PSRule dependency to v1.7.0. [#938](https://github.com/Azure/PSRule.Rules.Azure/issues/938)
 


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.8.0-B2108026:

- New rules:
  - Azure Kubernetes Service:
    - Check clusters have control plane audit logs enabled. Thanks [@ArmaanMcleod](https://github.com/ArmaanMcleod). #882
    - Check clusters have control plane diagnostics enabled. Thanks [@ArmaanMcleod](https://github.com/ArmaanMcleod). #922
- Engineering:
  - Bump PSRule dependency to v1.7.0. #938

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
