### PR TITLE
Fixes Bicep unexpected end of content #889

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,13 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since pre-release v1.8.0-B2109060:
+
+- Engineering:
+  - Increased test coverage of rule reasons. Thanks [@ArmaanMcleod](https://github.com/ArmaanMcleod). [#960](https://github.com/Azure/PSRule.Rules.Azure/issues/960)
+- Bug fixes:
+  - Fixed Bicep CLI fails with unexpected end of content. [#889](https://github.com/Azure/PSRule.Rules.Azure/issues/889)
+
 ## v1.8.0-B2109060 (pre-release)
 
 What's changed since pre-release v1.8.0-B2109046:


### PR DESCRIPTION
## PR Summary

- Fixed Bicep CLI fails with unexpected end of content.
- Refactored Bicep CLI code to reduce the chance of locking and no being able to get the full output from Bicep. Fairly sure we have this fixed but since it cannot be reproduced consistently further testing is required. 

Fixes #889

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
