### PR TITLE
Added V2 AppGw precondition for AZ rule and refactored code to be more reusable across AZ rules

### DIFF
--- a/docs/setup/configuring-rules.md
+++ b/docs/setup/configuring-rules.md
@@ -196,12 +196,14 @@ configuration:
 This configuration option adds availability zones that are not included in the existing [providers](https://github.com/Azure/PSRule.Rules.Azure/blob/main/data/providers.json).
 
 The following providers are supported:
-- `Microsoft.Compute/virtualMachineScaleSets`
-- `Microsoft.Network/applicationGateways`
+
+* `Microsoft.Compute/virtualMachineScaleSets`
+* `Microsoft.Network/applicationGateways`
 
 The following rules and configuration options are supported:
-- `Azure.AKS.AvailabilityZone` - `AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST`
-- `Azure.AppGw.AvailabilityZone` - `AZURE_APPGW_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST`
+
+* `Azure.AKS.AvailabilityZone` - `AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST`
+* `Azure.AppGw.AvailabilityZone` - `AZURE_APPGW_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST`
 
 Syntax:
 

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -185,9 +185,9 @@ Rule 'Azure.AKS.AvailabilityZone' -Type 'Microsoft.ContainerService/managedClust
 
     $configurationZoneMappings = $Configuration.AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST;
     $providerZoneMappings = $virtualMachineScaleSetProvider.ZoneMappings;
-    $availabilityZoneMappings = PrependConfigurationZoneMappingWithProviderZoneMapping -ConfigurationAvailabilityZoneMapping $configurationZoneMappings -ProviderAvailabilityZoneMapping $providerZoneMappings;
+    $mergedAvailabilityZones = PrependConfigurationZoneWithProviderZone -ConfigurationZone $configurationZoneMappings -ProviderZone $providerZoneMappings;
 
-    $availabilityZones = GetAvailabilityZone -AvailabilityZoneMapping $availabilityZoneMappings;
+    $availabilityZones = GetAvailabilityZone -Location $TargetObject.Location -Zone $mergedAvailabilityZones;
 
     if (-not $availabilityZones) {
         return $Assert.Pass();

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -181,19 +181,11 @@ Rule 'Azure.AKS.AvailabilityZone' -Type 'Microsoft.ContainerService/managedClust
         return $Assert.Pass();
     }
 
-    $configurationZones = $Configuration.AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST;
-
     $virtualMachineScaleSetProvider = [PSRule.Rules.Azure.Runtime.Helper]::GetResourceType('Microsoft.Compute', 'virtualMachineScaleSets');
 
-    if ($configurationZones.Length -gt 0) {
-
-        # Merge configuration options and default zone mappings together
-        # We put configuration options at the beginning so they are processed first
-        $availabilityZoneMappings = @($configurationZones) + @($virtualMachineScaleSetProvider.ZoneMappings);
-    }
-    else {
-        $availabilityZoneMappings = $virtualMachineScaleSetProvider.ZoneMappings;
-    }
+    $configurationZoneMappings = $Configuration.AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST;
+    $providerZoneMappings = $virtualMachineScaleSetProvider.ZoneMappings;
+    $availabilityZoneMappings = PrependConfigurationZoneMappingWithProviderZoneMapping -ConfigurationAvailabilityZoneMapping $configurationZoneMappings -ProviderAvailabilityZoneMapping $providerZoneMappings;
 
     $availabilityZones = GetAvailabilityZone -AvailabilityZoneMapping $availabilityZoneMappings;
 

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -177,7 +177,7 @@ Rule 'Azure.AKS.CNISubnetSize' -Type 'Microsoft.ContainerService/managedClusters
 Rule 'Azure.AKS.AvailabilityZone' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; ruleSet = '2021_09'; } {
     $agentPools = @(GetAgentPoolProfiles);
 
-    if ($agentPools.Length -eq 0 -or [string]::IsNullOrEmpty($TargetObject.Location)) {
+    if ($agentPools.Length -eq 0) {
         return $Assert.Pass();
     }
 

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -189,21 +189,19 @@ Rule 'Azure.AKS.AvailabilityZone' -Type 'Microsoft.ContainerService/managedClust
 
         # Merge configuration options and default zone mappings together
         # We put configuration options at the beginning so they are processed first
-        $availabilityZones = @($configurationZones) + @($virtualMachineScaleSetProvider.ZoneMappings);
+        $availabilityZoneMappings = @($configurationZones) + @($virtualMachineScaleSetProvider.ZoneMappings);
     }
     else {
-        $availabilityZones = $virtualMachineScaleSetProvider.ZoneMappings;
+        $availabilityZoneMappings = $virtualMachineScaleSetProvider.ZoneMappings;
     }
 
-    $location = GetNormalLocation -Location $TargetObject.Location;
+    $availabilityZones = GetAvailabilityZone -AvailabilityZoneMapping $availabilityZoneMappings;
 
-    $locationAvailabilityZones = $availabilityZones | Where-Object { (GetNormalLocation -Location $_.Location) -eq $location } | Select-Object -ExpandProperty Zones -First 1;
-
-    if (-not $locationAvailabilityZones) {
+    if (-not $availabilityZones) {
         return $Assert.Pass();
     }
 
-    $joinedZoneString = $locationAvailabilityZones -join ', ';
+    $joinedZoneString = $availabilityZones -join ', ';
 
     foreach ($agentPool in $agentPools) {
 

--- a/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.ps1
@@ -82,9 +82,9 @@ Rule 'Azure.AppGw.AvailabilityZone' -Type 'Microsoft.Network/applicationGateways
 
     $configurationZoneMappings = $Configuration.AZURE_APPGW_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST;
     $providerZoneMappings = $appGatewayProvider.ZoneMappings;
-    $availabilityZoneMappings = PrependConfigurationZoneMappingWithProviderZoneMapping -ConfigurationAvailabilityZoneMapping $configurationZoneMappings -ProviderAvailabilityZoneMapping $providerZoneMappings;
+    $mergedAvailabilityZones = PrependConfigurationZoneWithProviderZone -ConfigurationZone $configurationZoneMappings -ProviderZone $providerZoneMappings;
 
-    $availabilityZones = GetAvailabilityZone -AvailabilityZoneMapping $availabilityZoneMappings;
+    $availabilityZones = GetAvailabilityZone -Location $TargetObject.Location -Zone $mergedAvailabilityZones;
 
     if (-not $availabilityZones) {
         return $Assert.Pass();

--- a/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.ps1
@@ -78,10 +78,6 @@ Rule 'Azure.AppGw.UseHTTPS' -Type 'Microsoft.Network/applicationGateways' -Tag @
 
 # Synopsis: Application gateways deployed with V2 SKU(Standard_v2, WAF_v2) should use availability zones in supported regions for high availability.
 Rule 'Azure.AppGw.AvailabilityZone' -Type 'Microsoft.Network/applicationGateways' -If { IsAppGwV2Sku } -Tag @{ release = 'GA'; ruleSet = '2021_09'; } {
-    if ([string]::IsNullOrEmpty($TargetObject.Location)) {
-        return $Assert.Pass();
-    }
-
     $configurationZones = $Configuration.AZURE_APPGW_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST;
 
     $appGatewayProvider = [PSRule.Rules.Azure.Runtime.Helper]::GetResourceType('Microsoft.Network', 'applicationGateways');

--- a/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.ps1
@@ -78,19 +78,11 @@ Rule 'Azure.AppGw.UseHTTPS' -Type 'Microsoft.Network/applicationGateways' -Tag @
 
 # Synopsis: Application gateways deployed with V2 SKU(Standard_v2, WAF_v2) should use availability zones in supported regions for high availability.
 Rule 'Azure.AppGw.AvailabilityZone' -Type 'Microsoft.Network/applicationGateways' -If { IsAppGwV2Sku } -Tag @{ release = 'GA'; ruleSet = '2021_09'; } {
-    $configurationZones = $Configuration.AZURE_APPGW_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST;
-
     $appGatewayProvider = [PSRule.Rules.Azure.Runtime.Helper]::GetResourceType('Microsoft.Network', 'applicationGateways');
 
-    if ($configurationZones.Length -gt 0) {
-
-        # Merge configuration options and default zone mappings together
-        # We put configuration options at the beginning so they are processed first
-        $availabilityZoneMappings = @($configurationZones) + @($appGatewayProvider.ZoneMappings);
-    }
-    else {
-        $availabilityZoneMappings = $appGatewayProvider.ZoneMappings;
-    }
+    $configurationZoneMappings = $Configuration.AZURE_APPGW_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST;
+    $providerZoneMappings = $appGatewayProvider.ZoneMappings;
+    $availabilityZoneMappings = PrependConfigurationZoneMappingWithProviderZoneMapping -ConfigurationAvailabilityZoneMapping $configurationZoneMappings -ProviderAvailabilityZoneMapping $providerZoneMappings;
 
     $availabilityZones = GetAvailabilityZone -AvailabilityZoneMapping $availabilityZoneMappings;
 

--- a/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.ps1
@@ -86,22 +86,20 @@ Rule 'Azure.AppGw.AvailabilityZone' -Type 'Microsoft.Network/applicationGateways
 
         # Merge configuration options and default zone mappings together
         # We put configuration options at the beginning so they are processed first
-        $availabilityZones = @($configurationZones) + @($appGatewayProvider.ZoneMappings);
+        $availabilityZoneMappings = @($configurationZones) + @($appGatewayProvider.ZoneMappings);
     }
     else {
-        $availabilityZones = $appGatewayProvider.ZoneMappings;
+        $availabilityZoneMappings = $appGatewayProvider.ZoneMappings;
     }
 
-    $location = GetNormalLocation -Location $TargetObject.Location;
+    $availabilityZones = GetAvailabilityZone -AvailabilityZoneMapping $availabilityZoneMappings;
 
-    $locationAvailabilityZones = $availabilityZones | Where-Object { (GetNormalLocation -Location $_.Location) -eq $location } | Select-Object -ExpandProperty Zones -First 1;
-
-    if (-not $locationAvailabilityZones) {
+    if (-not $availabilityZones) {
         return $Assert.Pass();
     }
 
     $Assert.HasFieldValue($TargetObject, 'zones').
-        Reason($LocalizedData.AppGWAvailabilityZone, $TargetObject.name, $location, ($locationAvailabilityZones -join ', '));
+        Reason($LocalizedData.AppGWAvailabilityZone, $TargetObject.name, $location, ($availabilityZones -join ', '));
 
 } -Configure @{ AZURE_APPGW_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST = @() }
 

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -392,3 +392,17 @@ function global:GetNormalLocation {
         return $Location.Replace(' ', '').ToLower();
     }
 }
+
+function global:GetAvailabilityZone {
+    [CmdletBinding()]
+    [OutputType([String[]])]
+    param (
+        [Parameter(Mandatory = $True)]
+        [PSObject[]]$AvailabilityZoneMapping
+    )
+    process {
+        $normalizedLocation = GetNormalLocation -Location $TargetObject.Location;
+        $availabilityZone = $AvailabilityZoneMapping | Where-Object { (GetNormalLocation -Location $_.Location) -eq $normalizedLocation } | Select-Object -ExpandProperty Zones -First 1;
+        return $availabilityZone;
+    }
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -385,6 +385,7 @@ function global:GetNormalLocation {
     [OutputType([String])]
     param (
         [Parameter(Mandatory = $True)]
+        [AllowEmptyString()]
         [String]$Location
     )
     process {

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -406,3 +406,26 @@ function global:GetAvailabilityZone {
         return $availabilityZone;
     }
 }
+
+function global:PrependConfigurationZoneMappingWithProviderZoneMapping {
+    [CmdletBinding()]
+    [OutputType([PSObject[]])]
+    param (
+        [Parameter(Mandatory = $True)]
+        [AllowEmptyCollection()]
+        [PSObject[]]$ConfigurationAvailabilityZoneMapping,
+
+        [Parameter(Mandatory = $True)]
+        [AllowEmptyCollection()]
+        [PSObject[]]$ProviderAvailabilityZoneMapping
+    )
+
+    if ($ConfigurationAvailabilityZoneMapping.Length -gt 0) {
+
+        # Prepend configuration options and provider mappings together
+        # We put configuration options at the beginning so they are processed first
+        return @($ConfigurationAvailabilityZoneMapping) + @($ProviderAvailabilityZoneMapping);
+    }
+    
+    return $ProviderAvailabilityZoneMapping;
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -398,34 +398,41 @@ function global:GetAvailabilityZone {
     [OutputType([String[]])]
     param (
         [Parameter(Mandatory = $True)]
-        [PSObject[]]$AvailabilityZoneMapping
+        [AllowEmptyString()]
+        [string]$Location,
+
+        [Parameter(Mandatory = $True)]
+        [AllowEmptyCollection()]
+        [PSObject[]]$Zone
     )
     process {
-        $normalizedLocation = GetNormalLocation -Location $TargetObject.Location;
-        $availabilityZone = $AvailabilityZoneMapping | Where-Object { (GetNormalLocation -Location $_.Location) -eq $normalizedLocation } | Select-Object -ExpandProperty Zones -First 1;
-        return $availabilityZone;
+        $normalizedLocation = GetNormalLocation -Location $Location;
+        $availabilityZones = $Zone | Where-Object { (GetNormalLocation -Location $_.Location) -eq $normalizedLocation } | Select-Object -ExpandProperty Zones -First 1;
+        return $availabilityZones;
     }
 }
 
-function global:PrependConfigurationZoneMappingWithProviderZoneMapping {
+function global:PrependConfigurationZoneWithProviderZone {
     [CmdletBinding()]
     [OutputType([PSObject[]])]
     param (
         [Parameter(Mandatory = $True)]
         [AllowEmptyCollection()]
-        [PSObject[]]$ConfigurationAvailabilityZoneMapping,
+        [PSObject[]]$ConfigurationZone,
 
         [Parameter(Mandatory = $True)]
         [AllowEmptyCollection()]
-        [PSObject[]]$ProviderAvailabilityZoneMapping
+        [PSObject[]]$ProviderZone
     )
 
-    if ($ConfigurationAvailabilityZoneMapping.Length -gt 0) {
+    process {
+        if ($ConfigurationZone.Length -gt 0) {
 
-        # Prepend configuration options and provider mappings together
-        # We put configuration options at the beginning so they are processed first
-        return @($ConfigurationAvailabilityZoneMapping) + @($ProviderAvailabilityZoneMapping);
+            # Prepend configuration options and provider mappings together
+            # We put configuration options at the beginning so they are processed first
+            return @($ConfigurationZone) + @($ProviderZone);
+        }
+        
+        return $ProviderZone;
     }
-    
-    return $ProviderAvailabilityZoneMapping;
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppGw.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppGw.Tests.ps1
@@ -194,6 +194,12 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 3;
             $ruleResult.TargetName | Should -Be 'appgw-C', 'appgw-D', 'appgw-G';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-B';
         }
     }
 
@@ -237,6 +243,12 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult | Should -HaveCount 1;
             $ruleResult.TargetName | Should -BeIn 'appgw-D';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-B';
         }
 
         It 'Azure.AppGw.AvailabilityZone - YAML file option' {
@@ -254,6 +266,12 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult | Should -HaveCount 1;
             $ruleResult.TargetName | Should -BeIn 'appgw-D';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-B';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppGw.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppGw.Tests.ps1
@@ -192,8 +192,8 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-B', 'appgw-C', 'appgw-D', 'appgw-G';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -Be 'appgw-C', 'appgw-D', 'appgw-G';
         }
     }
 
@@ -235,8 +235,8 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 3;
-            $ruleResult.TargetName | Should -BeIn 'appgw-A', 'appgw-B', 'appgw-D';
+            $ruleResult | Should -HaveCount 1;
+            $ruleResult.TargetName | Should -BeIn 'appgw-D';
         }
 
         It 'Azure.AppGw.AvailabilityZone - YAML file option' {
@@ -252,8 +252,8 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 3;
-            $ruleResult.TargetName | Should -BeIn 'appgw-A', 'appgw-B', 'appgw-D';
+            $ruleResult | Should -HaveCount 1;
+            $ruleResult.TargetName | Should -BeIn 'appgw-D';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppGw.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppGw.Tests.ps1
@@ -229,7 +229,7 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
                 )
             }
 
-            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Option $option
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Option $option -Outcome All;
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppGw.AvailabilityZone' };
 
             # Fail
@@ -243,10 +243,16 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult | Should -HaveCount 1;
             $ruleResult.TargetName | Should -BeIn 'appgw-D';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-B';
         }
 
         It 'Azure.AppGw.AvailabilityZone - YAML file option' {
-            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Option $configPath
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Option $configPath -Outcome All;
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppGw.AvailabilityZone' };
 
             # Fail
@@ -260,6 +266,12 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult | Should -HaveCount 1;
             $ruleResult.TargetName | Should -BeIn 'appgw-D';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-B';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppGw.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppGw.Tests.ps1
@@ -243,12 +243,6 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult | Should -HaveCount 1;
             $ruleResult.TargetName | Should -BeIn 'appgw-D';
-
-            # None
-            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
-            $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-B';
         }
 
         It 'Azure.AppGw.AvailabilityZone - YAML file option' {
@@ -266,12 +260,6 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult | Should -HaveCount 1;
             $ruleResult.TargetName | Should -BeIn 'appgw-D';
-
-            # None
-            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
-            $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-B';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
@@ -714,29 +714,19 @@ Describe 'PrependConfigurationZoneWithProviderZone' {
             }
         )
 
-        $result = @(
-            [PSCustomObject]@{
-                Location = "Australia Southeast"
-                Zones = @("1", "2", "3")
-            }
-            [PSCustomObject]@{
-                Location = "Australia Central"
-                Zones = @("1", "2", "3")
-            }
-            [PSCustomObject]@{
-                Location = "South Africa North"
-                Zones = @()
-            }
-            [PSCustomObject]@{
-                Location = "Central US"
-                Zones = @("1", "2", "3")
-            }
-        );
-
         $merged = PrependConfigurationZoneWithProviderZone -ConfigurationZone $configurationZones -ProviderZone $providerZones;
-        $mergedJson = $merged | ConvertTo-Json -Compress;
-        $resultJson = $result | ConvertTo-Json -Compress;
-        $mergedJson | Should -BeExactly $resultJson;
+        
+        $merged[0].Location | Should -Be "Australia Southeast"
+        $merged[0].Zones | Should -Be @("1", "2", "3")
+
+        $merged[1].Location | Should -Be "Australia Central"
+        $merged[1].Zones | Should -Be @("1", "2", "3")
+
+        $merged[2].Location | Should -Be "South Africa North"
+        $merged[2].Zones | Should -Be @()
+
+        $merged[3].Location | Should -Be "Central US"
+        $merged[3].Zones | Should -Be @("1", "2", "3")
     }
 
     It 'Given empty configuration zones and provider zones only provider zones are returned' {
@@ -753,21 +743,13 @@ Describe 'PrependConfigurationZoneWithProviderZone' {
             }
         )
 
-        $result = @(
-            [PSCustomObject]@{
-                Location = "South Africa North"
-                Zones = @()
-            }
-            [PSCustomObject]@{
-                Location = "Central US"
-                Zones = @("1", "2", "3")
-            }
-        );
-
         $merged = PrependConfigurationZoneWithProviderZone -ConfigurationZone $configurationZones -ProviderZone $providerZones;
-        $mergedJson = $merged | ConvertTo-Json -Compress;
-        $resultJson = $result | ConvertTo-Json -Compress;
-        $mergedJson | Should -BeExactly $resultJson;
+        
+        $merged[0].Location | Should -Be "South Africa North"
+        $merged[0].Zones | Should -Be @()
+
+        $merged[1].Location | Should -Be "Central US"
+        $merged[1].Zones | Should -Be @("1", "2", "3")
     }
 }
 

--- a/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
@@ -25,6 +25,9 @@ BeforeAll {
     $Null = New-Item -Path $outputPath -ItemType Directory -Force;
     $here = (Resolve-Path $PSScriptRoot).Path;
 
+    # Import Common rule functions
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1) -Force;
+
     #region Mocks
 
     function MockContext {
@@ -631,6 +634,140 @@ Describe 'VisitAKSCluster' {
                 $clusterResource.resources[0].Properties.logs | Should -BeNullOrEmpty;
             }
         }
+    }
+}
+
+#endregion
+
+#region Azure.Common.Rule.ps1 Functions
+Describe 'GetAvailabilityZone' {
+    It "Given array of zones and '<location>' it returns '<expected>'" -TestCases @(
+        @{ 
+            Zones = @(
+                [PSCustomObject]@{
+                    Location = "South Africa North"
+                    Zones = @()
+                }
+                [PSCustomObject]@{
+                    Location = "Central US"
+                    Zones = @("1", "2", "3")
+                }
+            )
+            Location = "Central US"
+            Expected = @("1", "2", "3")
+        }
+        @{ 
+            Zones = @(
+                [PSCustomObject]@{
+                    Location = "South Africa North"
+                    Zones = @()
+                }
+                [PSCustomObject]@{
+                    Location = "Central US"
+                    Zones = @("1", "2", "3")
+                }
+            )
+            Location = "South Africa North"
+            Expected = @()
+        }
+        @{ 
+            Zones = @(
+                [PSCustomObject]@{
+                    Location = "South Africa North"
+                    Zones = @()
+                }
+                [PSCustomObject]@{
+                    Location = "Central US"
+                    Zones = @("1", "2", "3")
+                }
+            )
+            Location = "Australia East"
+            Expected = $null
+        }
+    ) {
+        param($Zones, $Location, $Expected)
+        GetAvailabilityZone -Location $Location -Zone $Zones | Should -Be $Expected;
+    }
+}
+
+Describe 'PrependConfigurationZoneWithProviderZone' {
+    It 'Given non-empty configuration zones and provider zones it prepends configuration zones in front of provider zones' {
+        $configurationZones = @(
+            [PSCustomObject]@{
+                Location = "Australia Southeast"
+                Zones = @("1", "2", "3")
+            }
+            [PSCustomObject]@{
+                Location = "Australia Central"
+                Zones = @("1", "2", "3")
+            }
+        );
+        
+        $providerZones = @(
+            [PSCustomObject]@{
+                Location = "South Africa North"
+                Zones = @()
+            }
+            [PSCustomObject]@{
+                Location = "Central US"
+                Zones = @("1", "2", "3")
+            }
+        )
+
+        $result = @(
+            [PSCustomObject]@{
+                Location = "Australia Southeast"
+                Zones = @("1", "2", "3")
+            }
+            [PSCustomObject]@{
+                Location = "Australia Central"
+                Zones = @("1", "2", "3")
+            }
+            [PSCustomObject]@{
+                Location = "South Africa North"
+                Zones = @()
+            }
+            [PSCustomObject]@{
+                Location = "Central US"
+                Zones = @("1", "2", "3")
+            }
+        );
+
+        $merged = PrependConfigurationZoneWithProviderZone -ConfigurationZone $configurationZones -ProviderZone $providerZones;
+        $mergedJson = $merged | ConvertTo-Json -Compress;
+        $resultJson = $result | ConvertTo-Json -Compress;
+        $mergedJson | Should -BeExactly $resultJson;
+    }
+
+    It 'Given empty configuration zones and provider zones only provider zones are returned' {
+        $configurationZones = @();
+        
+        $providerZones = @(
+            [PSCustomObject]@{
+                Location = "South Africa North"
+                Zones = @()
+            }
+            [PSCustomObject]@{
+                Location = "Central US"
+                Zones = @("1", "2", "3")
+            }
+        )
+
+        $result = @(
+            [PSCustomObject]@{
+                Location = "South Africa North"
+                Zones = @()
+            }
+            [PSCustomObject]@{
+                Location = "Central US"
+                Zones = @("1", "2", "3")
+            }
+        );
+
+        $merged = PrependConfigurationZoneWithProviderZone -ConfigurationZone $configurationZones -ProviderZone $providerZones;
+        $mergedJson = $merged | ConvertTo-Json -Compress;
+        $resultJson = $result | ConvertTo-Json -Compress;
+        $mergedJson | Should -BeExactly $resultJson;
     }
 }
 


### PR DESCRIPTION
## PR Summary

Added precondition for `Azure.AppGw.AvailabilityZone` rule to check V2 SKU. 

Also did some tidying up of the code to make it more reusable across AZ rules:

- Refactored null or empty checks and added a `AllowEmptyString` attribute to `GetNormalLocation`.
- Wrap code where AZ is fetched into a separate `GetAvailabilityZone` function. 
- Created `PrependConfigurationZoneWithProviderZone` function to prepend configuration zones to providers.

Also fixing up markdown docs after running `mkdocs` locally. 
Adding more tests.
## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [x] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
