### PR TITLE
Use REST API to fetch zones instead of Get-AzPublicIpAddress cmdlet

### DIFF
--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -202,9 +202,6 @@ task ModuleDependencies NuGet, PSRule, {
     if ($Null -eq (Get-InstalledModule -Name Az.Resources -MinimumVersion 4.3.0 -ErrorAction Ignore)) {
         Install-Module -Name Az.Resources -Scope CurrentUser -MinimumVersion 4.3.0 -Force;
     }
-    if ($Null -eq (Get-InstalledModule -Name Az.Network -MinimumVersion 4.11.0 -ErrorAction Ignore)) {
-        Install-Module -Name Az.Network -Scope CurrentUser -MinimumVersion 4.11.0 -Force;
-    }
 }
 
 task BuildDotNet {

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psd1
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psd1
@@ -53,7 +53,7 @@ DotNetFrameworkVersion = '4.7.2'
 # Modules that must be imported into the global environment prior to importing this module
 RequiredModules = @(
     @{ ModuleName = 'PSRule'; ModuleVersion = '0.0.1' }
-    @{ ModuleName = 'Az.Accounts'; ModuleVersion = '1.5.2' }
+    @{ ModuleName = 'Az.Accounts'; ModuleVersion = '2.5.2' }
     @{ ModuleName = 'Az.Resources'; ModuleVersion = '1.4.0' }
 )
 

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psd1
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psd1
@@ -55,7 +55,6 @@ RequiredModules = @(
     @{ ModuleName = 'PSRule'; ModuleVersion = '0.0.1' }
     @{ ModuleName = 'Az.Accounts'; ModuleVersion = '1.5.2' }
     @{ ModuleName = 'Az.Resources'; ModuleVersion = '1.4.0' }
-    @{ ModuleName = 'Az.Network'; ModuleVersion = '4.11.0' }
 )
 
 # Assemblies that must be loaded prior to importing this module

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1
@@ -616,48 +616,6 @@ function GetRestToken {
     }
 }
 
-function GetAccessToken {
-    [CmdletBinding()]
-    [OutputType([String])]
-    param (
-        [Parameter(Mandatory = $True)]
-        [Microsoft.Azure.Commands.Common.Authentication.Abstractions.Core.IAzureContextContainer]$Context
-    )
-
-    process {
-        $azureRmInstanceProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile;
-        $profileClient = New-Object -TypeName Microsoft.Azure.Commands.ResourceManager.Common.RMProfileClient -ArgumentList ($azureRmInstanceProfile);
-        $token = $profileClient.AcquireAccessToken($Context.DefaultContext.Subscription.TenantId);
-        return $token.AccessToken;
-    }
-}
-
-function GetRestResourceById {
-    [CmdletBinding()]
-    [OutputType([PSObject])]
-    param (
-        [Parameter(Mandatory = $True)]
-        [string]$ResourceId,
-
-        [Parameter(Mandatory = $True)]
-        [Microsoft.Azure.Commands.Common.Authentication.Abstractions.Core.IAzureContextContainer]$Context,
-
-        [Parameter(Mandatory = $True)]
-        [string]$ApiVersion
-    )
-
-    process {
-        $resourceManagerUri = [String]::Concat('https://management.azure.com', $ResourceId, '?api-version=', $ApiVersion);
-        $authorizationHeader = @{
-            'Content-Type'  = 'application/json'
-            'Authorization' = 'Bearer ' + (GetAccessToken -Context $Context)
-        };
-        $resource = Invoke-RestMethod -Method Get -Headers $authorizationHeader -Uri $resourceManagerUri;
-
-        return $resource
-    }
-}
-
 function GetSubProvider {
     [CmdletBinding()]
     param (
@@ -963,9 +921,9 @@ function VisitPublicIP {
     )
     process {
         # Get-AzResource does not return zones, even with latest API version
-        # Had to fetch the zones using REST API and insert them into the resource
+        # Had to fetch the zones using ARM REST API and insert them into the resource
         # Logged an issue with Az PowerShell: https://github.com/Azure/azure-powershell/issues/15905
-        $publicIpAddressZones = (GetRestResourceById -ResourceId $Resource.ResourceId -Context $Context -ApiVersion '2021-02-01').zones;
+        $publicIpAddressZones = ((Invoke-AzRestMethod -Path "$($Resource.ResourceId)?api-version=2021-02-01" -Method GET).Content | ConvertFrom-Json).zones;
         $Resource | Add-Member -MemberType NoteProperty -Name zones -Value $publicIpAddressZones -PassThru;
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
@@ -647,19 +647,21 @@ Describe 'VisitPublicIP' {
                     ResourceID = '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/lb-rg/providers/Microsoft.Network/publicIPAddresses/test-ip'
                 };
 
-                Mock -CommandName 'GetRestResourceById' -MockWith {
+                Mock -CommandName 'Invoke-AzRestMethod' -MockWith {
                     return [PSCustomObject]@{
-                        Name = 'Resource1'
-                        ResourceGroupName = 'lb-rg'
-                        ResourceID = '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/lb-rg/providers/Microsoft.Network/publicIPAddresses/test-ip'
-                        Zones = @("1", "2", "3")
+                        Content = [PSCustomObject]@{
+                            Name = 'Resource1'
+                            ResourceGroupName = 'lb-rg'
+                            ResourceID = '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/lb-rg/providers/Microsoft.Network/publicIPAddresses/test-ip'
+                            Zones = @("1", "2", "3")
+                        } | ConvertTo-Json
                     }
                 };
 
                 $context = New-MockObject -Type Microsoft.Azure.Commands.Profile.Models.Core.PSAzureContext;
                 $publicIpResource = $resource | VisitPublicIP -Context $context;
 
-                Assert-MockCalled -CommandName 'GetRestResourceById' -Times 1;
+                Assert-MockCalled -CommandName 'Invoke-AzRestMethod' -Times 1;
 
                 $publicIpResource[0].Name | Should -Be 'Resource1';
                 $publicIpResource[0].ResourceGroupName | Should -Be 'lb-rg';
@@ -676,19 +678,21 @@ Describe 'VisitPublicIP' {
                     ResourceID = '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/lb-rg/providers/Microsoft.Network/publicIPAddresses/test-ip'
                 };
 
-                Mock -CommandName 'GetRestResourceById' -MockWith {
+                Mock -CommandName 'Invoke-AzRestMethod' -MockWith {
                     return [PSCustomObject]@{
-                        Name = 'Resource1'
-                        ResourceGroupName = 'lb-rg'
-                        ResourceID = '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/lb-rg/providers/Microsoft.Network/publicIPAddresses/test-ip'
-                        Zones = @()
+                        Content = [PSCustomObject]@{
+                            Name = 'Resource1'
+                            ResourceGroupName = 'lb-rg'
+                            ResourceID = '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/lb-rg/providers/Microsoft.Network/publicIPAddresses/test-ip'
+                            Zones = @()
+                        } | ConvertTo-Json
                     }
                 };
 
                 $context = New-MockObject -Type Microsoft.Azure.Commands.Profile.Models.Core.PSAzureContext;
                 $publicIpResource = $resource | VisitPublicIP -Context $context;
 
-                Assert-MockCalled -CommandName 'GetRestResourceById' -Times 1;
+                Assert-MockCalled -CommandName 'Invoke-AzRestMethod' -Times 1;
 
                 $publicIpResource[0].Name | Should -Be 'Resource1';
                 $publicIpResource[0].ResourceGroupName | Should -Be 'lb-rg';

--- a/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
@@ -647,7 +647,7 @@ Describe 'VisitPublicIP' {
                     ResourceID = '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/lb-rg/providers/Microsoft.Network/publicIPAddresses/test-ip'
                 };
 
-                Mock -CommandName 'Get-AzPublicIpAddress' -MockWith {
+                Mock -CommandName 'GetRestResourceById' -MockWith {
                     return [PSCustomObject]@{
                         Name = 'Resource1'
                         ResourceGroupName = 'lb-rg'
@@ -659,7 +659,7 @@ Describe 'VisitPublicIP' {
                 $context = New-MockObject -Type Microsoft.Azure.Commands.Profile.Models.Core.PSAzureContext;
                 $publicIpResource = $resource | VisitPublicIP -Context $context;
 
-                Assert-MockCalled -CommandName 'Get-AzPublicIpAddress' -Times 1;
+                Assert-MockCalled -CommandName 'GetRestResourceById' -Times 1;
 
                 $publicIpResource[0].Name | Should -Be 'Resource1';
                 $publicIpResource[0].ResourceGroupName | Should -Be 'lb-rg';
@@ -676,7 +676,7 @@ Describe 'VisitPublicIP' {
                     ResourceID = '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/lb-rg/providers/Microsoft.Network/publicIPAddresses/test-ip'
                 };
 
-                Mock -CommandName 'Get-AzPublicIpAddress' -MockWith {
+                Mock -CommandName 'GetRestResourceById' -MockWith {
                     return [PSCustomObject]@{
                         Name = 'Resource1'
                         ResourceGroupName = 'lb-rg'
@@ -688,7 +688,7 @@ Describe 'VisitPublicIP' {
                 $context = New-MockObject -Type Microsoft.Azure.Commands.Profile.Models.Core.PSAzureContext;
                 $publicIpResource = $resource | VisitPublicIP -Context $context;
 
-                Assert-MockCalled -CommandName 'Get-AzPublicIpAddress' -Times 1;
+                Assert-MockCalled -CommandName 'GetRestResourceById' -Times 1;
 
                 $publicIpResource[0].Name | Should -Be 'Resource1';
                 $publicIpResource[0].ResourceGroupName | Should -Be 'lb-rg';


### PR DESCRIPTION
## PR Summary

Apologise for not bringing this up in the previous PR, but I pulled out some code that I stashed that uses the Rest API to get the zones instead of the `Get-AzPublicIpAddress` cmdlet. 

Thought it was a good idea to suggest this instead since we can remove the `Az.Network` dependency and have some cmdlets available to fetch resources from API when this issue happens again. This prevents the need to bring in other Az module dependencies. 

Let me know what you think. Perfectly happy to not merge this is the current approach is fine with you 🙂. 

To me it seems better to do this given alot of resources from `Get-AzResource` have missing properties, and means we don't need to introduce new Az modules everytime and just call the API instead. 

Related: https://github.com/Azure/PSRule.Rules.Azure/pull/983

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
