### PR TITLE
Pre-release v1.8.0-B2109060

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,8 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.8.0-B2109060 (pre-release)
+
 What's changed since pre-release v1.8.0-B2109046:
 
 - New features:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.8.0-B2109046:

- New features:
  - Added `Azure.GA_2021_09` baseline. #961
    - Includes rules released before or during September 2021 for Azure GA features.
    - Marked baseline `Azure.GA_2021_06` as obsolete.
- New rules:
  - Load Balancer:
    - Check Load Balancers are configured with zone-redundancy. Thanks [@ArmaanMcleod](https://github.com/ArmaanMcleod). #927

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
