### PR TITLE
Fixes issues with template rules #996 #995

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,12 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since pre-release v1.9.0-B2109027:
+
+- Bug fixes:
+  - Fixed handling of comments with template and parameter file rules. [#996](https://github.com/Azure/PSRule.Rules.Azure/issues/996)
+  - Fixed `Azure.Template.UseLocationParameter` to only apply to templates deployed as RG scope [#995](https://github.com/Azure/PSRule.Rules.Azure/issues/995)
+
 ## v1.9.0-B2109027 (pre-release)
 
 What's changed since v1.8.0:

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
@@ -373,6 +373,7 @@ Describe 'Azure.Template' -Tag 'Template' {
                 (Join-Path -Path $here -ChildPath 'Template.Bicep.1.json')
                 (Join-Path -Path $here -ChildPath 'Template.PSArm.1.json')
                 (Join-Path -Path $here -ChildPath 'Template.AzOps.1.json')
+                (Join-Path -Path $here -ChildPath 'Resources.Policy.Template.json')
             );
             $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All -Format None -Name 'Azure.Template.UseLocationParameter';
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Template.UseLocationParameter' };
@@ -397,9 +398,9 @@ Describe 'Azure.Template' -Tag 'Template' {
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
+            $ruleResult.Length | Should -Be 4;
             $targetNames = $ruleResult | ForEach-Object { $_.TargetName.Split([char[]]@('\', '/'))[-1] };
-            $targetNames | Should -BeIn 'Template.Bicep.1.json', 'Template.PSArm.1.json', 'Template.AzOps.1.json';
+            $targetNames | Should -BeIn 'Template.Bicep.1.json', 'Template.PSArm.1.json', 'Template.AzOps.1.json', 'Resources.Policy.Template.json';
         }
 
         It 'Azure.Template.ParameterMinMaxValue' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Parameters.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Parameters.json
@@ -17,8 +17,9 @@
         "subnets": {
             "value": [
                 {
+                    // Additional comments here in file
                     "name": "subnet1",
-                    "addressPrefix": "10.1.0.32/28",
+                    "addressPrefix": "10.1.0.32/28", // End of line comments
                     "securityRules": [
                         {
                             "name": "deny-rdp-inbound",

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Policy.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Policy.Template.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
     "contentVersion": "1.1.1.0",
     "metadata": {
         "name": "Policy",

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
@@ -6,8 +6,9 @@
         "description": "This template creates a hub virtual network."
     },
     "parameters": {
+        // Some additional comment here
         "vnetName": {
-            "type": "string",
+            "type": "string", // End of line comments
             "metadata": {
                 "description": "The name of the virtual network."
             }


### PR DESCRIPTION
## PR Summary

- Fixed handling of comments with template and parameter file rules. #996
- Fixed `Azure.Template.UseLocationParameter` to only apply to templates deployed as RG scope #995

Fixes #996 
Fixes #995 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
