### PR TITLE
Fixes createObject function with no params #1000

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -12,6 +12,7 @@ What's changed since pre-release v1.9.0-B2109027:
 - Bug fixes:
   - Fixed handling of comments with template and parameter file rules. [#996](https://github.com/Azure/PSRule.Rules.Azure/issues/996)
   - Fixed `Azure.Template.UseLocationParameter` to only apply to templates deployed as RG scope [#995](https://github.com/Azure/PSRule.Rules.Azure/issues/995)
+  - Fixed expand template fails with `createObject` when no parameters are specified. [#1000](https://github.com/Azure/PSRule.Rules.Azure/issues/1000)
 
 ## v1.9.0-B2109027 (pre-release)
 

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -253,7 +253,7 @@ namespace PSRule.Rules.Azure.Data.Template
         internal static object CreateObject(ITemplateContext context, object[] args)
         {
             var argCount = CountArgs(args);
-            if (argCount < 2 || argCount % 2 != 0)
+            if (argCount % 2 != 0)
                 throw ArgumentsOutOfRange(nameof(CreateObject), args);
 
             var properties = new JProperty[argCount / 2];

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -130,6 +130,7 @@ namespace PSRule.Rules.Azure
                 "arrayProp", Functions.CreateArray(context, new object[] { "a", "b", "c" }),
                 "objectProp", Functions.CreateObject(context, new object[] { "key1", "value1" }),
             }) as JObject;
+            var actual2 = Functions.CreateObject(context, new object[] { }) as JObject;
 
             Assert.Equal(1, actual1["intProp"]);
             Assert.Equal("abc", actual1["stringProp"]);
@@ -137,8 +138,8 @@ namespace PSRule.Rules.Azure
             Assert.Equal("b", actual1["arrayProp"][1]);
             Assert.Equal("value1", actual1["objectProp"]["key1"]);
 
-            Assert.Throws<ExpressionArgumentException>(() => Functions.CreateObject(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.CreateObject(context, new object[] { }));
+            Assert.NotNull(actual2);
+
             Assert.Throws<ExpressionArgumentException>(() => Functions.CreateObject(context, new object[] { "intProp", 1, "stringProp" }));
         }
 


### PR DESCRIPTION
## PR Summary

Fixed expand template fails with `createObject` when no parameters are specified.

Fixes #1000

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
