### PR TITLE
Fixes app service plan rules #946 #945 #944 #932

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,17 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since pre-release v1.8.0-B2109020:
+
+- New rules:
+  - Application Gateways:
+    - Check App Gateways should use availability zones when available. Thanks [@ArmaanMcleod](https://github.com/ArmaanMcleod). [#928](https://github.com/Azure/PSRule.Rules.Azure/issues/928)
+- Bug fixes:
+  - Fixed plan instance count is not applicable to Elastic Premium plans. [#946](https://github.com/Azure/PSRule.Rules.Azure/issues/946)
+  - Fixed minimum App Service Plan fails Elastic Premium plans. [#945](https://github.com/Azure/PSRule.Rules.Azure/issues/945)
+  - Fixed App Service Plan should include PremiumV3 plan. [#944](https://github.com/Azure/PSRule.Rules.Azure/issues/944)
+  - Fixed Azure.VM.NICAttached with private endpoints. [#932](https://github.com/Azure/PSRule.Rules.Azure/issues/932)
+
 ## v1.8.0-B2109020 (pre-release)
 
 What's changed since pre-release v1.8.0-B2108026:

--- a/docs/en/rules/Azure.AppService.AlwaysOn.md
+++ b/docs/en/rules/Azure.AppService.AlwaysOn.md
@@ -32,3 +32,4 @@ Consider enabling Always On for each App Services app.
 ## LINKS
 
 - [Configure an App Service app](https://docs.microsoft.com/azure/app-service/configure-common#configure-general-settings)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.web/sites#siteconfig-object)

--- a/docs/en/rules/Azure.AppService.HTTP2.md
+++ b/docs/en/rules/Azure.AppService.HTTP2.md
@@ -29,3 +29,4 @@ Consider using HTTP/2 for Azure Services apps to improve protocol efficiency.
 
 - [Configure an App Service app](https://docs.microsoft.com/azure/app-service/configure-common#configure-general-settings)
 - [Performance efficiency checklist](https://docs.microsoft.com/azure/architecture/framework/scalability/performance-efficiency)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.web/sites#siteconfig-object)

--- a/docs/en/rules/Azure.AppService.MinPlan.md
+++ b/docs/en/rules/Azure.AppService.MinPlan.md
@@ -1,13 +1,13 @@
 ---
 severity: Important
-pillar: Operational Excellence
-category: Deployment
+pillar: Performance Efficiency
+category: Capacity planning
 resource: App Service
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AppService.MinPlan/
 ms-content-id: 97b58cfa-7b7e-4630-ac13-4596defe1795
 ---
 
-# Azure.AppService.MinPlan
+# Use App Service production SKU
 
 ## SYNOPSIS
 
@@ -15,8 +15,71 @@ Use at least a Standard App Service Plan.
 
 ## DESCRIPTION
 
-Use at least a Standard App Service Plan.
+Azure App Services provide a range of different plans that can be used to scale your application.
+Each plan provides different levels of performance and features.
+
+To get you started a number of entry level plans are available.
+The `Free`, `Shared`, and `Basic` plans can be used for limited testing and development.
+However these plans are not suitable for production use.
+Production workloads are best suited to standard and premium plans with `PremiumV3` the newest plan.
+
+This rule does not apply to consumption or elastic App Services Plans used for Azure Functions.
 
 ## RECOMMENDATION
 
-Use a Standard or high plans for production services.
+Consider using a standard or premium plan for hosting apps on Azure App Service.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy App Services Plans that pass this rule:
+
+- Set `sku.tier` to a plan equal to or greater than `Standard`.
+  For example: `PremiumV3`, `PremiumV2`, `Premium`, `Standard`
+
+For example:
+
+```json
+{
+    "type": "Microsoft.Web/serverfarms",
+    "apiVersion": "2021-01-15",
+    "name": "[parameters('planName')]",
+    "location": "[parameters('location')]",
+    "sku": {
+        "name": "S1",
+        "tier": "Standard",
+        "capacity": 2
+    }
+}
+```
+
+### Configure with Bicep
+
+To deploy App Services Plans that pass this rule:
+
+- Set `sku.tier` to a plan equal to or greater than `Standard`.
+  For example: `PremiumV3`, `PremiumV2`, `Premium`, `Standard`
+
+For example:
+
+```bicep
+resource appPlan 'Microsoft.Web/serverfarms@2021-01-15' = {
+  name: planName
+  location: location
+  sku: {
+    name: 'S1'
+    tier: 'Standard'
+    capacity: 2
+  }
+}
+```
+
+## LINKS
+
+- [Choose the right resources](https://docs.microsoft.com/azure/architecture/framework/scalability/design-capacity#choose-the-right-resources)
+- [Azure App Service plan overview](https://docs.microsoft.com/azure/app-service/overview-hosting-plans)
+- [Manage an App Service plan in Azure](https://docs.microsoft.com/azure/app-service/app-service-plan-manage)
+- [Configure PremiumV3 tier for Azure App Service](https://docs.microsoft.com/azure/app-service/app-service-configure-premium-tier)
+- [App Service pricing](https://azure.microsoft.com/pricing/details/app-service/windows/)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.web/serverfarms)

--- a/docs/en/rules/Azure.AppService.MinTLS.md
+++ b/docs/en/rules/Azure.AppService.MinTLS.md
@@ -32,3 +32,4 @@ Also consider using Azure Policy to audit or enforce this configuration.
 - [Enforce TLS versions](https://docs.microsoft.com/azure/app-service/configure-ssl-bindings#enforce-tls-versions)
 - [Preparing for TLS 1.2 in Microsoft Azure](https://azure.microsoft.com/updates/azuretls12/)
 - [Insecure protocols](https://docs.microsoft.com/Azure/app-service/overview-security#insecure-protocols-http-tls-10-ftp)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.web/sites#siteconfig-object)

--- a/docs/en/rules/Azure.AppService.NETVersion.md
+++ b/docs/en/rules/Azure.AppService.NETVersion.md
@@ -24,3 +24,4 @@ Consider updating the site to use a newer .NET Framework version.
 ## LINKS
 
 - [Set .NET Framework runtime version](https://docs.microsoft.com/azure/app-service/configure-language-dotnet-framework#set-net-framework-runtime-version)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.web/sites#siteconfig-object)

--- a/docs/en/rules/Azure.AppService.PHPVersion.md
+++ b/docs/en/rules/Azure.AppService.PHPVersion.md
@@ -24,3 +24,4 @@ Consider updating the site to use a newer PHP runtime version.
 ## LINKS
 
 - [Set PHP Version](https://docs.microsoft.com/azure/app-service/configure-language-php?pivots=platform-linux#set-php-version)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.web/sites#siteconfig-object)

--- a/docs/en/rules/Azure.AppService.PlanInstanceCount.md
+++ b/docs/en/rules/Azure.AppService.PlanInstanceCount.md
@@ -1,26 +1,77 @@
 ---
 severity: Important
 pillar: Reliability
-category: Load balancing and failover
+category: Resiliency and dependencies
 resource: App Service
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AppService.PlanInstanceCount/
 ms-content-id: 6f3eff05-1bd0-4c82-a5a5-573fc8e0beda
 ---
 
-# Azure.AppService.PlanInstanceCount
+# Use two or more App Service Plan instances
 
 ## SYNOPSIS
 
-Use an App Service Plan with at least two (2) instances.
+App Service Plan should use a minimum number of instances for failover.
 
 ## DESCRIPTION
 
-Use an App Service Plan with at least two (2) instances.
+App Services Plans provides a configurable number of instances that will run apps.
+When a single instance is configured your app may be temporarily unavailable during unplanned interruptions.
+In most circumstances, Azure will self heal faulty app service instances automatically.
+However during this time there may interruptions to your workload.
+
+This rule does not apply to consumption or elastic App Services Plans.
 
 ## RECOMMENDATION
 
-Use an App Service Plan with at least two (2) instances.
+Consider using an App Service Plan with at least two (2) instances.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy App Services Plans that pass this rule:
+
+- Set `sku.capacity` to `2` or more.
+
+For example:
+
+```json
+{
+    "type": "Microsoft.Web/serverfarms",
+    "apiVersion": "2021-01-15",
+    "name": "[parameters('planName')]",
+    "location": "[parameters('location')]",
+    "sku": {
+        "name": "S1",
+        "tier": "Standard",
+        "capacity": 2
+    }
+}
+```
+
+### Configure with Bicep
+
+To deploy App Services Plans that pass this rule:
+
+- Set `sku.capacity` to `2` or more.
+
+For example:
+
+```bicep
+resource appPlan 'Microsoft.Web/serverfarms@2021-01-15' = {
+  name: planName
+  location: location
+  sku: {
+    name: 'S1'
+    tier: 'Standard'
+    capacity: 2
+  }
+}
+```
 
 ## LINKS
 
 - [Resiliency and dependencies](https://docs.microsoft.com/azure/architecture/framework/resiliency/design-resiliency)
+- [Get started with Autoscale in Azure](https://docs.microsoft.com/azure/azure-monitor/autoscale/autoscale-get-started)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.web/serverfarms)

--- a/docs/en/rules/Azure.VM.NICAttached.md
+++ b/docs/en/rules/Azure.VM.NICAttached.md
@@ -14,10 +14,20 @@ Network interfaces (NICs) should be attached.
 
 ## DESCRIPTION
 
-NICs are deployed as resources separate from virtual machines.
-NICs that are not attached to a virtual machine perform no purpose.
+Network interfaces (NICs) are used to attach services to a virtual network.
+Each NIC is deployed as a separate resource, however are intended to be used with a related service.
+A NIC that is not attached to a related service perform no purpose.
+
+Example of services that use NICs include:
+
+- Virtual Machines
+- Private Endpoints
 
 ## RECOMMENDATION
 
 Consider cleaning up NICs that are not required to reduce management complexity.
 Also consider using Resource Groups to help manage the lifecycle of related resources together.
+
+## LINKS
+
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.network/networkinterfaces)

--- a/docs/en/rules/module.md
+++ b/docs/en/rules/module.md
@@ -42,7 +42,6 @@ Name | Synopsis | Severity
 [Azure.AppConfig.SKU](Azure.AppConfig.SKU.md) | App Configuration should use a minimum size of Standard. | Important
 [Azure.AppGw.MinSku](Azure.AppGw.MinSku.md) | Application Gateway should use a minimum instance size of Medium. | Important
 [Azure.AppInsights.Workspace](Azure.AppInsights.Workspace.md) | Configure Application Insights resources to store data in workspaces. | Important
-[Azure.AppService.MinPlan](Azure.AppService.MinPlan.md) | Use at least a Standard App Service Plan. | Important
 [Azure.AppService.NETVersion](Azure.AppService.NETVersion.md) | Configure applications to use newer .NET Framework versions. | Important
 [Azure.AppService.PHPVersion](Azure.AppService.PHPVersion.md) | Configure applications to use newer PHP runtime versions. | Important
 [Azure.DataFactory.Version](Azure.DataFactory.Version.md) | Consider migrating to DataFactory v2. | Awareness
@@ -167,6 +166,7 @@ Name | Synopsis | Severity
 [Azure.AKS.NodeMinPods](Azure.AKS.NodeMinPods.md) | Azure Kubernetes Cluster (AKS) nodes should use a minimum number of pods. | Important
 [Azure.AKS.PoolScaleSet](Azure.AKS.PoolScaleSet.md) | Deploy AKS clusters with nodes pools based on VM scale sets. | Important
 [Azure.AKS.StandardLB](Azure.AKS.StandardLB.md) | Azure Kubernetes Clusters (AKS) should use a Standard load balancer SKU. | Important
+[Azure.AppService.MinPlan](Azure.AppService.MinPlan.md) | Use at least a Standard App Service Plan. | Important
 [Azure.Redis.MaxMemoryReserved](Azure.Redis.MaxMemoryReserved.md) | Configure maxmemory-reserved to reserve memory for non-cache operations. | Important
 [Azure.Redis.MinSKU](Azure.Redis.MinSKU.md) | Use Azure Cache for Redis instances of at least Standard C1. | Important
 [Azure.Search.SKU](Azure.Search.SKU.md) | Use the basic and standard tiers for entry level workloads. | Critical
@@ -225,7 +225,6 @@ Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.AKS.MinNodeCount](Azure.AKS.MinNodeCount.md) | AKS clusters should have minimum number of nodes for failover and updates. | Important
 [Azure.AppGw.MinInstance](Azure.AppGw.MinInstance.md) | Application Gateways should use a minimum of two instances. | Important
-[Azure.AppService.PlanInstanceCount](Azure.AppService.PlanInstanceCount.md) | Use an App Service Plan with at least two (2) instances. | Important
 [Azure.FrontDoor.Probe](Azure.FrontDoor.Probe.md) | Configure and enable health probes for each backend pool. | Important
 [Azure.FrontDoor.ProbeMethod](Azure.FrontDoor.ProbeMethod.md) | Configure health probes to use HEAD instead of GET requests. | Important
 [Azure.FrontDoor.ProbePath](Azure.FrontDoor.ProbePath.md) | Configure a dedicated path for health probe requests. | Important
@@ -233,6 +232,12 @@ Name | Synopsis | Severity
 [Azure.TrafficManager.Endpoints](Azure.TrafficManager.Endpoints.md) | Traffic Manager should use at lest two enabled endpoints. | Important
 [Azure.VM.ASMinMembers](Azure.VM.ASMinMembers.md) | Availability sets should be deployed with at least two members. | Important
 [Azure.VNG.VPNActiveActive](Azure.VNG.VPNActiveActive.md) | Use VPN gateways configured to operate in an Active-Active configuration to reduce connectivity downtime. | Important
+
+### Resiliency and dependencies
+
+Name | Synopsis | Severity
+---- | -------- | --------
+[Azure.AppService.PlanInstanceCount](Azure.AppService.PlanInstanceCount.md) | App Service Plan should use a minimum number of instances for failover. | Important
 
 ### Resource deployment
 

--- a/docs/en/rules/resource.md
+++ b/docs/en/rules/resource.md
@@ -66,7 +66,7 @@ Name | Synopsis | Severity
 [Azure.AppService.MinTLS](Azure.AppService.MinTLS.md) | App Service should reject TLS versions older then 1.2. | Critical
 [Azure.AppService.NETVersion](Azure.AppService.NETVersion.md) | Configure applications to use newer .NET Framework versions. | Important
 [Azure.AppService.PHPVersion](Azure.AppService.PHPVersion.md) | Configure applications to use newer PHP runtime versions. | Important
-[Azure.AppService.PlanInstanceCount](Azure.AppService.PlanInstanceCount.md) | Use an App Service Plan with at least two (2) instances. | Important
+[Azure.AppService.PlanInstanceCount](Azure.AppService.PlanInstanceCount.md) | App Service Plan should use a minimum number of instances for failover. | Important
 [Azure.AppService.RemoteDebug](Azure.AppService.RemoteDebug.md) | Disable remote debugging on App Service apps when not in use. | Important
 [Azure.AppService.UseHTTPS](Azure.AppService.UseHTTPS.md) | Azure App Service apps should only accept encrypted connections. | Important
 

--- a/docs/examples-appservice.bicep
+++ b/docs/examples-appservice.bicep
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Bicep documentation examples
+
+@description('The name of the App Services Plan.')
+param planName string
+
+
+@description('The location resources will be deployed.')
+param location string = resourceGroup().location
+
+// An example App Services Plan
+resource appPlan 'Microsoft.Web/serverfarms@2021-01-15' = {
+  name: planName
+  location: location
+  sku: {
+    name: 'S1'
+    tier: 'Standard'
+    capacity: 2
+  }
+}

--- a/docs/examples-appservice.json
+++ b/docs/examples-appservice.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.613.9944",
+      "templateHash": "1932883006592877589"
+    }
+  },
+  "parameters": {
+    "planName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the App Services Plan."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location resources will be deployed."
+      }
+    }
+  },
+  "functions": [],
+  "resources": [
+    {
+      "type": "Microsoft.Web/serverfarms",
+      "apiVersion": "2021-01-15",
+      "name": "[parameters('planName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "S1",
+        "tier": "Standard",
+        "capacity": 2
+      }
+    }
+  ]
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.VM.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VM.Rule.ps1
@@ -219,9 +219,12 @@ Rule 'Azure.VM.ASName' -Type 'Microsoft.Compute/availabilitySets' -Tag @{ releas
 
 #region Network Interface
 
-# Synopsis: Network interfaces should be attached
+# Synopsis: Network interfaces (NICs) should be attached.
 Rule 'Azure.VM.NICAttached' -Type 'Microsoft.Network/networkInterfaces' -If { IsExport } -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $Assert.HasFieldValue($TargetObject, 'Properties.virtualMachine.id');
+    $Assert.AnyOf(
+        $Assert.HasFieldValue($TargetObject, 'Properties.virtualMachine.id'),
+        $Assert.HasFieldValue($TargetObject, 'Properties.privateEndpoint.id')
+    )
 }
 
 # Synopsis: Network interfaces should inherit from virtual network

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
@@ -226,6 +226,54 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             $result = Invoke-PSRule @invokeParams -InputPath $outputFile -Outcome All;
         }
 
+        It 'Azure.AppService.PlanInstanceCount' {
+            $filteredResult = $result | Where-Object {
+                $_.RuleName -eq 'Azure.AppService.PlanInstanceCount' -and
+                $_.TargetType -eq 'Microsoft.Web/serverfarms'
+            };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.TargetName | Should -BeIn 'plan-a';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'plan-b';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'plan-c';
+        }
+
+        It 'Azure.AppService.MinPlan' {
+            $filteredResult = $result | Where-Object {
+                $_.RuleName -eq 'Azure.AppService.MinPlan' -and
+                $_.TargetType -eq 'Microsoft.Web/serverfarms'
+            };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.TargetName | Should -BeIn 'plan-a';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'plan-b';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'plan-c';
+        }
+
         It 'Azure.AppService.MinTLS' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppService.MinTLS' };
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VM.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VM.Tests.ps1
@@ -6,9 +6,7 @@
 #
 
 [CmdletBinding()]
-param (
-
-)
+param ()
 
 BeforeAll {
     # Setup error handling
@@ -198,8 +196,8 @@ Describe 'Azure.VM' -Tag 'VM' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'aks-agentpool-00000000-nic-1', 'aks-agentpool-00000000-nic-2', 'aks-agentpool-00000000-nic-3';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'aks-agentpool-00000000-nic-1', 'aks-agentpool-00000000-nic-2', 'aks-agentpool-00000000-nic-3', 'pe-001';
         }
 
         It 'Azure.VM.DiskAttached' {
@@ -461,8 +459,8 @@ Describe 'Azure.VM' -Tag 'VM' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -BeIn 'nic-A', 'nic-B', 'aks-agentpool-00000000-nic-1', 'aks-agentpool-00000000-nic-2', 'aks-agentpool-00000000-nic-3';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'nic-A', 'nic-B', 'aks-agentpool-00000000-nic-1', 'aks-agentpool-00000000-nic-2', 'aks-agentpool-00000000-nic-3', 'pe-001';
         }
 
         It 'Azure.VM.Name' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AppService.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AppService.Template.json
@@ -87,7 +87,9 @@
                 "microsoftAccountOAuthScopes": null
             },
             "false": null
-        }
+        },
+        "planName2": "plan-b",
+        "planName3": "plan-c"
     },
     "resources": [
         {
@@ -218,6 +220,27 @@
             "properties": {
                 "ApplicationId": "[parameters('appName')]",
                 "Request_Source": "IbizaWebAppExtensionCreate"
+            }
+        },
+        {
+            "type": "Microsoft.Web/serverfarms",
+            "apiVersion": "2021-01-15",
+            "name": "[variables('planName2')]",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "S1",
+                "tier": "Standard",
+                "capacity": 2
+            }
+        },
+        {
+            "type": "Microsoft.Web/serverfarms",
+            "apiVersion": "2021-01-15",
+            "name": "[variables('planName3')]",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "EP1",
+                "tier": "ElasticPremium"
             }
         }
     ],

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualMachine.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualMachine.json
@@ -1481,5 +1481,117 @@
                 "SubscriptionId": null
             }
         ]
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/pe-001",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/pe-001",
+        "Identity": null,
+        "Kind": null,
+        "Location": "region",
+        "ManagedBy": null,
+        "ResourceName": "pe-001",
+        "Name": "pe-001",
+        "ExtensionResourceName": null,
+        "ParentResource": null,
+        "Plan": null,
+        "Properties": {
+            "ipConfigurations": [
+                {
+                    "name": "redisCache-redisCache.privateEndpoint",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/pe-001/ipConfigurations/redisCache-redisCache.privateEndpoint",
+                    "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+                    "properties": {
+                        "privateIPAddress": "10.0.0.4",
+                        "privateIPAllocationMethod": "Dynamic",
+                        "subnet": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/sub-pe"
+                        },
+                        "primary": true,
+                        "privateIPAddressVersion": "IPv4",
+                        "privateLinkConnectionProperties": {
+                            "groupId": "redisCache",
+                            "requiredMemberName": "redisCache",
+                            "fqdns": [
+                                "redis-001.redis.cache.windows.net"
+                            ]
+                        }
+                    }
+                }
+            ],
+            "dnsSettings": {
+                "dnsServers": [],
+                "appliedDnsServers": []
+            },
+            "macAddress": "",
+            "enableAcceleratedNetworking": false,
+            "vnetEncryptionSupported": false,
+            "enableIPForwarding": false,
+            "hostedWorkloads": [],
+            "tapConfigurations": [],
+            "privateEndpoint": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/privateEndpoints/pe-001"
+            },
+            "nicType": "Standard"
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Network/networkInterfaces",
+        "ResourceType": "Microsoft.Network/networkInterfaces",
+        "ExtensionResourceType": null,
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/privateEndpoints/pe-001",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/privateEndpoints/pe-001",
+        "Identity": null,
+        "Kind": null,
+        "Location": "region",
+        "ManagedBy": null,
+        "ResourceName": "pe-001",
+        "Name": "pe-001",
+        "ExtensionResourceName": null,
+        "ParentResource": null,
+        "Plan": null,
+        "Properties": {
+            "privateLinkServiceConnections": [
+                {
+                    "name": "pec-001",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/privateEndpoints/pe-001/privateLinkServiceConnections/pec-001",
+                    "properties": {
+                        "privateLinkServiceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Cache/Redis/redis-001",
+                        "groupIds": [
+                            "redisCache"
+                        ],
+                        "privateLinkServiceConnectionState": {
+                            "status": "Approved",
+                            "description": "Auto-Approved",
+                            "actionsRequired": "None"
+                        }
+                    },
+                    "type": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections"
+                }
+            ],
+            "manualPrivateLinkServiceConnections": [],
+            "subnet": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/sub-pe"
+            },
+            "ipConfigurations": [],
+            "networkInterfaces": [
+                {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/pe-001"
+                }
+            ],
+            "customDnsConfigs": []
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Network/privateEndpoints",
+        "ResourceType": "Microsoft.Network/privateEndpoints",
+        "ExtensionResourceType": null,
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "CreatedTime": null,
+        "ChangedTime": null
     }
 ]


### PR DESCRIPTION
## PR Summary

- Fixed plan instance count is not applicable to Elastic Premium plans. #946
- Fixed minimum App Service Plan fails Elastic Premium plans. #945
- Fixed App Service Plan should include PremiumV3 plan. #944
- Fixed Azure.VM.NICAttached with private endpoints. #932

Fixes #946
Fixes #945
Fixes #944
Fixes #932

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
