### PR TITLE
Patch v1.8 with #996 #995 #986 #1000

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,8 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since v1.8.0:
+
 - Bug fixes:
   - Fixed handling of comments with template and parameter file rules. [#996](https://github.com/Azure/PSRule.Rules.Azure/issues/996)
   - Fixed `Azure.Template.UseLocationParameter` to only apply to templates deployed as RG scope [#995](https://github.com/Azure/PSRule.Rules.Azure/issues/995)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -11,6 +11,7 @@ See [troubleshooting guide] for a workaround to this issue.
   - Fixed handling of comments with template and parameter file rules. [#996](https://github.com/Azure/PSRule.Rules.Azure/issues/996)
   - Fixed `Azure.Template.UseLocationParameter` to only apply to templates deployed as RG scope [#995](https://github.com/Azure/PSRule.Rules.Azure/issues/995)
   - Fixed expand template fails with `createObject` when no parameters are specified. [#1000](https://github.com/Azure/PSRule.Rules.Azure/issues/1000)
+  - Fixed `ToUpper` fails to convert character. [#986](https://github.com/Azure/PSRule.Rules.Azure/issues/986)
 
 ## v1.8.0
 

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,11 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+- Bug fixes:
+  - Fixed handling of comments with template and parameter file rules. [#996](https://github.com/Azure/PSRule.Rules.Azure/issues/996)
+  - Fixed `Azure.Template.UseLocationParameter` to only apply to templates deployed as RG scope [#995](https://github.com/Azure/PSRule.Rules.Azure/issues/995)
+  - Fixed expand template fails with `createObject` when no parameters are specified. [#1000](https://github.com/Azure/PSRule.Rules.Azure/issues/1000)
+
 ## v1.8.0
 
 What's changed since v1.7.0:

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -277,7 +277,7 @@ namespace PSRule.Rules.Azure.Data.Template
             else if (args[0] is JArray jArray)
                 return jArray[0];
             else if (ExpressionHelpers.TryString(args[0], out string svalue))
-                return svalue[0];
+                return new string(svalue[0], 1);
 
             return null;
         }
@@ -350,7 +350,7 @@ namespace PSRule.Rules.Azure.Data.Template
             else if (args[0] is JArray jArray)
                 return jArray[jArray.Count - 1];
             else if (ExpressionHelpers.TryString(args[0], out string svalue))
-                return svalue[svalue.Length - 1];
+                return new string(svalue[svalue.Length - 1], 1);
 
             return null;
         }
@@ -1425,6 +1425,9 @@ namespace PSRule.Rules.Azure.Data.Template
             if (CountArgs(args) != 1)
                 throw ArgumentsOutOfRange(nameof(ToLower), args);
 
+            if (args[0] is char c)
+                return new string(char.ToLower(c, Thread.CurrentThread.CurrentCulture), 1);
+
             if (!ExpressionHelpers.TryString(args[0], out string stringToChange))
                 throw new ArgumentException();
 
@@ -1435,6 +1438,9 @@ namespace PSRule.Rules.Azure.Data.Template
         {
             if (CountArgs(args) != 1)
                 throw ArgumentsOutOfRange(nameof(ToUpper), args);
+
+            if (args[0] is char c)
+                return new string(char.ToUpper(c, Thread.CurrentThread.CurrentCulture), 1);
 
             if (!ExpressionHelpers.TryString(args[0], out string stringToChange))
                 throw new ArgumentException();

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -253,7 +253,7 @@ namespace PSRule.Rules.Azure.Data.Template
         internal static object CreateObject(ITemplateContext context, object[] args)
         {
             var argCount = CountArgs(args);
-            if (argCount < 2 || argCount % 2 != 0)
+            if (argCount % 2 != 0)
                 throw ArgumentsOutOfRange(nameof(CreateObject), args);
 
             var properties = new JProperty[argCount / 2];

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
@@ -387,9 +387,9 @@ Describe 'Azure.Template' -Tag 'Template' {
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
+            $ruleResult.Length | Should -Be 2;
             $targetNames = $ruleResult | ForEach-Object { $_.TargetName.Split([char[]]@('\', '/'))[-1] };
-            $targetNames | Should -BeIn 'Resources.Policy.Template.json';
+            $targetNames | Should -BeIn 'Template.Bicep.1.json', 'Resources.Policy.Template.json';
         }
 
         It 'Azure.Template.ParameterMinMaxValue' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
@@ -362,6 +362,7 @@ Describe 'Azure.Template' -Tag 'Template' {
                 (Join-Path -Path $here -ChildPath 'Resources.TTK.Template.2.json')
                 (Join-Path -Path $here -ChildPath 'Resources.Template4.json')
                 (Join-Path -Path $here -ChildPath 'Template.Bicep.1.json')
+                (Join-Path -Path $here -ChildPath 'Resources.Policy.Template.json')
             );
             $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All -Format None -Name 'Azure.Template.UseLocationParameter';
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Template.UseLocationParameter' };
@@ -382,6 +383,13 @@ Describe 'Azure.Template' -Tag 'Template' {
             $ruleResult.Length | Should -Be 3;
             $targetNames = $ruleResult | ForEach-Object { $_.TargetName.Split([char[]]@('\', '/'))[-1] };
             $targetNames | Should -BeIn 'Resources.Template4.json', 'Resources.Empty.Template.json', 'Resources.TTK.Template.2.json';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $targetNames = $ruleResult | ForEach-Object { $_.TargetName.Split([char[]]@('\', '/'))[-1] };
+            $targetNames | Should -BeIn 'Resources.Policy.Template.json';
         }
 
         It 'Azure.Template.ParameterMinMaxValue' {

--- a/tests/PSRule.Rules.Azure.Tests/ExpressionBuilderTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/ExpressionBuilderTests.cs
@@ -68,6 +68,17 @@ namespace PSRule.Rules.Azure
         }
 
         [Fact]
+        public void BuildExpression7()
+        {
+            var expression = "[toUpper(first(variables('environment')))]";
+            var context = GetContext();
+            context.Variable("environment", "Test");
+
+            var actual = Build(context, expression) as string;
+            Assert.Equal("T", actual);
+        }
+
+        [Fact]
         public void BuildExpressionWithNullProperty()
         {
             var context = GetContext();

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -130,6 +130,7 @@ namespace PSRule.Rules.Azure
                 "arrayProp", Functions.CreateArray(context, new object[] { "a", "b", "c" }),
                 "objectProp", Functions.CreateObject(context, new object[] { "key1", "value1" }),
             }) as JObject;
+            var actual2 = Functions.CreateObject(context, new object[] { }) as JObject;
 
             Assert.Equal(1, actual1["intProp"]);
             Assert.Equal("abc", actual1["stringProp"]);
@@ -137,8 +138,8 @@ namespace PSRule.Rules.Azure
             Assert.Equal("b", actual1["arrayProp"][1]);
             Assert.Equal("value1", actual1["objectProp"]["key1"]);
 
-            Assert.Throws<ExpressionArgumentException>(() => Functions.CreateObject(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.CreateObject(context, new object[] { }));
+            Assert.NotNull(actual2);
+
             Assert.Throws<ExpressionArgumentException>(() => Functions.CreateObject(context, new object[] { "intProp", 1, "stringProp" }));
         }
 

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -175,8 +175,8 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // String
-            var actual1 = (char)Functions.First(context, new object[] { "one" });
-            Assert.Equal('o', actual1);
+            var actual1 = (string)Functions.First(context, new object[] { "one" });
+            Assert.Equal("o", actual1);
 
             // Array
             var actual2 = Functions.First(context, new object[] { new string[] { "one", "two", "three" } }) as string;
@@ -242,8 +242,8 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // String
-            var actual1 = (char)Functions.Last(context, new object[] { "one" });
-            Assert.Equal('e', actual1);
+            var actual1 = (string)Functions.Last(context, new object[] { "one" });
+            Assert.Equal("e", actual1);
 
             // Array
             var actual2 = Functions.Last(context, new object[] { new string[] { "one", "two", "three" } }) as string;
@@ -1373,10 +1373,17 @@ namespace PSRule.Rules.Azure
         {
             var context = GetContext();
 
+            // String
             var actual1 = Functions.ToLower(context, new object[] { "One Two Three" }) as string;
             var actual2 = Functions.ToLower(context, new object[] { "one two three" }) as string;
             Assert.Equal("one two three", actual1);
             Assert.Equal("one two three", actual2);
+
+            // Char
+            var actual3 = Functions.ToLower(context, new object[] { 'o' }) as string;
+            var actual4 = Functions.ToLower(context, new object[] { 'O' }) as string;
+            Assert.Equal("o", actual3);
+            Assert.Equal("o", actual4);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.ToLower(context, null));
             Assert.Throws<ExpressionArgumentException>(() => Functions.ToLower(context, new object[] { }));
@@ -1390,10 +1397,17 @@ namespace PSRule.Rules.Azure
         {
             var context = GetContext();
 
+            // String
             var actual1 = Functions.ToUpper(context, new object[] { "One Two Three" }) as string;
             var actual2 = Functions.ToUpper(context, new object[] { "ONE TWO THREE" }) as string;
             Assert.Equal("ONE TWO THREE", actual1);
             Assert.Equal("ONE TWO THREE", actual2);
+
+            // Char
+            var actual3 = Functions.ToUpper(context, new object[] { 'o' }) as string;
+            var actual4 = Functions.ToUpper(context, new object[] { 'O' }) as string;
+            Assert.Equal("O", actual3);
+            Assert.Equal("O", actual4);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.ToUpper(context, null));
             Assert.Throws<ExpressionArgumentException>(() => Functions.ToUpper(context, new object[] { }));

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Parameters.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Parameters.json
@@ -17,8 +17,9 @@
         "subnets": {
             "value": [
                 {
+                    // Additional comments here in file
                     "name": "subnet1",
-                    "addressPrefix": "10.1.0.32/28",
+                    "addressPrefix": "10.1.0.32/28", // End of line comments
                     "securityRules": [
                         {
                             "name": "deny-rdp-inbound",

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Policy.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Policy.Template.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
     "contentVersion": "1.1.1.0",
     "metadata": {
         "name": "Policy",

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
@@ -6,8 +6,9 @@
         "description": "This template creates a hub virtual network."
     },
     "parameters": {
+        // Some additional comment here
         "vnetName": {
-            "type": "string",
+            "type": "string", // End of line comments
             "metadata": {
                 "description": "The name of the virtual network."
             }


### PR DESCRIPTION
## PR Summary

This merges fixes for v1.8 from v1.9 pre-releases.

- Bug fixes:
  - Fixed handling of comments with template and parameter file rules. #996
  - Fixed `Azure.Template.UseLocationParameter` to only apply to templates deployed as RG scope #995
  - Fixed expand template fails with `createObject` when no parameters are specified. #1000
  - Fixed `ToUpper` fails to convert character. #986

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
