### PR TITLE
Fix docs tags insertion for examples

### DIFF
--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -56,15 +56,17 @@ def replace_maml(markdown: str, page: mkdocs.structure.nav.Page, config: mkdocs.
     if page.meta.get("rule", "None") != "None":
         markdown = markdown.replace("<!-- TAGS -->", " · :octicons-file-code-24: " + page.meta['rule'] + "\r<!-- TAGS -->")
 
-    return markdown
+    return markdown.replace("<!-- TAGS -->", "")
 
 def add_tags(markdown: str) -> str:
     lines = markdown.splitlines()
     converted = []
+    foundHeader = True
     for l in lines:
         converted.append(l)
-        if l.startswith("# "):
+        if l.startswith("# ") and not foundHeader:
             converted.append("<!-- TAGS -->")
+            foundHeader = True
 
     return "\r".join(converted)
 


### PR DESCRIPTION
## PR Summary

- Fix bug in docs where `<!-- TAGS -->` is added into examples that include a line comment.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
