### PR TITLE
Release v1.8.1

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,8 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.8.1
+
 What's changed since v1.8.0:
 
 - Bug fixes:
@@ -16,7 +18,6 @@ What's changed since v1.8.0:
   - Fixed `ToUpper` fails to convert character. [#986](https://github.com/Azure/PSRule.Rules.Azure/issues/986)
   - Fixes expression out of range of valid values. [#1005](https://github.com/Azure/PSRule.Rules.Azure/issues/1005)
   - Fixes template expand fails in nested reference expansion. [#1007](https://github.com/Azure/PSRule.Rules.Azure/issues/1007)
-
 
 ## v1.8.0
 


### PR DESCRIPTION
## PR Summary

What's changed since v1.8.0:

- Bug fixes:
  - Fixed handling of comments with template and parameter file rules. #996
  - Fixed `Azure.Template.UseLocationParameter` to only apply to templates deployed as RG scope #995
  - Fixed expand template fails with `createObject` when no parameters are specified. #1000
  - Fixed `ToUpper` fails to convert character. #986
  - Fixes expression out of range of valid values. #1005
  - Fixes template expand fails in nested reference expansion. #1007

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
