### PR TITLE
Fixes Azure.ACR.AdminUser fails when not set #1014

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,13 +7,18 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since pre-release v1.9.0-B2110014:
+
+- Bug fixes:
+  - Fixed `Azure.ACR.AdminUser` fails when `adminUserEnabled` not set. [#1014](https://github.com/Azure/PSRule.Rules.Azure/issues/1014)
+
 ## v1.9.0-B2110014 (pre-release)
 
 What's changed since pre-release v1.9.0-B2110009:
 
 - Bug fixes:
-  - Fixes expression out of range of valid values. [#1005](https://github.com/Azure/PSRule.Rules.Azure/issues/1005)
-  - Fixes template expand fails in nested reference expansion. [#1007](https://github.com/Azure/PSRule.Rules.Azure/issues/1007)
+  - Fixed expression out of range of valid values. [#1005](https://github.com/Azure/PSRule.Rules.Azure/issues/1005)
+  - Fixed template expand fails in nested reference expansion. [#1007](https://github.com/Azure/PSRule.Rules.Azure/issues/1007)
 
 ## v1.9.0-B2110009 (pre-release)
 
@@ -50,8 +55,8 @@ What's changed since v1.8.0:
   - Fixed `Azure.Template.UseLocationParameter` to only apply to templates deployed as RG scope [#995](https://github.com/Azure/PSRule.Rules.Azure/issues/995)
   - Fixed expand template fails with `createObject` when no parameters are specified. [#1000](https://github.com/Azure/PSRule.Rules.Azure/issues/1000)
   - Fixed `ToUpper` fails to convert character. [#986](https://github.com/Azure/PSRule.Rules.Azure/issues/986)
-  - Fixes expression out of range of valid values. [#1005](https://github.com/Azure/PSRule.Rules.Azure/issues/1005)
-  - Fixes template expand fails in nested reference expansion. [#1007](https://github.com/Azure/PSRule.Rules.Azure/issues/1007)
+  - Fixed expression out of range of valid values. [#1005](https://github.com/Azure/PSRule.Rules.Azure/issues/1005)
+  - Fixed template expand fails in nested reference expansion. [#1007](https://github.com/Azure/PSRule.Rules.Azure/issues/1007)
 
 ## v1.8.0
 

--- a/src/PSRule.Rules.Azure/rules/Azure.ACR.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.ACR.Rule.ps1
@@ -7,7 +7,7 @@
 
 # Synopsis: Use RBAC for delegating access to ACR instead of the registry admin user
 Rule 'Azure.ACR.AdminUser' -Type 'Microsoft.ContainerRegistry/registries' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $Assert.HasFieldValue($TargetObject, 'Properties.adminUserEnabled', $False)
+    $Assert.HasDefaultValue($TargetObject, 'Properties.adminUserEnabled', $False)
 }
 
 # Synopsis: ACR should use the Premium or Standard SKU for production deployments

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
@@ -6,9 +6,7 @@
 #
 
 [CmdletBinding()]
-param (
-
-)
+param ()
 
 BeforeAll {
     # Setup error handling

--- a/tests/PSRule.Rules.Azure.Tests/Resources.ACR.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.ACR.json
@@ -184,7 +184,6 @@
         "Name": "registry-C",
         "Properties": {
             "loginServer": "registry-C.azurecr.io",
-            "adminUserEnabled": false,
             "policies": {
                 "quarantinePolicy": {
                     "status": "enabled"


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.ACR.AdminUser` fails when `adminUserEnabled` not set.

Fixes #1014

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
