### PR TITLE
Release v1.9.0

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,43 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.9.0
+
+What's changed since v1.8.1:
+
+- New rules:
+  - API Management Service:
+    - Check API management services are using availability zones when available. [#1017](https://github.com/Azure/PSRule.Rules.Azure/issues/1017)
+  - Public IP Address:
+    - Check Public IP addresses are configured with zone-redundancy. [#958](https://github.com/Azure/PSRule.Rules.Azure/issues/958)
+    - Check Public IP addresses are using Standard SKU. [#979](https://github.com/Azure/PSRule.Rules.Azure/issues/979)
+  - User Assigned Managed Identity:
+    - Check identities meet naming requirements. [#1021](https://github.com/Azure/PSRule.Rules.Azure/issues/1021)
+  - Virtual Network Gateway:
+    - Check VPN/ExpressRoute gateways are configured with availability zone SKU. [#926](https://github.com/Azure/PSRule.Rules.Azure/issues/926)
+- General improvements:
+  - Improved processing of AzOps generated templates. [#799](https://github.com/Azure/PSRule.Rules.Azure/issues/799)
+    - `Azure.Template.DefineParameters` is ignored for AzOps generated templates.
+    - `Azure.Template.UseLocationParameter` is ignored for AzOps generated templates.
+  - Bicep is now installed when using PSRule GitHub Action. [#1050](https://github.com/Azure/PSRule.Rules.Azure/issues/1050)
+- Engineering:
+  - Bump PSRule dependency to v1.8.0. [#1018](https://github.com/Azure/PSRule.Rules.Azure/issues/1018)
+  - Added automated PR workflow to bump `providers.json` monthly. [#1041](https://github.com/Azure/PSRule.Rules.Azure/issues/1041)
+- Bug fixes:
+  - Fixed AKS Network Policy should accept calico. [#1046](https://github.com/Azure/PSRule.Rules.Azure/issues/1046)
+  - Fixed `Azure.ACR.AdminUser` fails when `adminUserEnabled` not set. [#1014](https://github.com/Azure/PSRule.Rules.Azure/issues/1014)
+  - Fixed `Azure.KeyVault.Logs` reports cannot index into a null array. [#1024](https://github.com/Azure/PSRule.Rules.Azure/issues/1024)
+  - Fixed template function empty returns object reference not set exception. [#1025](https://github.com/Azure/PSRule.Rules.Azure/issues/1025)
+  - Fixed delayed binding of `and` template function. [#1026](https://github.com/Azure/PSRule.Rules.Azure/issues/1026)
+  - Fixed template function array nests array with array parameters. [#1027](https://github.com/Azure/PSRule.Rules.Azure/issues/1027)
+  - Fixed property used by `Azure.ACR.MinSKU` to work more reliably with templates. [#1034](https://github.com/Azure/PSRule.Rules.Azure/issues/1034)
+  - Fixed could not determine JSON object type for MockMember using CreateObject. [#1035](https://github.com/Azure/PSRule.Rules.Azure/issues/1035)
+  - Fixed Bicep convention ordering. [#1053](https://github.com/Azure/PSRule.Rules.Azure/issues/1053)
+
+What's changed since pre-release v1.9.0-B2110087:
+
+- No additional changes.
+
 ## v1.9.0-B2110087 (pre-release)
 
 What's changed since pre-release v1.9.0-B2110082:


### PR DESCRIPTION
## PR Summary

What's changed since v1.8.1:

- New rules:
  - API Management Service:
    - Check API management services are using availability zones when available. #1017
  - Public IP Address:
    - Check Public IP addresses are configured with zone-redundancy. #958
    - Check Public IP addresses are using Standard SKU. #979
  - User Assigned Managed Identity:
    - Check identities meet naming requirements. #1021
  - Virtual Network Gateway:
    - Check VPN/ExpressRoute gateways are configured with availability zone SKU. #926
- General improvements:
  - Improved processing of AzOps generated templates. #799
    - `Azure.Template.DefineParameters` is ignored for AzOps generated templates.
    - `Azure.Template.UseLocationParameter` is ignored for AzOps generated templates.
  - Bicep is now installed when using PSRule GitHub Action. #1050
- Engineering:
  - Bump PSRule dependency to v1.8.0. #1018
  - Added automated PR workflow to bump `providers.json` monthly. #1041
- Bug fixes:
  - Fixed AKS Network Policy should accept calico. #1046
  - Fixed `Azure.ACR.AdminUser` fails when `adminUserEnabled` not set. #1014
  - Fixed `Azure.KeyVault.Logs` reports cannot index into a null array. #1024
  - Fixed template function empty returns object reference not set exception. #1025
  - Fixed delayed binding of `and` template function. #1026
  - Fixed template function array nests array with array parameters. #1027
  - Fixed property used by `Azure.ACR.MinSKU` to work more reliably with templates. #1034
  - Fixed could not determine JSON object type for MockMember using CreateObject. #1035)
  - Fixed Bicep convention ordering. #1053

What's changed since pre-release v1.9.0-B2110087:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
