### PR TITLE
Pre-release v1.9.0-B2110025

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,8 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.9.0-B2110025 (pre-release)
+
 What's changed since pre-release v1.9.0-B2110014:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.9.0-B2110014:

- Engineering:
  - Bump PSRule dependency to v1.8.0. #1018
- Bug fixes:
  - Fixed `Azure.ACR.AdminUser` fails when `adminUserEnabled` not set. #1014

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
