### PR TITLE
Fixed ToUpper fails to convert character #986

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -17,6 +17,8 @@ What's changed since v1.8.0:
   - Improved processing of AzOps generated templates. [#799](https://github.com/Azure/PSRule.Rules.Azure/issues/799)
     - `Azure.Template.DefineParameters` is ignored for AzOps generated templates.
     - `Azure.Template.UseLocationParameter` is ignored for AzOps generated templates.
+- Bug fixes:
+  - Fixed `ToUpper` fails to convert character. [#986](https://github.com/Azure/PSRule.Rules.Azure/issues/986)
 
 ## v1.8.0
 

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -277,7 +277,7 @@ namespace PSRule.Rules.Azure.Data.Template
             else if (args[0] is JArray jArray)
                 return jArray[0];
             else if (ExpressionHelpers.TryString(args[0], out string svalue))
-                return svalue[0];
+                return new string(svalue[0], 1);
 
             return null;
         }
@@ -350,7 +350,7 @@ namespace PSRule.Rules.Azure.Data.Template
             else if (args[0] is JArray jArray)
                 return jArray[jArray.Count - 1];
             else if (ExpressionHelpers.TryString(args[0], out string svalue))
-                return svalue[svalue.Length - 1];
+                return new string(svalue[svalue.Length - 1], 1);
 
             return null;
         }
@@ -1425,6 +1425,9 @@ namespace PSRule.Rules.Azure.Data.Template
             if (CountArgs(args) != 1)
                 throw ArgumentsOutOfRange(nameof(ToLower), args);
 
+            if (args[0] is char c)
+                return new string(char.ToLower(c, Thread.CurrentThread.CurrentCulture), 1);
+
             if (!ExpressionHelpers.TryString(args[0], out string stringToChange))
                 throw new ArgumentException();
 
@@ -1435,6 +1438,9 @@ namespace PSRule.Rules.Azure.Data.Template
         {
             if (CountArgs(args) != 1)
                 throw ArgumentsOutOfRange(nameof(ToUpper), args);
+
+            if (args[0] is char c)
+                return new string(char.ToUpper(c, Thread.CurrentThread.CurrentCulture), 1);
 
             if (!ExpressionHelpers.TryString(args[0], out string stringToChange))
                 throw new ArgumentException();

--- a/tests/PSRule.Rules.Azure.Tests/ExpressionBuilderTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/ExpressionBuilderTests.cs
@@ -68,6 +68,17 @@ namespace PSRule.Rules.Azure
         }
 
         [Fact]
+        public void BuildExpression7()
+        {
+            var expression = "[toUpper(first(variables('environment')))]";
+            var context = GetContext();
+            context.Variable("environment", "Test");
+
+            var actual = Build(context, expression) as string;
+            Assert.Equal("T", actual);
+        }
+
+        [Fact]
         public void BuildExpressionWithNullProperty()
         {
             var context = GetContext();

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -174,8 +174,8 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // String
-            var actual1 = (char)Functions.First(context, new object[] { "one" });
-            Assert.Equal('o', actual1);
+            var actual1 = (string)Functions.First(context, new object[] { "one" });
+            Assert.Equal("o", actual1);
 
             // Array
             var actual2 = Functions.First(context, new object[] { new string[] { "one", "two", "three" } }) as string;
@@ -241,8 +241,8 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // String
-            var actual1 = (char)Functions.Last(context, new object[] { "one" });
-            Assert.Equal('e', actual1);
+            var actual1 = (string)Functions.Last(context, new object[] { "one" });
+            Assert.Equal("e", actual1);
 
             // Array
             var actual2 = Functions.Last(context, new object[] { new string[] { "one", "two", "three" } }) as string;
@@ -1372,10 +1372,17 @@ namespace PSRule.Rules.Azure
         {
             var context = GetContext();
 
+            // String
             var actual1 = Functions.ToLower(context, new object[] { "One Two Three" }) as string;
             var actual2 = Functions.ToLower(context, new object[] { "one two three" }) as string;
             Assert.Equal("one two three", actual1);
             Assert.Equal("one two three", actual2);
+
+            // Char
+            var actual3 = Functions.ToLower(context, new object[] { 'o' }) as string;
+            var actual4 = Functions.ToLower(context, new object[] { 'O' }) as string;
+            Assert.Equal("o", actual3);
+            Assert.Equal("o", actual4);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.ToLower(context, null));
             Assert.Throws<ExpressionArgumentException>(() => Functions.ToLower(context, new object[] { }));
@@ -1389,10 +1396,17 @@ namespace PSRule.Rules.Azure
         {
             var context = GetContext();
 
+            // String
             var actual1 = Functions.ToUpper(context, new object[] { "One Two Three" }) as string;
             var actual2 = Functions.ToUpper(context, new object[] { "ONE TWO THREE" }) as string;
             Assert.Equal("ONE TWO THREE", actual1);
             Assert.Equal("ONE TWO THREE", actual2);
+
+            // Char
+            var actual3 = Functions.ToUpper(context, new object[] { 'o' }) as string;
+            var actual4 = Functions.ToUpper(context, new object[] { 'O' }) as string;
+            Assert.Equal("O", actual3);
+            Assert.Equal("O", actual4);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.ToUpper(context, null));
             Assert.Throws<ExpressionArgumentException>(() => Functions.ToUpper(context, new object[] { }));


### PR DESCRIPTION
## PR Summary

- Fixed `ToUpper` fails to convert character.

Fixes #986

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
