### PR TITLE
Fixes for storage account rules #971 #965

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -13,6 +13,8 @@ What's changed since pre-release v1.8.0-B2109060:
   - Increased test coverage of rule reasons. Thanks [@ArmaanMcleod](https://github.com/ArmaanMcleod). [#960](https://github.com/Azure/PSRule.Rules.Azure/issues/960)
 - Bug fixes:
   - Fixed Bicep CLI fails with unexpected end of content. [#889](https://github.com/Azure/PSRule.Rules.Azure/issues/889)
+  - Fixed incomplete reason message for `Azure.Storage.MinTLS`. [#971](https://github.com/Azure/PSRule.Rules.Azure/issues/971)
+  - Fixed false positive of `Azure.Storage.UseReplication` with large file storage. [#965](https://github.com/Azure/PSRule.Rules.Azure/issues/965)
 
 ## v1.8.0-B2109060 (pre-release)
 

--- a/docs/en/rules/Azure.Storage.UseReplication.md
+++ b/docs/en/rules/Azure.Storage.UseReplication.md
@@ -30,18 +30,81 @@ The following geo-replicated options are available within Azure:
 
 Consider using GRS for storage accounts that contain data.
 
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy Storage Accounts that pass this rule:
+
+- Set the `sku.name` property to a geo-replicated SKU.
+  Such as `Standard_GRS`.
+
+For example:
+
+```json
+{
+    "comments": "Storage Account",
+    "type": "Microsoft.Storage/storageAccounts",
+    "apiVersion": "2019-06-01",
+    "name": "st0000001",
+    "location": "[parameters('location')]",
+    "sku": {
+        "name": "Standard_GRS",
+        "tier": "Standard"
+    },
+    "kind": "StorageV2",
+    "properties": {
+        "supportsHttpsTrafficOnly": true,
+        "minimumTlsVersion": "TLS1_2",
+        "allowBlobPublicAccess": false,
+        "accessTier": "Hot"
+    }
+}
+```
+
+### Configure with Bicep
+
+To deploy Storage Accounts that pass this rule:
+
+- Set the `sku.name` property to a geo-replicated SKU.
+  Such as `Standard_GRS`.
+
+For example:
+
+```bicep
+resource st0000001 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+  name: 'st0000001'
+  location: location
+  sku: {
+    name: 'Standard_GRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    supportsHttpsTrafficOnly: true
+    accessTier: 'Hot'
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    networkAcls: {
+      defaultAction: 'Deny'
+    }
+  }
+}
+```
+
 ## NOTES
 
+This rule is not applicable for premium storage accounts.
 Storage Accounts with the following tags are automatically excluded from this rule:
 
 - `ms-resource-usage = 'azure-cloud-shell'` - Storage Accounts used for Cloud Shell are not intended to store data.
-This tag is applied by Azure to Cloud Shell Storage Accounts by default.
+  This tag is applied by Azure to Cloud Shell Storage Accounts by default.
 - `resource-usage = 'azure-functions'` - Storage Accounts used for Azure Functions.
-This tag can be optionally configured.
+  This tag can be optionally configured.
 - `resource-usage = 'azure-monitor'` - Storage Accounts used by Azure Monitor are intended for diagnostic logs.
-This tag can be optionally configured.
+  This tag can be optionally configured.
 
 ## LINKS
 
+- [Multiple and paired regions](https://docs.microsoft.com/azure/architecture/framework/resiliency/design-requirements)
 - [Azure Storage redundancy](https://docs.microsoft.com/azure/storage/common/storage-redundancy)
 - [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.storage/storageaccounts)

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
@@ -45,6 +45,11 @@ Describe 'Azure.Storage' -Tag Storage {
             $ruleResult.Length | Should -Be 2;
             $ruleResult.TargetName | Should -BeIn 'storage-B', 'storage-E';
 
+            $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[0].Reason | Should -BeExactly 'The field value ''Standard_LRS'' was not included in the set.';
+            $ruleResult[1].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[1].Reason | Should -BeExactly 'The field value ''Standard_LRS'' was not included in the set.';
+
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
@@ -54,8 +59,8 @@ Describe 'Azure.Storage' -Tag Storage {
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'storage-D', 'storage-C', 'storage-F';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'storage-D', 'storage-C', 'storage-F', 'storage-G';
         }
 
         It 'Azure.Storage.SecureTransfer' {
@@ -70,8 +75,8 @@ Describe 'Azure.Storage' -Tag Storage {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'storage-A', 'storage-E', 'storage-F';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'storage-A', 'storage-E', 'storage-F', 'storage-G';
         }
 
         It 'Azure.Storage.SoftDelete' {
@@ -91,8 +96,8 @@ Describe 'Azure.Storage' -Tag Storage {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'storage-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'storage-A', 'storage-G';
 
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
@@ -107,8 +112,8 @@ Describe 'Azure.Storage' -Tag Storage {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'storage-B', 'storage-C', 'storage-D', 'storage-E';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'storage-B', 'storage-C', 'storage-D', 'storage-E', 'storage-G';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -138,8 +143,8 @@ Describe 'Azure.Storage' -Tag Storage {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'storage-A', 'storage-C', 'storage-D', 'storage-E';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'storage-A', 'storage-C', 'storage-D', 'storage-E', 'storage-G';
 
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
@@ -158,19 +163,19 @@ Describe 'Azure.Storage' -Tag Storage {
             $ruleResult.TargetName | Should -BeIn 'storage-B', 'storage-C', 'storage-D', 'storage-F';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[0].Reason | Should -BeExactly "Minimum TLS version is set to TLS1_0.";
+            $ruleResult[0].Reason | Should -BeExactly "The field 'Properties.minimumTlsVersion' is set to 'TLS1_0'.";
             $ruleResult[1].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[1].Reason | Should -BeExactly "Minimum TLS version is set to {0}.";
+            $ruleResult[1].Reason | Should -BeExactly "The field 'Properties.minimumTlsVersion' does not exist.";
             $ruleResult[2].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[2].Reason | Should -BeExactly "Minimum TLS version is set to {0}.";
+            $ruleResult[2].Reason | Should -BeExactly "The field 'Properties.minimumTlsVersion' does not exist.";
             $ruleResult[3].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[3].Reason | Should -BeExactly "Minimum TLS version is set to {0}.";
+            $ruleResult[3].Reason | Should -BeExactly "The field 'Properties.minimumTlsVersion' does not exist.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'storage-A', 'storage-E';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'storage-A', 'storage-E', 'storage-G';
         }
 
         It 'Azure.Storage.Firewall' {
@@ -179,8 +184,8 @@ Describe 'Azure.Storage' -Tag Storage {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'storage-A', 'storage-B', 'storage-C', 'storage-E';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'storage-A', 'storage-B', 'storage-C', 'storage-E', 'storage-G';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Storage.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Storage.json
@@ -470,5 +470,117 @@
         "ChangedTime": null,
         "ETag": null,
         "resources": []
+    },
+    {
+        "sku": {
+            "name": "Standard_LRS",
+            "tier": "Standard"
+        },
+        "kind": "StorageV2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test-002/providers/Microsoft.Storage/storageAccounts/storage-G",
+        "name": "storage-G",
+        "type": "Microsoft.Storage/storageAccounts",
+        "location": "region",
+        "properties": {
+            "defaultToOAuthAuthentication": false,
+            "keyCreationTime": {
+                "key1": "2021-09-16T06:51:27.5840355Z",
+                "key2": "2021-09-16T06:51:27.5840355Z"
+            },
+            "allowCrossTenantReplication": true,
+            "privateEndpointConnections": [],
+            "minimumTlsVersion": "TLS1_2",
+            "allowBlobPublicAccess": true,
+            "allowSharedKeyAccess": true,
+            "largeFileSharesState": "Enabled",
+            "networkAcls": {
+                "bypass": "AzureServices",
+                "virtualNetworkRules": [],
+                "ipRules": [],
+                "defaultAction": "Allow"
+            },
+            "supportsHttpsTrafficOnly": true,
+            "encryption": {
+                "services": {
+                    "file": {
+                        "keyType": "Account",
+                        "enabled": true,
+                        "lastEnabledTime": "2021-09-16T06:51:27.5997091Z"
+                    },
+                    "blob": {
+                        "keyType": "Account",
+                        "enabled": true,
+                        "lastEnabledTime": "2021-09-16T06:51:27.5997091Z"
+                    }
+                },
+                "keySource": "Microsoft.Storage"
+            },
+            "accessTier": "Hot",
+            "provisioningState": "Succeeded",
+            "creationTime": "2021-09-16T06:51:27.4590405Z",
+            "primaryEndpoints": {
+                "dfs": "https://storage-G.dfs.core.windows.net/",
+                "web": "https://storage-G.z13.web.core.windows.net/",
+                "blob": "https://storage-G.blob.core.windows.net/",
+                "queue": "https://storage-G.queue.core.windows.net/",
+                "table": "https://storage-G.table.core.windows.net/",
+                "file": "https://storage-G.file.core.windows.net/"
+            },
+            "primaryLocation": "region",
+            "statusOfPrimary": "available"
+        },
+        "resources": [
+            {
+                "type": "Microsoft.Storage/storageAccounts/blobServices",
+                "apiVersion": "2021-04-01",
+                "name": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test-002/providers/Microsoft.Storage/storageAccounts/storage-G/blobServices/default",
+                "sku": {
+                    "name": "Standard_LRS",
+                    "tier": "Standard"
+                },
+                "properties": {
+                    "changeFeed": {
+                        "enabled": true
+                    },
+                    "restorePolicy": {
+                        "enabled": true,
+                        "days": 6
+                    },
+                    "containerDeleteRetentionPolicy": {
+                        "enabled": true,
+                        "days": 7
+                    },
+                    "cors": {
+                        "corsRules": []
+                    },
+                    "deleteRetentionPolicy": {
+                        "enabled": true,
+                        "days": 7
+                    },
+                    "isVersioningEnabled": true
+                }
+            },
+            {
+                "type": "Microsoft.Storage/storageAccounts/fileServices",
+                "apiVersion": "2021-04-01",
+                "name": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test-002/providers/Microsoft.Storage/storageAccounts/storage-G/fileServices/default",
+                "sku": {
+                    "name": "Standard_LRS",
+                    "tier": "Standard"
+                },
+                "properties": {
+                    "protocolSettings": {
+                        "smb": {}
+                    },
+                    "cors": {
+                        "corsRules": []
+                    },
+                    "shareDeleteRetentionPolicy": {
+                        "enabled": true,
+                        "days": 7
+                    }
+                }
+            }
+        ]
     }
 ]


### PR DESCRIPTION
## PR Summary

- Fixed incomplete reason message for `Azure.Storage.MinTLS`. #971
- Fixed false positive of `Azure.Storage.UseReplication` with large file storage. #965

Fixes #971 
Fixes #965 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
