### PR TITLE
Fixes policy exception date conversion #1118

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,11 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since v1.10.0:
+
+- Bug fixes:
+  - Fixed `Azure.Policy.WaiverExpiry` date conversion. [#1118](https://github.com/Azure/PSRule.Rules.Azure/issues/1118)
+
 ## v1.10.0
 
 What's changed since v1.9.1:

--- a/src/PSRule.Rules.Azure/rules/Azure.Policy.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Policy.Rule.ps1
@@ -31,10 +31,5 @@ Rule 'Azure.Policy.ExemptionDescriptors' -Type 'Microsoft.Authorization/policyEx
 
 # Synopsis: Policy exceptions must be less then 2 years.
 Rule 'Azure.Policy.WaiverExpiry' -Type 'Microsoft.Authorization/policyExemptions' -With 'Azure.PolicyExemptionWaiver' -Tag @{ release = 'GA'; ruleSet = '2021_06' } {
-    $expiresOn = $Assert.HasFieldValue($TargetObject, 'properties.expiresOn');
-    $expiresOn;
-    if ($expiresOn.Result) {
-        $days = [int]($TargetObject.Properties.expiresOn - [DateTime]::Now).TotalDays;
-        $Assert.LessOrEqual($days, '.', $Configuration.AZURE_POLICY_WAIVER_MAX_EXPIRY);
-    }
+    $Assert.LessOrEqual($TargetObject, 'properties.expiresOn', $Configuration.AZURE_POLICY_WAIVER_MAX_EXPIRY);
 } -Configure @{ AZURE_POLICY_WAIVER_MAX_EXPIRY = 366 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Policy.Parameters.2.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Policy.Parameters.2.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "template": "./Resources.Policy.Template.2.json"
+    },
+    "parameters": {
+        "exemptionNameSuffix": {
+            "value": "test"
+        },
+        "assignmentId": {
+            "value": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/policy-001"
+        },
+        "resourceGroup": {
+            "value": "exception-001"
+        },
+        "exemptionCategory": {
+            "value": "Waiver"
+        },
+        "description": {
+            "value": "Some requirement for the exception."
+        },
+        "displayName": {
+            "value": "Test exception 001"
+        },
+        "requestedBy": {
+            "value": "test"
+        },
+        "approvedBy": {
+            "value": "test"
+        },
+        "expiresOnDate": {
+            "value": "2023-04-28T00:00:00+10:00"
+        },
+        "policyDefinitionReferenceIds": {
+            "value": [
+                "ref-001"
+            ]
+        }
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Policy.Template.2.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Policy.Template.2.json
@@ -1,0 +1,127 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/subscriptionDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "name": "Policy Exemption",
+        "description": "Create or update an Azure Policy exemption for a Resource Group."
+    },
+    "parameters": {
+        "exemptionNameSuffix": {
+            "type": "string",
+            "metadata": {
+                "description": "This value will be added as a suffix to the exemption name.",
+                "example": ""
+            }
+        },
+        "assignmentId": {
+            "type": "string",
+            "metadata": {
+                "description": "The resource identifier to the policy assignment that will be exempt."
+            }
+        },
+        "resourceGroup": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The name of the Resource Group where the exemption will be scoped.",
+                "example": "<resource_group_name>"
+            }
+        },
+        "exemptionCategory": {
+            "type": "string",
+            "defaultValue": "Waiver",
+            "allowedValues": [
+                "Waiver",
+                "Mitigated"
+            ],
+            "metadata": {
+                "description": "The type of exemption."
+            }
+        },
+        "description": {
+            "type": "string",
+            "metadata": {
+                "description": "A description for the policy exemption.",
+                "example": "<description>"
+            }
+        },
+        "displayName": {
+            "type": "string",
+            "metadata": {
+                "description": "The display name of the policy exemption.",
+                "example": "<display_name>"
+            }
+        },
+        "requestedBy": {
+            "type": "string",
+            "metadata": {
+                "description": "The team that own the resource that the exemption is being created for.",
+                "example": "<requested_team>"
+            }
+        },
+        "approvedBy": {
+            "type": "string",
+            "metadata": {
+                "description": "The team that approved the exemption.",
+                "example": "<approval_team>"
+            }
+        },
+        "expiresOnDate": {
+            "type": "string",
+            "metadata": {
+                "description": "The expiration date and time (in UTC ISO 8601 format yyyy-MM-ddTHH:mm:ssZ) of the policy exemption.",
+                "example": "2021-04-28T00:00:00+10:00"
+            }
+        },
+        "policyDefinitionReferenceIds": {
+            "type": "array",
+            "metadata": {
+                "description": "An array of definition references that this resource is exempt from."
+            }
+        }
+    },
+    "variables": {
+        "exemptionName": "[concat(subscription().subscriptionId, '-', parameters('exemptionNameSuffix'))]"
+    },
+    "resources": [
+        {
+            "comments": "Create or update an Azure Policy exemption for a Resource Group.",
+            "name": "[variables('exemptionName')]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-10-01",
+            "subscriptionId": "[subscription().subscriptionId]",
+            "resourceGroup": "[parameters('resourceGroup')]",
+            "location": "[if(empty(parameters('resourceGroup')), deployment().location, '')]",
+            "properties": {
+                "expressionEvaluationOptions": {
+                    "scope": "outer"
+                },
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "name": "[variables('exemptionName')]",
+                            "type": "Microsoft.Authorization/policyExemptions",
+                            "apiVersion": "2020-07-01-preview",
+                            "properties": {
+                                "policyAssignmentId": "[parameters('assignmentId')]",
+                                "policyDefinitionReferenceIds": "[parameters('policyDefinitionReferenceIds')]",
+                                "exemptionCategory": "[parameters('exemptionCategory')]",
+                                "expiresOn": "[parameters('expiresOnDate')]",
+                                "displayName": "[parameters('displayName')]",
+                                "description": "[parameters('description')]",
+                                "metadata": {
+                                    "requestedBy": "[parameters('requestedBy')]",
+                                    "approvedBy": "[parameters('approvedBy')]",
+                                    "createdBy": "DevOps deployment"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.Policy.WaiverExpiry` date conversion. #1118

Fixes #1118 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
