### PR TITLE
Bump PSRule dependency to v1.8.0 #1018

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -9,6 +9,8 @@ See [troubleshooting guide] for a workaround to this issue.
 
 What's changed since pre-release v1.9.0-B2110014:
 
+- Engineering:
+  - Bump PSRule dependency to v1.8.0. [#1018](https://github.com/Azure/PSRule.Rules.Azure/issues/1018)
 - Bug fixes:
   - Fixed `Azure.ACR.AdminUser` fails when `adminUserEnabled` not set. [#1014](https://github.com/Azure/PSRule.Rules.Azure/issues/1014)
 

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -119,7 +119,7 @@ task VersionModule ModuleDependencies, {
     $manifest = Test-ModuleManifest -Path $manifestPath;
     $requiredModules = $manifest.RequiredModules | ForEach-Object -Process {
         if ($_.Name -eq 'PSRule' -and $Configuration -eq 'Release') {
-            @{ ModuleName = 'PSRule'; ModuleVersion = '1.7.2' }
+            @{ ModuleName = 'PSRule'; ModuleVersion = '1.8.0' }
         }
         else {
             @{ ModuleName = $_.Name; ModuleVersion = $_.Version }
@@ -169,8 +169,8 @@ task PSScriptAnalyzer NuGet, {
 
 # Synopsis: Install PSRule
 task PSRule NuGet, {
-    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.7.2 -ErrorAction Ignore)) {
-        Install-Module -Name PSRule -Repository PSGallery -MinimumVersion 1.7.2 -Scope CurrentUser -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.8.0 -ErrorAction Ignore)) {
+        Install-Module -Name PSRule -Repository PSGallery -MinimumVersion 1.8.0 -Scope CurrentUser -Force;
     }
     if ($Null -eq (Get-InstalledModule -Name PSRule.Rules.MSFT.OSS -MinimumVersion 0.1.0 -AllowPrerelease -ErrorAction Ignore)) {
         Install-Module -Name PSRule.Rules.MSFT.OSS -Repository PSGallery -MinimumVersion 0.1.0 -AllowPrerelease -Scope CurrentUser -Force;

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -16,7 +16,7 @@ bugs:
   url: https://github.com/Azure/PSRule.Rules.Azure/issues
 
 modules:
-  PSRule: ^1.7.2
+  PSRule: ^1.8.0
 
 tasks:
   clear:


### PR DESCRIPTION
## PR Summary

- Bump PSRule dependency to v1.8.0.

Fixes #1018

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
