### PR TITLE
Pre-release v1.9.0-B2110087

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,10 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.9.0-B2110087 (pre-release)
+
+What's changed since pre-release v1.9.0-B2110082:
+
 - Bug fixes:
   - Fixed Bicep convention ordering. [#1053](https://github.com/Azure/PSRule.Rules.Azure/issues/1053)
 


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.9.0-B2110082:

- Bug fixes:
  - Fixed Bicep convention ordering. #1053

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
