### PR TITLE
Fixes for template bugs #1005 #1007 (#1008)

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -14,6 +14,9 @@ What's changed since v1.8.0:
   - Fixed `Azure.Template.UseLocationParameter` to only apply to templates deployed as RG scope [#995](https://github.com/Azure/PSRule.Rules.Azure/issues/995)
   - Fixed expand template fails with `createObject` when no parameters are specified. [#1000](https://github.com/Azure/PSRule.Rules.Azure/issues/1000)
   - Fixed `ToUpper` fails to convert character. [#986](https://github.com/Azure/PSRule.Rules.Azure/issues/986)
+  - Fixes expression out of range of valid values. [#1005](https://github.com/Azure/PSRule.Rules.Azure/issues/1005)
+  - Fixes template expand fails in nested reference expansion. [#1007](https://github.com/Azure/PSRule.Rules.Azure/issues/1007)
+
 
 ## v1.8.0
 

--- a/docs/using-templates.md
+++ b/docs/using-templates.md
@@ -76,6 +76,7 @@ Automatic nesting a sub-resource requires:
 - References to Key Vault secrets are not expanded.
   A placeholder value is used instead.
 - Multi-line strings are not supported.
+- Template expressions up to a maximum of 100,000 characters are supported.
 
 ## Template links
 

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionStream.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionStream.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using PSRule.Rules.Azure.Resources;
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 
 namespace PSRule.Rules.Azure.Data.Template
 {
@@ -24,7 +26,7 @@ namespace PSRule.Rules.Azure.Data.Template
         private int _EscapeLength;
 
         // The maximum length of a template expression
-        private const int MaxLength = 24576;
+        private const int MaxLength = 100000;
 
         private const char Backslash = '\\';
         private const char Apostrophe = '\'';
@@ -46,7 +48,7 @@ namespace PSRule.Rules.Azure.Data.Template
             _EscapeLength = 0;
 
             if (_Length < 0 || _Length > MaxLength)
-                throw new ArgumentOutOfRangeException(nameof(expression));
+                throw new ArgumentOutOfRangeException(nameof(expression), string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.TemplateExpressionTooLong, expression));
 
             UpdateCurrent();
         }

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -942,6 +942,9 @@ namespace PSRule.Rules.Azure.Data.Template
                 return value;
 
             var result = EvaluteExpression<object>(context, value);
+            if (result is MockMember mock)
+                result = mock.BuildString();
+
             return result == null ? null : JToken.FromObject(result);
         }
 

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
@@ -151,7 +151,7 @@ namespace PSRule.Rules.Azure.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An error occured evaluating expression &apos;{0}&apos; line {1}. {2}.
+        ///   Looks up a localized string similar to An error occurred evaluating expression &apos;{0}&apos; line {1}. {2}.
         /// </summary>
         internal static string ExpressionEvaluateError {
             get {
@@ -300,6 +300,15 @@ namespace PSRule.Rules.Azure.Resources {
         internal static string TemplateExpandInvalid {
             get {
                 return ResourceManager.GetString("TemplateExpandInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The template expression &apos;{0}&apos; exceeded the maximum length of 100K characters..
+        /// </summary>
+        internal static string TemplateExpressionTooLong {
+            get {
+                return ResourceManager.GetString("TemplateExpressionTooLong", resourceCulture);
             }
         }
         

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
@@ -148,7 +148,7 @@
     <value>Bicep CLI can not be found. Consider installing Bicep or setting the PSRULE_AZURE_BICEP_PATH environment variable to resolve this issue.</value>
   </data>
   <data name="ExpressionEvaluateError" xml:space="preserve">
-    <value>An error occured evaluating expression '{0}' line {1}. {2}</value>
+    <value>An error occurred evaluating expression '{0}' line {1}. {2}</value>
   </data>
   <data name="ExpressionInvalid" xml:space="preserve">
     <value>Failed to parse expression. The expression may not be valid. Expression: "{0}"</value>
@@ -204,6 +204,9 @@
   </data>
   <data name="TemplateExpandInvalid" xml:space="preserve">
     <value>Unable to expand resources because the template '{0}' was not valid with parameters '{1}'. {2}</value>
+  </data>
+  <data name="TemplateExpressionTooLong" xml:space="preserve">
+    <value>The template expression '{0}' exceeded the maximum length of 100K characters.</value>
   </data>
   <data name="TemplateFileNotFound" xml:space="preserve">
     <value>Unable to find the specified template file '{0}'.</value>

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -76,6 +76,9 @@
     <None Update="Template.Parsing.6.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Template.Parsing.7.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/PSRule.Rules.Azure.Tests/Template.Parsing.7.json
+++ b/tests/PSRule.Rules.Azure.Tests/Template.Parsing.7.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "resourceName": {
+            "type": "string",
+            "defaultValue": "resource-001",
+            "metadata": {
+                "description": "The name of the resource."
+            }
+        }
+    },
+    "variables": {
+        "byo_identity": true
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-10-01",
+            "name": "addRoleAssignment",
+            "properties": {
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                    "principalId": {
+                        "value": "[if(variables('byo_identity'), reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('resourceName')))).principalId, '')]"
+                    },
+                    "user_identity_name": {
+                        "value": "[format('id-{0}', parameters('resourceName'))]"
+                    },
+                    "user_identity_rg": {
+                        "value": "[resourceGroup().name]"
+                    }
+                },
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "user_identity_name": {
+                            "type": "string"
+                        },
+                        "user_identity_rg": {
+                            "type": "string"
+                        },
+                        "principalId": {
+                            "type": "string"
+                        }
+                    },
+                    "functions": [],
+                    "variables": {
+                        "networkContributorRole": "[resourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+                        "variable1": ""
+                    },
+                    "resources": [
+                        {
+                            "type": "Microsoft.Authorization/roleAssignments",
+                            "apiVersion": "2020-04-01-preview",
+                            "name": "[guid(parameters('principalId'), variables('variable1'))]",
+                            "properties": {
+                                "roleDefinitionId": "[variables('networkContributorRole')]",
+                                "principalId": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('user_identity_rg')), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('user_identity_name')), '2018-11-30').principalId]",
+                                "principalType": "ServicePrincipal"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -182,6 +182,17 @@ namespace PSRule.Rules.Azure
             Assert.Equal("Other", actual1["properties"]["value4"].Value<string>());
         }
 
+        [Fact]
+        public void NestedDeploymentWithMock()
+        {
+            var resources = ProcessTemplate(GetSourcePath("Template.Parsing.7.json"), null);
+            Assert.NotNull(resources);
+            Assert.Single(resources);
+
+            var actual1 = resources[0];
+            Assert.Equal("Microsoft.Authorization/roleAssignments", actual1["type"].Value<string>());
+        }
+
         #region Helper methods
 
         private static string GetSourcePath(string fileName)


### PR DESCRIPTION
## PR Summary

Merge fixes from v1.9.0-B2110014 pre-release.

- Fixes expression out of range of valid values. #1005
- Fixes template expand fails in nested reference expansion. #1007

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
