### PR TITLE
Added AKS rules #992 #993 #1130 #1131

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,10 @@
     "[markdown]": {
         "editor.tabSize": 2
     },
+    "[arm-template]": {
+        "editor.tabSize": 4,
+        "editor.defaultFormatter": "msazurermtools.azurerm-vscode-tools"
+    },
     "files.associations": {
         "**/.azure-pipelines/*.yaml": "azure-pipelines",
         "**/.azure-pipelines/jobs/*.yaml": "azure-pipelines",

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -9,6 +9,14 @@ See [troubleshooting guide] for a workaround to this issue.
 
 What's changed since pre-release v1.11.0-B2111014:
 
+- New rules:
+  - Azure Kubernetes Service:
+    - Check clusters have the HTTP application routing add-on disabled. [#1131](https://github.com/Azure/PSRule.Rules.Azure/issues/1131)
+    - Check clusters use the Secrets Store CSI Driver add-on. [#992](https://github.com/Azure/PSRule.Rules.Azure/issues/992)
+    - Check clusters autorotation with the Secrets Store CSI Driver add-on. [#993](https://github.com/Azure/PSRule.Rules.Azure/issues/993)
+- Update rules:
+  - Azure Kubernetes Service:
+    - Promoted `Azure.AKS.AutoUpgrade` to GA rule set. [#1130](https://github.com/Azure/PSRule.Rules.Azure/issues/1130)
 - Bug fixes:
   - Fixed `Azure.Policy.WaiverExpiry` date conversion. [#1118](https://github.com/Azure/PSRule.Rules.Azure/issues/1118)
 

--- a/docs/en/baselines/Azure.All.md
+++ b/docs/en/baselines/Azure.All.md
@@ -4,7 +4,7 @@ Includes all Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.All`. This baseline includes a total of 247 rules.
+The following rules are included within `Azure.All`. This baseline includes a total of 250 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -28,6 +28,7 @@ Name | Synopsis | Severity
 [Azure.AKS.CNISubnetSize](../rules/Azure.AKS.CNISubnetSize.md) | AKS clusters using Azure CNI should use large subnets to reduce IP exhaustion issues. | Important
 [Azure.AKS.ContainerInsights](../rules/Azure.AKS.ContainerInsights.md) | Enable Container insights to monitor AKS cluster workloads. | Important
 [Azure.AKS.DNSPrefix](../rules/Azure.AKS.DNSPrefix.md) | Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements. | Awareness
+[Azure.AKS.HttpAppRouting](../rules/Azure.AKS.HttpAppRouting.md) | Disable HTTP application routing add-on in AKS clusters. | Important
 [Azure.AKS.LocalAccounts](../rules/Azure.AKS.LocalAccounts.md) | Enforce named user accounts with RBAC assigned permissions. | Important
 [Azure.AKS.ManagedAAD](../rules/Azure.AKS.ManagedAAD.md) | Use AKS-managed Azure AD to simplify authorization and improve security. | Important
 [Azure.AKS.ManagedIdentity](../rules/Azure.AKS.ManagedIdentity.md) | Configure AKS clusters to use managed identities for managing cluster infrastructure. | Important
@@ -38,6 +39,8 @@ Name | Synopsis | Severity
 [Azure.AKS.PlatformLogs](../rules/Azure.AKS.PlatformLogs.md) | AKS clusters should collect platform diagnostic logs to monitor the state of workloads. | Important
 [Azure.AKS.PoolScaleSet](../rules/Azure.AKS.PoolScaleSet.md) | Deploy AKS clusters with nodes pools based on VM scale sets. | Important
 [Azure.AKS.PoolVersion](../rules/Azure.AKS.PoolVersion.md) | AKS node pools should match Kubernetes control plane version. | Important
+[Azure.AKS.SecretStore](../rules/Azure.AKS.SecretStore.md) | Deploy AKS clusters with Secrets Store CSI Driver and store Secrets in Key Vayult. | Important
+[Azure.AKS.SecretStoreRotation](../rules/Azure.AKS.SecretStoreRotation.md) | Enable autorotation of Secrets Store CSI Driver secrets for AKS clusters. | Important
 [Azure.AKS.StandardLB](../rules/Azure.AKS.StandardLB.md) | Azure Kubernetes Clusters (AKS) should use a Standard load balancer SKU. | Important
 [Azure.AKS.UseRBAC](../rules/Azure.AKS.UseRBAC.md) | Deploy AKS cluster with role-based access control (RBAC) enabled. | Important
 [Azure.AKS.Version](../rules/Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important

--- a/docs/en/baselines/Azure.Default.md
+++ b/docs/en/baselines/Azure.Default.md
@@ -4,7 +4,7 @@ Default baseline for Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.Default`. This baseline includes a total of 242 rules.
+The following rules are included within `Azure.Default`. This baseline includes a total of 246 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -19,12 +19,14 @@ Name | Synopsis | Severity
 [Azure.AKS.AuditLogs](../rules/Azure.AKS.AuditLogs.md) | AKS clusters should collect security-based audit logs to assess and monitor the compliance status of workloads. | Important
 [Azure.AKS.AuthorizedIPs](../rules/Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
 [Azure.AKS.AutoScaling](../rules/Azure.AKS.AutoScaling.md) | Use Autoscaling to ensure AKS clusters deployed with virtual machine scale sets are running efficiently with the right number of nodes for the workloads present. | Important
+[Azure.AKS.AutoUpgrade](../rules/Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
 [Azure.AKS.AvailabilityZone](../rules/Azure.AKS.AvailabilityZone.md) | AKS clusters deployed with virtual machine scale sets should use availability zones in supported regions for high availability. | Important
 [Azure.AKS.AzurePolicyAddOn](../rules/Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
 [Azure.AKS.AzureRBAC](../rules/Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important
 [Azure.AKS.CNISubnetSize](../rules/Azure.AKS.CNISubnetSize.md) | AKS clusters using Azure CNI should use large subnets to reduce IP exhaustion issues. | Important
 [Azure.AKS.ContainerInsights](../rules/Azure.AKS.ContainerInsights.md) | Enable Container insights to monitor AKS cluster workloads. | Important
 [Azure.AKS.DNSPrefix](../rules/Azure.AKS.DNSPrefix.md) | Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements. | Awareness
+[Azure.AKS.HttpAppRouting](../rules/Azure.AKS.HttpAppRouting.md) | Disable HTTP application routing add-on in AKS clusters. | Important
 [Azure.AKS.ManagedAAD](../rules/Azure.AKS.ManagedAAD.md) | Use AKS-managed Azure AD to simplify authorization and improve security. | Important
 [Azure.AKS.ManagedIdentity](../rules/Azure.AKS.ManagedIdentity.md) | Configure AKS clusters to use managed identities for managing cluster infrastructure. | Important
 [Azure.AKS.MinNodeCount](../rules/Azure.AKS.MinNodeCount.md) | AKS clusters should have minimum number of nodes for failover and updates. | Important
@@ -34,6 +36,8 @@ Name | Synopsis | Severity
 [Azure.AKS.PlatformLogs](../rules/Azure.AKS.PlatformLogs.md) | AKS clusters should collect platform diagnostic logs to monitor the state of workloads. | Important
 [Azure.AKS.PoolScaleSet](../rules/Azure.AKS.PoolScaleSet.md) | Deploy AKS clusters with nodes pools based on VM scale sets. | Important
 [Azure.AKS.PoolVersion](../rules/Azure.AKS.PoolVersion.md) | AKS node pools should match Kubernetes control plane version. | Important
+[Azure.AKS.SecretStore](../rules/Azure.AKS.SecretStore.md) | Deploy AKS clusters with Secrets Store CSI Driver and store Secrets in Key Vayult. | Important
+[Azure.AKS.SecretStoreRotation](../rules/Azure.AKS.SecretStoreRotation.md) | Enable autorotation of Secrets Store CSI Driver secrets for AKS clusters. | Important
 [Azure.AKS.StandardLB](../rules/Azure.AKS.StandardLB.md) | Azure Kubernetes Clusters (AKS) should use a Standard load balancer SKU. | Important
 [Azure.AKS.UseRBAC](../rules/Azure.AKS.UseRBAC.md) | Deploy AKS cluster with role-based access control (RBAC) enabled. | Important
 [Azure.AKS.Version](../rules/Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important

--- a/docs/en/baselines/Azure.Preview.md
+++ b/docs/en/baselines/Azure.Preview.md
@@ -4,7 +4,7 @@ Includes Azure features in preview.
 
 ## Rules
 
-The following rules are included within `Azure.Preview`. This baseline includes a total of 247 rules.
+The following rules are included within `Azure.Preview`. This baseline includes a total of 250 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -28,6 +28,7 @@ Name | Synopsis | Severity
 [Azure.AKS.CNISubnetSize](../rules/Azure.AKS.CNISubnetSize.md) | AKS clusters using Azure CNI should use large subnets to reduce IP exhaustion issues. | Important
 [Azure.AKS.ContainerInsights](../rules/Azure.AKS.ContainerInsights.md) | Enable Container insights to monitor AKS cluster workloads. | Important
 [Azure.AKS.DNSPrefix](../rules/Azure.AKS.DNSPrefix.md) | Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements. | Awareness
+[Azure.AKS.HttpAppRouting](../rules/Azure.AKS.HttpAppRouting.md) | Disable HTTP application routing add-on in AKS clusters. | Important
 [Azure.AKS.LocalAccounts](../rules/Azure.AKS.LocalAccounts.md) | Enforce named user accounts with RBAC assigned permissions. | Important
 [Azure.AKS.ManagedAAD](../rules/Azure.AKS.ManagedAAD.md) | Use AKS-managed Azure AD to simplify authorization and improve security. | Important
 [Azure.AKS.ManagedIdentity](../rules/Azure.AKS.ManagedIdentity.md) | Configure AKS clusters to use managed identities for managing cluster infrastructure. | Important
@@ -38,6 +39,8 @@ Name | Synopsis | Severity
 [Azure.AKS.PlatformLogs](../rules/Azure.AKS.PlatformLogs.md) | AKS clusters should collect platform diagnostic logs to monitor the state of workloads. | Important
 [Azure.AKS.PoolScaleSet](../rules/Azure.AKS.PoolScaleSet.md) | Deploy AKS clusters with nodes pools based on VM scale sets. | Important
 [Azure.AKS.PoolVersion](../rules/Azure.AKS.PoolVersion.md) | AKS node pools should match Kubernetes control plane version. | Important
+[Azure.AKS.SecretStore](../rules/Azure.AKS.SecretStore.md) | Deploy AKS clusters with Secrets Store CSI Driver and store Secrets in Key Vayult. | Important
+[Azure.AKS.SecretStoreRotation](../rules/Azure.AKS.SecretStoreRotation.md) | Enable autorotation of Secrets Store CSI Driver secrets for AKS clusters. | Important
 [Azure.AKS.StandardLB](../rules/Azure.AKS.StandardLB.md) | Azure Kubernetes Clusters (AKS) should use a Standard load balancer SKU. | Important
 [Azure.AKS.UseRBAC](../rules/Azure.AKS.UseRBAC.md) | Deploy AKS cluster with role-based access control (RBAC) enabled. | Important
 [Azure.AKS.Version](../rules/Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important

--- a/docs/en/rules/Azure.AKS.HttpAppRouting.md
+++ b/docs/en/rules/Azure.AKS.HttpAppRouting.md
@@ -1,38 +1,35 @@
 ---
 reviewed: 2021/12/10
 severity: Important
-pillar: Operational Excellence
-category: Automation
+pillar: Security
+category: Application endpoints
 resource: Azure Kubernetes Service
-online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AKS.AutoUpgrade/
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AKS.HttpAppRouting/
 ---
 
-# Set AKS auto-upgrade channel
+# Disable HTTP application routing add-on
 
 ## SYNOPSIS
 
-Configure AKS to automatically upgrade to newer supported AKS versions as they are made available.
+Disable HTTP application routing add-on in AKS clusters.
 
 ## DESCRIPTION
 
-In additional to performing manual upgrades, AKS supports auto-upgrades.
-Auto-upgrades reduces manual intervention required to maintain an AKS cluster.
+The HTTP application routing add-on is designed to quickly expose HTTP endpoints to the public internet.
+This may be helpful in some limited scenarios, but should not be used in production.
 
-To configure auto-upgrades select a release channel instead of the default `none`.
-The following release channels are available:
+When exposing application endpoints consider using an ingress controller that supports:
 
-- `none` - Disables auto-upgrades.
-The default setting.
-- `patch` - Automatically upgrade to the latest supported patch version of the current minor version.
-- `stable` - Automatically upgrade to the latest supported patch release of the recommended minor version.
-This is N-1 of the current AKS non-preview minor version.
-- `rapid` - Automatically upgrade to the latest supported patch of the latest support minor version.
-- `node-image` - Automatically upgrade to the latest node image version.
-Normally upgraded weekly.
+- Security filtering behind web application firewall (WAF).
+- Encyption in transit over TLS.
+- Multiple replicas.
+
+Azure provides a production ready ingress controller _Application Gateway Ingress Controller_ (AGIC).
 
 ## RECOMMENDATION
 
-Consider enabling auto-upgrades for AKS clusters by setting an auto-upgrade channel.
+Consider disabling the HTTP application routing add-on in your AKS cluster.
+Also consider using Application Gateway Ingress Controller (AGIC) instead to protect application endpoints.
 
 ## EXAMPLES
 
@@ -40,7 +37,7 @@ Consider enabling auto-upgrades for AKS clusters by setting an auto-upgrade chan
 
 To deploy AKS clusters that pass this rule:
 
-- Set `properties.autoUpgradeProfile.upgradeChannel` to an upgrade channel such as `stable`.
+- Set `Properties.addonProfiles.httpApplicationRouting.enabled` to `false`.
 
 For example:
 
@@ -114,9 +111,9 @@ For example:
 
 ### Configure with Bicep
 
-To deploy resource that pass this rule:
+To deploy AKS clusters that pass this rule:
 
-- steps
+- Set `Properties.addonProfiles.httpApplicationRouting.enabled` to `false`.
 
 For example:
 
@@ -183,16 +180,9 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2021-07-01' = {
 }
 ```
 
-### Configure with Azure CLI
-
-```bash
-az aks update -n '<name>' -g '<resource_group>' --auto-upgrade-channel 'stable'
-```
-
 ## LINKS
 
-- [Automation overview](https://docs.microsoft.com/azure/architecture/framework/devops/automation-overview)
-- [Supported Kubernetes versions in Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/supported-kubernetes-versions)
-- [Support policies for Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/support-policies)
-- [Set auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel)
+- [Best practices for endpoint security on Azure](https://docs.microsoft.com/azure/architecture/framework/security/design-network-endpoints)
+- [HTTP application routing](https://docs.microsoft.com/azure/aks/http-application-routing)
+- [Enable Application Gateway Ingress Controller add-on for an existing AKS cluster](https://docs.microsoft.com/azure/application-gateway/tutorial-ingress-controller-add-on-existing)
 - [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters#ManagedClusterAutoUpgradeProfile)

--- a/docs/en/rules/Azure.AKS.SecretStore.md
+++ b/docs/en/rules/Azure.AKS.SecretStore.md
@@ -1,38 +1,33 @@
 ---
 reviewed: 2021/12/10
 severity: Important
-pillar: Operational Excellence
-category: Automation
+pillar: Security
+category: Key and secret management
 resource: Azure Kubernetes Service
-online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AKS.AutoUpgrade/
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AKS.SecretStore/
 ---
 
-# Set AKS auto-upgrade channel
+# AKS clusters use Key Vault to store secrets
 
 ## SYNOPSIS
 
-Configure AKS to automatically upgrade to newer supported AKS versions as they are made available.
+Deploy AKS clusters with Secrets Store CSI Driver and store Secrets in Key Vayult.
 
 ## DESCRIPTION
 
-In additional to performing manual upgrades, AKS supports auto-upgrades.
-Auto-upgrades reduces manual intervention required to maintain an AKS cluster.
+AKS clusters may need to store and retrieve secrets, keys, and certificates.
+The Secrets Store CSI Driver provides cluster support to integrate with Key Vault.
+When enabled and configured secrets, keys, and certificates can be securely accessed from a pod.
 
-To configure auto-upgrades select a release channel instead of the default `none`.
-The following release channels are available:
+The Secrets Store CSI Driver can automatically refresh secrets and keys periodically from Key Vault.
+To enable this feature, enable Secrets Store CSI Driver autorotation.
 
-- `none` - Disables auto-upgrades.
-The default setting.
-- `patch` - Automatically upgrade to the latest supported patch version of the current minor version.
-- `stable` - Automatically upgrade to the latest supported patch release of the recommended minor version.
-This is N-1 of the current AKS non-preview minor version.
-- `rapid` - Automatically upgrade to the latest supported patch of the latest support minor version.
-- `node-image` - Automatically upgrade to the latest node image version.
-Normally upgraded weekly.
+Avoid storing secrets to access Azure resources.
+Use a Managed Identity when possible instead of cryptographic keys or a regular service principal.
 
 ## RECOMMENDATION
 
-Consider enabling auto-upgrades for AKS clusters by setting an auto-upgrade channel.
+Consider deploying AKS clusters with the Secrets Store CSI Driver and store Secrets in Key Vault.
 
 ## EXAMPLES
 
@@ -40,7 +35,7 @@ Consider enabling auto-upgrades for AKS clusters by setting an auto-upgrade chan
 
 To deploy AKS clusters that pass this rule:
 
-- Set `properties.autoUpgradeProfile.upgradeChannel` to an upgrade channel such as `stable`.
+- Set `Properties.addonProfiles.azureKeyvaultSecretsProvider.enabled` to `true`.
 
 For example:
 
@@ -114,9 +109,9 @@ For example:
 
 ### Configure with Bicep
 
-To deploy resource that pass this rule:
+To deploy AKS clusters that pass this rule:
 
-- steps
+- Set `Properties.addonProfiles.azureKeyvaultSecretsProvider.enabled` to `true`.
 
 For example:
 
@@ -186,13 +181,14 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2021-07-01' = {
 ### Configure with Azure CLI
 
 ```bash
-az aks update -n '<name>' -g '<resource_group>' --auto-upgrade-channel 'stable'
+az aks enable-addons --addons azure-keyvault-secrets-provider -n '<name>' -g '<resource_group>'
 ```
 
 ## LINKS
 
-- [Automation overview](https://docs.microsoft.com/azure/architecture/framework/devops/automation-overview)
-- [Supported Kubernetes versions in Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/supported-kubernetes-versions)
-- [Support policies for Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/support-policies)
-- [Set auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel)
+- [Key and secret management considerations in Azure](https://docs.microsoft.com/azure/architecture/framework/security/design-storage-keys#operational-considerations)
+- [Operational considerations](https://docs.microsoft.com/azure/architecture/framework/security/design-storage-keys#operational-considerations)
+- [Use the Azure Key Vault Provider for Secrets Store CSI Driver in an AKS cluster](https://docs.microsoft.com/azure/aks/csi-secrets-store-driver)
+- [Automate the rotation of a secret for resources that use one set of authentication credentials](https://docs.microsoft.com/azure/key-vault/secrets/tutorial-rotation)
+- [Automate the rotation of a secret for resources that have two sets of authentication credentials](https://docs.microsoft.com/azure/key-vault/secrets/tutorial-rotation-dual)
 - [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters#ManagedClusterAutoUpgradeProfile)

--- a/docs/en/rules/Azure.AKS.SecretStoreRotation.md
+++ b/docs/en/rules/Azure.AKS.SecretStoreRotation.md
@@ -1,38 +1,35 @@
 ---
 reviewed: 2021/12/10
 severity: Important
-pillar: Operational Excellence
-category: Automation
+pillar: Security
+category: Key and secret management
 resource: Azure Kubernetes Service
-online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AKS.AutoUpgrade/
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AKS.SecretStoreRotation/
 ---
 
-# Set AKS auto-upgrade channel
+# AKS clusters refresh secrets from Key Vault
 
 ## SYNOPSIS
 
-Configure AKS to automatically upgrade to newer supported AKS versions as they are made available.
+Enable autorotation of Secrets Store CSI Driver secrets for AKS clusters.
 
 ## DESCRIPTION
 
-In additional to performing manual upgrades, AKS supports auto-upgrades.
-Auto-upgrades reduces manual intervention required to maintain an AKS cluster.
+AKS clusters may need to store and retrieve secrets, keys, and certificates.
+The Secrets Store CSI Driver provides cluster support to integrate with Key Vault.
+When enabled and configured secrets, keys, and certificates can be securely accessed from a pod.
 
-To configure auto-upgrades select a release channel instead of the default `none`.
-The following release channels are available:
+When secrets are updated in Key Vault, pods may need to be restarted to pick up the new secrets.
+Enabling autorotation with the Secrets Store CSI Driver, automatically refreshed pods with new secrets.
+It does this by periodically polling for updates to the secrets in Key Vault.
+The default interval is every 2 minutes.
 
-- `none` - Disables auto-upgrades.
-The default setting.
-- `patch` - Automatically upgrade to the latest supported patch version of the current minor version.
-- `stable` - Automatically upgrade to the latest supported patch release of the recommended minor version.
-This is N-1 of the current AKS non-preview minor version.
-- `rapid` - Automatically upgrade to the latest supported patch of the latest support minor version.
-- `node-image` - Automatically upgrade to the latest node image version.
-Normally upgraded weekly.
+The Secrets Store CSI Driver does not automatically change secrets in Key Vault.
+Updating the secrets in Key Vault must be done by an external process, such as an Azure Function.
 
 ## RECOMMENDATION
 
-Consider enabling auto-upgrades for AKS clusters by setting an auto-upgrade channel.
+Consider enabling autorotation of Secrets Store CSI Driver secrets for AKS clusters.
 
 ## EXAMPLES
 
@@ -40,7 +37,7 @@ Consider enabling auto-upgrades for AKS clusters by setting an auto-upgrade chan
 
 To deploy AKS clusters that pass this rule:
 
-- Set `properties.autoUpgradeProfile.upgradeChannel` to an upgrade channel such as `stable`.
+- Set `Properties.addonProfiles.azureKeyvaultSecretsProvider.config.enableSecretRotation` to `true`.
 
 For example:
 
@@ -114,9 +111,9 @@ For example:
 
 ### Configure with Bicep
 
-To deploy resource that pass this rule:
+To deploy AKS clusters that pass this rule:
 
-- steps
+- Set `Properties.addonProfiles.azureKeyvaultSecretsProvider.config.enableSecretRotation` to `true`.
 
 For example:
 
@@ -186,13 +183,14 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2021-07-01' = {
 ### Configure with Azure CLI
 
 ```bash
-az aks update -n '<name>' -g '<resource_group>' --auto-upgrade-channel 'stable'
+az aks update --enable-secret-rotation -n '<name>' -g '<resource_group>'
 ```
 
 ## LINKS
 
-- [Automation overview](https://docs.microsoft.com/azure/architecture/framework/devops/automation-overview)
-- [Supported Kubernetes versions in Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/supported-kubernetes-versions)
-- [Support policies for Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/support-policies)
-- [Set auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel)
+- [Key and secret management considerations in Azure](https://docs.microsoft.com/azure/architecture/framework/security/design-storage-keys#operational-considerations)
+- [Operational considerations](https://docs.microsoft.com/azure/architecture/framework/security/design-storage-keys#operational-considerations)
+- [Use the Azure Key Vault Provider for Secrets Store CSI Driver in an AKS cluster](https://docs.microsoft.com/azure/aks/csi-secrets-store-driver)
+- [Automate the rotation of a secret for resources that use one set of authentication credentials](https://docs.microsoft.com/azure/key-vault/secrets/tutorial-rotation)
+- [Automate the rotation of a secret for resources that have two sets of authentication credentials](https://docs.microsoft.com/azure/key-vault/secrets/tutorial-rotation-dual)
 - [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters#ManagedClusterAutoUpgradeProfile)

--- a/docs/en/rules/module.md
+++ b/docs/en/rules/module.md
@@ -28,6 +28,12 @@ Name | Synopsis | Severity
 
 ## Operational Excellence
 
+### Automation
+
+Name | Synopsis | Severity
+---- | -------- | --------
+[Azure.AKS.AutoUpgrade](Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
+
 ### Configuration
 
 Name | Synopsis | Severity
@@ -226,7 +232,6 @@ Name | Synopsis | Severity
 Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.ACR.MinSku](Azure.ACR.MinSku.md) | ACR should use the Premium or Standard SKU for production deployments. | Important
-[Azure.AKS.AutoUpgrade](Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
 [Azure.AKS.AvailabilityZone](Azure.AKS.AvailabilityZone.md) | AKS clusters deployed with virtual machine scale sets should use availability zones in supported regions for high availability. | Important
 [Azure.AKS.PoolVersion](Azure.AKS.PoolVersion.md) | AKS node pools should match Kubernetes control plane version. | Important
 [Azure.AKS.Version](Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important
@@ -271,6 +276,7 @@ Name | Synopsis | Severity
 
 Name | Synopsis | Severity
 ---- | -------- | --------
+[Azure.AKS.HttpAppRouting](Azure.AKS.HttpAppRouting.md) | Disable HTTP application routing add-on in AKS clusters. | Important
 [Azure.Storage.Firewall](Azure.Storage.Firewall.md) | Storage Accounts should only accept explicitly allowed traffic. | Important
 
 ### Applications and services
@@ -360,6 +366,13 @@ Name | Synopsis | Severity
 [Azure.Storage.BlobAccessType](Azure.Storage.BlobAccessType.md) | Storage Accounts use containers configured with an access type other than Private. | Important
 [Azure.Storage.BlobPublicAccess](Azure.Storage.BlobPublicAccess.md) | Storage Accounts should only accept authorized requests. | Important
 [Azure.VM.PublicKey](Azure.VM.PublicKey.md) | Linux virtual machines should use public keys. | Important
+
+### Key and secret management
+
+Name | Synopsis | Severity
+---- | -------- | --------
+[Azure.AKS.SecretStore](Azure.AKS.SecretStore.md) | Deploy AKS clusters with Secrets Store CSI Driver and store Secrets in Key Vayult. | Important
+[Azure.AKS.SecretStoreRotation](Azure.AKS.SecretStoreRotation.md) | Enable autorotation of Secrets Store CSI Driver secrets for AKS clusters. | Important
 
 ### Monitor
 

--- a/docs/en/rules/resource.md
+++ b/docs/en/rules/resource.md
@@ -158,6 +158,7 @@ Name | Synopsis | Severity
 [Azure.AKS.CNISubnetSize](Azure.AKS.CNISubnetSize.md) | AKS clusters using Azure CNI should use large subnets to reduce IP exhaustion issues. | Important
 [Azure.AKS.ContainerInsights](Azure.AKS.ContainerInsights.md) | Enable Container insights to monitor AKS cluster workloads. | Important
 [Azure.AKS.DNSPrefix](Azure.AKS.DNSPrefix.md) | Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements. | Awareness
+[Azure.AKS.HttpAppRouting](Azure.AKS.HttpAppRouting.md) | Disable HTTP application routing add-on in AKS clusters. | Important
 [Azure.AKS.LocalAccounts](Azure.AKS.LocalAccounts.md) | Enforce named user accounts with RBAC assigned permissions. | Important
 [Azure.AKS.ManagedAAD](Azure.AKS.ManagedAAD.md) | Use AKS-managed Azure AD to simplify authorization and improve security. | Important
 [Azure.AKS.ManagedIdentity](Azure.AKS.ManagedIdentity.md) | Configure AKS clusters to use managed identities for managing cluster infrastructure. | Important
@@ -168,6 +169,8 @@ Name | Synopsis | Severity
 [Azure.AKS.PlatformLogs](Azure.AKS.PlatformLogs.md) | AKS clusters should collect platform diagnostic logs to monitor the state of workloads. | Important
 [Azure.AKS.PoolScaleSet](Azure.AKS.PoolScaleSet.md) | Deploy AKS clusters with nodes pools based on VM scale sets. | Important
 [Azure.AKS.PoolVersion](Azure.AKS.PoolVersion.md) | AKS node pools should match Kubernetes control plane version. | Important
+[Azure.AKS.SecretStore](Azure.AKS.SecretStore.md) | Deploy AKS clusters with Secrets Store CSI Driver and store Secrets in Key Vayult. | Important
+[Azure.AKS.SecretStoreRotation](Azure.AKS.SecretStoreRotation.md) | Enable autorotation of Secrets Store CSI Driver secrets for AKS clusters. | Important
 [Azure.AKS.StandardLB](Azure.AKS.StandardLB.md) | Azure Kubernetes Clusters (AKS) should use a Standard load balancer SKU. | Important
 [Azure.AKS.UseRBAC](Azure.AKS.UseRBAC.md) | Deploy AKS cluster with role-based access control (RBAC) enabled. | Important
 [Azure.AKS.Version](Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important

--- a/docs/examples-aks.bicep
+++ b/docs/examples-aks.bicep
@@ -67,12 +67,6 @@ param vnetId string
 @description('The name of the subnet do deploy cluster resources.')
 param systemPoolSubnet string
 
-@description('Determines if the Key Vault provider automatically rotates secrets.')
-param useSecretRotation bool = false
-
-@description('Determines if Open Service Mesh for Kubernetes is enabled.')
-param useOpenServiceMesh bool = false
-
 @description('The object Ids of groups that will be added with the cluster admin role.')
 param clusterAdmins array = []
 
@@ -90,15 +84,6 @@ param clusterAdmins array = []
   ]
 })
 param pools array = []
-
-@description('Determine if cluster upgrades are automatically applied.')
-@allowed([
-  'none'
-  'rapid'
-  'stable'
-  'patch'
-])
-param upgradeChannel string = 'none'
 
 @metadata({
   description: 'Tags to apply to the resource.'
@@ -192,7 +177,7 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2021-07-01' = {
       dockerBridgeCidr: dockerBridgeCidr
     }
     autoUpgradeProfile: {
-      upgradeChannel: upgradeChannel
+      upgradeChannel: 'stable'
     }
     addonProfiles: {
       httpApplicationRouting: {
@@ -216,11 +201,8 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2021-07-01' = {
       azureKeyvaultSecretsProvider: {
         enabled: true
         config: {
-          enableSecretRotation: string(useSecretRotation)
+          enableSecretRotation: 'true'
         }
-      }
-      openServiceMesh: {
-        enabled: useOpenServiceMesh
       }
     }
   }

--- a/docs/examples-aks.json
+++ b/docs/examples-aks.json
@@ -4,8 +4,8 @@
     "metadata": {
         "_generator": {
             "name": "bicep",
-            "version": "0.4.613.9944",
-            "templateHash": "6304755602461575155"
+            "version": "0.4.1008.15138",
+            "templateHash": "12910428772196393994"
         }
     },
     "parameters": {
@@ -106,20 +106,6 @@
                 "description": "The name of the subnet do deploy cluster resources."
             }
         },
-        "useSecretRotation": {
-            "type": "bool",
-            "defaultValue": false,
-            "metadata": {
-                "description": "Determines if the Key Vault provider automatically rotates secrets."
-            }
-        },
-        "useOpenServiceMesh": {
-            "type": "bool",
-            "defaultValue": false,
-            "metadata": {
-                "description": "Determines if Open Service Mesh for Kubernetes is enabled."
-            }
-        },
         "clusterAdmins": {
             "type": "array",
             "defaultValue": [],
@@ -142,19 +128,6 @@
                         "vmSize": "Standard_D2s_v3"
                     }
                 ]
-            }
-        },
-        "upgradeChannel": {
-            "type": "string",
-            "defaultValue": "none",
-            "allowedValues": [
-                "none",
-                "rapid",
-                "stable",
-                "patch"
-            ],
-            "metadata": {
-                "description": "Determine if cluster upgrades are automatically applied."
             }
         },
         "tags": {
@@ -232,7 +205,7 @@
             "identity": {
                 "type": "UserAssigned",
                 "userAssignedIdentities": {
-                    "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]": {}
+                    "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')))]": {}
                 }
             },
             "properties": {
@@ -255,7 +228,7 @@
                     "dockerBridgeCidr": "[variables('dockerBridgeCidr')]"
                 },
                 "autoUpgradeProfile": {
-                    "upgradeChannel": "[parameters('upgradeChannel')]"
+                    "upgradeChannel": "stable"
                 },
                 "addonProfiles": {
                     "httpApplicationRouting": {
@@ -279,11 +252,8 @@
                     "azureKeyvaultSecretsProvider": {
                         "enabled": true,
                         "config": {
-                            "enableSecretRotation": "[string(parameters('useSecretRotation'))]"
+                            "enableSecretRotation": "true"
                         }
-                    },
-                    "openServiceMesh": {
-                        "enabled": "[parameters('useOpenServiceMesh')]"
                     }
                 }
             },

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -112,12 +112,6 @@ Rule 'Azure.AKS.ManagedAAD' -Type 'Microsoft.ContainerService/managedClusters' -
     $Assert.HasFieldValue($TargetObject, 'Properties.aadProfile.managed', $True);
 }
 
-# Synopsis: Configure AKS to automatically upgrade to newer supported AKS versions as they are made available.
-Rule 'Azure.AKS.AutoUpgrade' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'preview'; ruleSet = '2021_06'; } {
-    $Assert.HasFieldValue($TargetObject, 'Properties.autoUpgradeProfile.upgradeChannel');
-    $Assert.NotIn($TargetObject, 'Properties.autoUpgradeProfile.upgradeChannel', @('none'));
-}
-
 # Synopsis: Restrict access to API server endpoints to authorized IP addresses.
 Rule 'Azure.AKS.AuthorizedIPs' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; ruleSet = '2021_06'; } {
     $Assert.GreaterOrEqual($TargetObject, 'Properties.apiServerAccessProfile.authorizedIPRanges', 1);

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.yaml
@@ -25,4 +25,94 @@ spec:
     - azure
     - calico
 
+---
+# Synopsis: Deploy AKS clusters with Secrets Store CSI Driver and store Secrets in Key Vayult.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AKS.SecretStore
+  tags:
+    release: 'GA'
+    ruleSet: '2021_12'
+spec:
+  type:
+  - Microsoft.ContainerService/managedClusters
+  condition:
+    field: Properties.addonProfiles.azureKeyvaultSecretsProvider.enabled
+    equals: true
+
+---
+# Synopsis: Enable autorotation of Secrets Store CSI Driver secrets for AKS clusters.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AKS.SecretStoreRotation
+  tags:
+    release: 'GA'
+    ruleSet: '2021_12'
+spec:
+  type:
+  - Microsoft.ContainerService/managedClusters
+  with:
+  - Azure.AKS.SecretStoreEnabled
+  condition:
+    field: Properties.addonProfiles.azureKeyvaultSecretsProvider.config.enableSecretRotation
+    equals: 'true'
+
+---
+# Synopsis: Disable HTTP application routing add-on in AKS clusters.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AKS.HttpAppRouting
+  tags:
+    release: 'GA'
+    ruleSet: '2021_12'
+spec:
+  type:
+  - Microsoft.ContainerService/managedClusters
+  condition:
+    anyOf:
+    - field: Properties.addonProfiles.httpApplicationRouting.enabled
+      exists: false
+    - field: Properties.addonProfiles.httpApplicationRouting.enabled
+      equals: false
+
+---
+# Synopsis: Configure AKS to automatically upgrade to newer supported AKS versions as they are made available.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AKS.AutoUpgrade
+  tags:
+    release: 'GA'
+    ruleSet: '2021_12'
+spec:
+  type:
+  - Microsoft.ContainerService/managedClusters
+  condition:
+    allOf:
+    - field: Properties.autoUpgradeProfile.upgradeChannel
+      hasValue: true
+    - field: Properties.autoUpgradeProfile.upgradeChannel
+      notEquals: none
+
 #endregion Rules
+
+#region Selectors
+
+---
+# Synopsis: AKS clusters with Secret Store CSI Driver enabled.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Azure.AKS.SecretStoreEnabled
+spec:
+  if:
+    allOf:
+    - type: '.'
+      equals: 'Microsoft.ContainerService/managedClusters'
+    - field: Properties.addonProfiles.azureKeyvaultSecretsProvider.enabled
+      equals: true
+
+#endregion Selectors

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -6,9 +6,7 @@
 #
 
 [CmdletBinding()]
-param (
-
-)
+param ()
 
 BeforeAll {
     # Setup error handling
@@ -44,8 +42,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -Be 'cluster-B', 'cluster-D', 'cluster-F';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -Be 'cluster-B', 'cluster-D', 'cluster-F', 'cluster-K', 'cluster-L';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -69,8 +67,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 9;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'system', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
+            $ruleResult.Length | Should -Be 11;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'system', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.PoolVersion' {
@@ -88,8 +86,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 8;
-            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
+            $ruleResult.Length | Should -Be 10;
+            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.UseRBAC' {
@@ -104,8 +102,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 8;
-            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
+            $ruleResult.Length | Should -Be 10;
+            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.NetworkPolicy' {
@@ -120,8 +118,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -Be 'cluster-C', 'cluster-D', 'cluster-F';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -Be 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.PoolScaleSet' {
@@ -141,8 +139,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 8;
-            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-F', 'system', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
+            $ruleResult.Length | Should -Be 10;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-F', 'system', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.NodeMinPods' {
@@ -157,8 +155,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-F', 'system';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-F', 'system', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.ManagedIdentity' {
@@ -173,8 +171,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'cluster-D', 'cluster-F';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -Be 'cluster-D', 'cluster-F', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.StandardLB' {
@@ -189,8 +187,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'cluster-D', 'cluster-F';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'cluster-D', 'cluster-F', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.AzurePolicyAddOn' {
@@ -205,8 +203,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -Be 'cluster-C', 'cluster-D', 'cluster-F';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -Be 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.ManagedAAD' {
@@ -221,8 +219,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'cluster-D', 'cluster-F';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -Be 'cluster-D', 'cluster-F', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.AutoUpgrade' {
@@ -237,8 +235,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'cluster-F';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'cluster-F', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.AutoScaling' {
@@ -266,8 +264,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 4;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'system', 'cluster-F';
+            $ruleResult | Should -HaveCount 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'system', 'cluster-F', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.AuthorizedIPs' {
@@ -276,8 +274,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 8;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
+            $ruleResult.Length | Should -Be 10;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J', 'cluster-K', 'cluster-L';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -292,8 +290,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 8;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
+            $ruleResult.Length | Should -Be 10;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J', 'cluster-K', 'cluster-L';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -314,8 +312,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'cluster-F';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'cluster-F', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.CNISubnetSize' {
@@ -347,8 +345,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 3;
-            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-G', 'cluster-H';
+            $ruleResult | Should -HaveCount 5;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-G', 'cluster-H', 'cluster-K', 'cluster-L';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "The agent pool (agentpool) deployed to region (australiaeast) should use following availability zones [1, 2, 3].";
@@ -376,8 +374,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 7;
-            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
+            $ruleResult | Should -HaveCount 9;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J', 'cluster-K', 'cluster-L';
         }
 
         It 'Azure.AKS.AuditLogs' {
@@ -386,8 +384,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 7;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H';
+            $ruleResult | Should -HaveCount 9;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-K', 'cluster-L';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "Diagnostic settings are not configured.";
@@ -417,8 +415,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 8;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I';
+            $ruleResult | Should -HaveCount 10;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-K', 'cluster-L';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "Diagnostic settings are not configured.";
@@ -441,6 +439,54 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult | Should -HaveCount 1;
             $ruleResult.TargetName | Should -BeIn 'cluster-J';
+        }
+
+        It 'Azure.AKS.HttpAppRouting' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.HttpAppRouting' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -Be 'cluster-B', 'cluster-D', 'cluster-J', 'cluster-K', 'cluster-L';
+        }
+
+        It 'Azure.AKS.SecretStore' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.SecretStore' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 8;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'cluster-F', 'cluster-K', 'cluster-L';
+        }
+
+        It 'Azure.AKS.SecretStoreRotation' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.SecretStoreRotation' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'cluster-F', 'cluster-K';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'cluster-L';
         }
     }
 
@@ -570,8 +616,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD', 'clusterE';
+            $ruleResult.Length | Should -Be 7;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD', 'clusterE', 'clusterF';
         }
 
         It 'Azure.AKS.PoolVersion' {
@@ -586,8 +632,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'clusterB';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterF';
         }
 
         It 'Azure.AKS.PoolScaleSet' {
@@ -602,8 +648,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD', 'clusterE';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD', 'clusterE', 'clusterF';
         }
 
         It 'Azure.AKS.NodeMinPods' {
@@ -618,8 +664,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD', 'clusterE';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool3', 'clusterC/agentpool4', 'clusterD', 'clusterE', 'clusterF';
         }
 
         It 'Azure.AKS.ManagedIdentity' {
@@ -632,8 +678,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterD', 'clusterE';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterD', 'clusterE', 'clusterF';
         }
 
         It 'Azure.AKS.StandardLB' {
@@ -646,8 +692,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterD', 'clusterE';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterD', 'clusterE', 'clusterF';
         }
 
         It 'Azure.AKS.AzurePolicyAddOn' {
@@ -662,8 +708,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'clusterA';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterF';
         }
 
         It 'Azure.AKS.ManagedAAD' {
@@ -678,8 +724,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE', 'clusterF';
         }
 
         It 'Azure.AKS.AutoUpgrade' {
@@ -694,8 +740,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE', 'clusterF';
         }
 
         It 'Azure.AKS.AutoScaling' {
@@ -710,8 +756,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool4';
+            $ruleResult | Should -HaveCount 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterC/agentpool4', 'clusterF';
         }
 
         It 'Azure.AKS.AuthorizedIPs' {
@@ -726,8 +772,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE', 'clusterF';
         }
 
         It 'Azure.AKS.LocalAccounts' {
@@ -742,8 +788,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE', 'clusterF';
         }
 
         It 'Azure.AKS.AzureRBAC' {
@@ -758,8 +804,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'clusterB', 'clusterD', 'clusterE', 'clusterF';
         }
 
         It 'Azure.AKS.AvailabilityZone' {
@@ -781,8 +827,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 1;
-            $ruleResult.TargetName | Should -BeIn 'clusterD';
+            $ruleResult | Should -HaveCount 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterD', 'clusterF';
         }
 
         It 'Azure.AKS.ContainerInsights' {
@@ -797,8 +843,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB';
+            $ruleResult | Should -HaveCount 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterF';
         }
 
         It 'Azure.AKS.AuditLogs' {
@@ -818,8 +864,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterD', 'clusterE';
+            $ruleResult | Should -HaveCount 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterD', 'clusterE', 'clusterF';
         }
 
         It 'Azure.AKS.PlatformLogs' {
@@ -841,8 +887,56 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 1;
-            $ruleResult.TargetName | Should -BeIn 'clusterE';
+            $ruleResult | Should -HaveCount 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterE', 'clusterF';
+        }
+
+        It 'Azure.AKS.HttpAppRouting' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.HttpAppRouting' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterD', 'clusterE', 'clusterF';
+        }
+
+        It 'Azure.AKS.SecretStore' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.SecretStore' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterD', 'clusterE', 'clusterF';
+        }
+
+        It 'Azure.AKS.SecretStoreRotation' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.SecretStoreRotation' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'clusterD', 'clusterE';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterF';
         }
     }
 
@@ -877,8 +971,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 6;
-            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
+            $ruleResult | Should -HaveCount 8;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J', 'cluster-K', 'cluster-L';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "The agent pool (agentpool) deployed to region (australiaeast) should use following availability zones [1, 2, 3].";
@@ -907,8 +1001,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 6;
-            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J';
+            $ruleResult | Should -HaveCount 8;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J', 'cluster-K', 'cluster-L';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "The agent pool (agentpool) deployed to region (australiaeast) should use following availability zones [1, 2, 3].";
@@ -946,8 +1040,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 7;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H';
+            $ruleResult | Should -HaveCount 9;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-H', 'cluster-K', 'cluster-L';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "Diagnostic settings are not configured.";
@@ -987,8 +1081,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 7;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-I';
+            $ruleResult | Should -HaveCount 9;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-I', 'cluster-K', 'cluster-L';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "Diagnostic settings are not configured.";
@@ -1027,8 +1121,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 6;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G';
+            $ruleResult | Should -HaveCount 8;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-K', 'cluster-L';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "Diagnostic settings are not configured.";
@@ -1057,8 +1151,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 7;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-I';
+            $ruleResult | Should -HaveCount 9;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-F', 'cluster-G', 'cluster-I', 'cluster-K', 'cluster-L';
 
             
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -22,6 +22,10 @@
             "defaultValue": "clusterE",
             "type": "string"
         },
+        "clusterName6": {
+            "defaultValue": "clusterF",
+            "type": "string"
+        },
         "clusterLocation": {
             "defaultValue": "[resourceGroup().location]",
             "type": "string"
@@ -248,10 +252,7 @@
                         }
                     },
                     "azureKeyvaultSecretsProvider": {
-                        "enabled": true,
-                        "config": {
-                            "enableSecretRotation": "false"
-                        }
+                        "enabled": false
                     },
                     "openServiceMesh": {
                         "enabled": true
@@ -460,16 +461,13 @@
                         "enabled": false
                     },
                     "httpApplicationRouting": {
-                        "enabled": true
+                        "enabled": false
                     },
                     "kubeDashboard": {
                         "enabled": true
                     },
                     "azureKeyvaultSecretsProvider": {
-                        "enabled": true,
-                        "config": {
-                            "enableSecretRotation": "false"
-                        }
+                        "enabled": true
                     },
                     "openServiceMesh": {
                         "enabled": true
@@ -623,7 +621,7 @@
         },
         {
             "type": "Microsoft.ContainerService/managedClusters",
-            "apiVersion": "2020-12-01",
+            "apiVersion": "2021-07-01",
             "name": "[parameters('clusterName5')]",
             "location": "[parameters('clusterLocation')]",
             "identity": {
@@ -662,9 +660,6 @@
                     },
                     "azurePolicy": {
                         "enabled": false
-                    },
-                    "httpApplicationRouting": {
-                        "enabled": true
                     },
                     "kubeDashboard": {
                         "enabled": true
@@ -749,6 +744,193 @@
                         "availabilityZones": null
                     }
                 },
+                {
+                    "apiVersion": "2016-09-01",
+                    "type": "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings",
+                    "name": "[concat(parameters('clusterName5'), '/Microsoft.Insights/service')]",
+                    "properties": {
+                        "workspaceId": "[parameters('workspaceId')]",
+                        "logs": [
+                            {
+                                "category": "kube-apiserver",
+                                "enabled": true,
+                                "retentionPolicy": {
+                                    "days": 0,
+                                    "enabled": false
+                                }
+                            },
+                            {
+                                "category": "kube-audit",
+                                "enabled": true,
+                                "retentionPolicy": {
+                                    "days": 0,
+                                    "enabled": false
+                                }
+                            },
+                            {
+                                "category": "kube-audit-admin",
+                                "enabled": true,
+                                "retentionPolicy": {
+                                    "days": 0,
+                                    "enabled": false
+                                }
+                            },
+                            {
+                                "category": "kube-controller-manager",
+                                "enabled": true,
+                                "retentionPolicy": {
+                                    "days": 0,
+                                    "enabled": false
+                                }
+                            },
+                            {
+                                "category": "kube-scheduler",
+                                "enabled": true,
+                                "retentionPolicy": {
+                                    "days": 0,
+                                    "enabled": false
+                                }
+                            },
+                            {
+                                "category": "cluster-autoscaler",
+                                "enabled": true,
+                                "retentionPolicy": {
+                                    "days": 0,
+                                    "enabled": false
+                                }
+                            },
+                            {
+                                "category": "guard",
+                                "enabled": true,
+                                "retentionPolicy": {
+                                    "days": 0,
+                                    "enabled": false
+                                }
+                            }
+                        ],
+                        "metrics": [
+                            {
+                                "category": "AllMetrics",
+                                "enabled": true,
+                                "retentionPolicy": {
+                                    "days": 0,
+                                    "enabled": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "type": "Microsoft.ContainerService/managedClusters",
+            "apiVersion": "2021-07-01",
+            "name": "[parameters('clusterName6')]",
+            "location": "[parameters('clusterLocation')]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "kubernetesVersion": "1.20.5",
+                "dnsPrefix": "[concat('dns-', parameters('clusterName6'))]",
+                "agentPoolProfiles": [
+                    {
+                        "name": "agentpool1",
+                        "count": 3,
+                        "vmSize": "Standard_B2ms",
+                        "osDiskSizeGB": 100,
+                        "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-01')]",
+                        "maxPods": 50,
+                        "type": "VirtualMachineScaleSets",
+                        "osType": "Linux",
+                        "enableAutoScaling": true,
+                        "availabilityZones": [
+                            "1",
+                            "2",
+                            "3"
+                        ]
+                    }
+                ],
+                "servicePrincipalProfile": {
+                    "clientId": "00000000-0000-0000-0000-000000000000"
+                },
+                "addonProfiles": {
+                    "aciConnectorLinux": {
+                        "enabled": true,
+                        "config": {
+                            "SubnetName": "subnet-aci"
+                        }
+                    },
+                    "azurePolicy": {
+                        "enabled": true,
+                        "config": {
+                            "version": "v2"
+                        }
+                    },
+                    "kubeDashboard": {
+                        "enabled": true
+                    },
+                    "omsagent": {
+                        "enabled": true,
+                        "config": {
+                            "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
+                        }
+                    },
+                    "azureKeyvaultSecretsProvider": {
+                        "enabled": true,
+                        "config": {
+                            "enableSecretRotation": "true"
+                        }
+                    },
+                    "openServiceMesh": {
+                        "enabled": true
+                    }
+                },
+                "aadProfile": {
+                    "managed": true,
+                    "enableAzureRBAC": true,
+                    "adminGroupObjectIDs": [],
+                    "tenantID": "[subscription().tenantId]"
+                },
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "stable"
+                },
+                "autoScalerProfile": {
+                    "balance-similar-node-groups": "false",
+                    "expander": "random",
+                    "max-empty-bulk-delete": "10",
+                    "max-graceful-termination-sec": "600",
+                    "max-total-unready-percentage": "45",
+                    "new-pod-scale-up-delay": "0s",
+                    "ok-total-unready-count": "3",
+                    "scale-down-delay-after-add": "10m",
+                    "scale-down-delay-after-delete": "10s",
+                    "scale-down-delay-after-failure": "3m",
+                    "scale-down-unneeded-time": "10m",
+                    "scale-down-unready-time": "20m",
+                    "scale-down-utilization-threshold": "0.5",
+                    "scan-interval": "10s",
+                    "skip-nodes-with-local-storage": "false",
+                    "skip-nodes-with-system-pods": "true"
+                },
+                "disableLocalAccounts": true,
+                "enableRBAC": true,
+                "enablePodSecurityPolicy": false,
+                "networkProfile": {
+                    "networkPlugin": "azure",
+                    "networkPolicy": "azure",
+                    "loadBalancerSku": "Standard",
+                    "serviceCidr": "192.168.0.0/16",
+                    "dnsServiceIP": "192.168.0.4",
+                    "dockerBridgeCidr": "172.17.0.1/16"
+                },
+                "apiServerAccessProfile": {
+                    "authorizedIpRanges": [
+                        "0.0.0.0/32"
+                    ]
+                }
+            },
+            "resources": [
                 {
                     "apiVersion": "2016-09-01",
                     "type": "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings",

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -98,12 +98,6 @@
                     "config": {
                         "subnetname": "subnet-A"
                     }
-                },
-                "httpapplicationrouting": {
-                    "enabled": true,
-                    "config": {
-                        "httpapplicationroutingzonename": "test-dns-zone.region.aksapp.io"
-                    }
                 }
             },
             "nodeResourceGroup": "MC_test-rg_cluster-B_region",
@@ -345,15 +339,7 @@
                     }
                 },
                 "httpApplicationRouting": {
-                    "enabled": true,
-                    "config": {
-                        "HTTPApplicationRoutingZoneName": "dca47a62fed041939528.region.aksapp.io"
-                    },
-                    "identity": {
-                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_test-rg_cluster-D_region/providers/Microsoft.ManagedIdentity/userAssignedIdentities/httpapplicationrouting-cluster-D",
-                        "clientId": "00000000-0000-0000-0000-000000000000",
-                        "objectId": "00000000-0000-0000-0000-000000000000"
-                    }
+                    "enabled": false
                 },
                 "kubeDashboard": {
                     "enabled": false,
@@ -1332,12 +1318,6 @@
                         "subnetname": "subnet-A"
                     }
                 },
-                "httpapplicationrouting": {
-                    "enabled": true,
-                    "config": {
-                        "httpapplicationroutingzonename": "test-dns-zone.region.aksapp.io"
-                    }
-                },
                 "omsagent": {
                     "enabled": true,
                     "config": {
@@ -1470,5 +1450,367 @@
                 "ETag": null
             }
         ]
+    },
+    {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-K",
+        "location": "eastus",
+        "name": "cluster-K",
+        "tags": null,
+        "type": "Microsoft.ContainerService/ManagedClusters",
+        "properties": {
+            "provisioningState": "Succeeded",
+            "powerState": {
+                "code": "Running"
+            },
+            "kubernetesVersion": "1.21.2",
+            "dnsPrefix": "cluster-K",
+            "fqdn": "cluster-K-00000000.hcp.eastus.azmk8s.io",
+            "azurePortalFQDN": "cluster-K-00000000.portal.hcp.eastus.azmk8s.io",
+            "agentPoolProfiles": [
+                {
+                    "name": "system",
+                    "count": 2,
+                    "vmSize": "Standard_D2s_v3",
+                    "osDiskSizeGB": 32,
+                    "osDiskType": "Ephemeral",
+                    "kubeletDiskType": "OS",
+                    "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
+                    "maxPods": 50,
+                    "type": "VirtualMachineScaleSets",
+                    "maxCount": 2,
+                    "minCount": 2,
+                    "enableAutoScaling": true,
+                    "provisioningState": "Succeeded",
+                    "powerState": {
+                        "code": "Running"
+                    },
+                    "orchestratorVersion": "1.21.2",
+                    "mode": "System",
+                    "osType": "Linux",
+                    "osSKU": "Ubuntu",
+                    "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.07.17",
+                    "enableFIPS": false
+                }
+            ],
+            "windowsProfile": {
+                "adminUsername": "azureuser",
+                "enableCSIProxy": true
+            },
+            "servicePrincipalProfile": {
+                "clientId": "msi"
+            },
+            "addonProfiles": {
+                "aciConnectorLinux": {
+                    "enabled": true,
+                    "config": {
+                        "SubnetName": "subnet-B"
+                    },
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aciconnectorlinux-cluster-K",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                },
+                "azureKeyvaultSecretsProvider": {
+                    "enabled": true,
+                    "config": {
+                        "enableSecretRotation": "False"
+                    },
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/azurekeyvaultsecretsprovider-cluster-K",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                },
+                "azurepolicy": {
+                    "enabled": true,
+                    "config": null,
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/azurepolicy-cluster-K",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                },
+                "kubeDashboard": {
+                    "enabled": false,
+                    "config": null
+                },
+                "omsagent": {
+                    "enabled": true,
+                    "config": {
+                        "logAnalyticsWorkspaceResourceID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.operationalinsights/workspaces/defaultworkspace-00000000-0000-0000-0000-000000000000-eus"
+                    },
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/omsagent-cluster-K",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                },
+                "openServiceMesh": {
+                    "enabled": true,
+                    "config": null,
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/openservicemesh-cluster-K",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                }
+            },
+            "nodeResourceGroup": "test-rg",
+            "enableRBAC": true,
+            "enablePodSecurityPolicy": false,
+            "networkProfile": {
+                "networkPlugin": "azure",
+                "networkPolicy": "azure",
+                "loadBalancerSku": "Standard",
+                "loadBalancerProfile": {
+                    "managedOutboundIPs": {
+                        "count": 1
+                    },
+                    "effectiveOutboundIPs": [
+                        {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/publicIP-A"
+                        }
+                    ]
+                },
+                "serviceCidr": "192.168.0.0/16",
+                "dnsServiceIP": "192.168.0.4",
+                "dockerBridgeCidr": "172.17.0.1/16",
+                "outboundType": "loadBalancer"
+            },
+            "aadProfile": {
+                "managed": true,
+                "adminGroupObjectIDs": null,
+                "enableAzureRBAC": true,
+                "tenantID": "00000000-0000-0000-0000-000000000000"
+            },
+            "maxAgentPools": 100,
+            "identityProfile": {
+                "kubeletidentity": {
+                    "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cluster-K-agentpool",
+                    "clientId": "00000000-0000-0000-0000-000000000000",
+                    "objectId": "00000000-0000-0000-0000-000000000000"
+                }
+            },
+            "autoScalerProfile": {
+                "balance-similar-node-groups": "false",
+                "expander": "random",
+                "max-empty-bulk-delete": "10",
+                "max-graceful-termination-sec": "600",
+                "max-node-provision-time": "15m",
+                "max-total-unready-percentage": "45",
+                "new-pod-scale-up-delay": "0s",
+                "ok-total-unready-count": "3",
+                "scale-down-delay-after-add": "10m",
+                "scale-down-delay-after-delete": "10s",
+                "scale-down-delay-after-failure": "3m",
+                "scale-down-unneeded-time": "10m",
+                "scale-down-unready-time": "20m",
+                "scale-down-utilization-threshold": "0.5",
+                "scan-interval": "10s",
+                "skip-nodes-with-local-storage": "false",
+                "skip-nodes-with-system-pods": "true"
+            },
+            "autoUpgradeProfile": {
+                "upgradeChannel": "rapid"
+            }
+        },
+        "identity": {
+            "type": "UserAssigned",
+            "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-A": {
+                    "clientId": "00000000-0000-0000-0000-000000000000",
+                    "principalId": "00000000-0000-0000-0000-000000000000"
+                }
+            }
+        },
+        "sku": {
+            "name": "Basic",
+            "tier": "Free"
+        }
+    },
+    {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-L",
+        "location": "eastus",
+        "name": "cluster-L",
+        "tags": null,
+        "type": "Microsoft.ContainerService/ManagedClusters",
+        "properties": {
+            "provisioningState": "Succeeded",
+            "powerState": {
+                "code": "Running"
+            },
+            "kubernetesVersion": "1.21.2",
+            "dnsPrefix": "nnn-cluster-L",
+            "fqdn": "nnn-cluster-L-00000000.hcp.eastus.azmk8s.io",
+            "azurePortalFQDN": "nnn-cluster-L-00000000.portal.hcp.eastus.azmk8s.io",
+            "agentPoolProfiles": [
+                {
+                    "name": "system",
+                    "count": 2,
+                    "vmSize": "Standard_D2s_v3",
+                    "osDiskSizeGB": 32,
+                    "osDiskType": "Ephemeral",
+                    "kubeletDiskType": "OS",
+                    "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
+                    "maxPods": 50,
+                    "type": "VirtualMachineScaleSets",
+                    "maxCount": 2,
+                    "minCount": 2,
+                    "enableAutoScaling": true,
+                    "provisioningState": "Succeeded",
+                    "powerState": {
+                        "code": "Running"
+                    },
+                    "orchestratorVersion": "1.21.2",
+                    "mode": "System",
+                    "osType": "Linux",
+                    "osSKU": "Ubuntu",
+                    "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.07.17",
+                    "enableFIPS": false
+                }
+            ],
+            "windowsProfile": {
+                "adminUsername": "azureuser",
+                "enableCSIProxy": true
+            },
+            "servicePrincipalProfile": {
+                "clientId": "msi"
+            },
+            "addonProfiles": {
+                "aciConnectorLinux": {
+                    "enabled": true,
+                    "config": {
+                        "SubnetName": "subnet-B"
+                    },
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aciconnectorlinux-cluster-L",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                },
+                "azureKeyvaultSecretsProvider": {
+                    "enabled": true,
+                    "config": {
+                        "enableSecretRotation": "true"
+                    },
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/azurekeyvaultsecretsprovider-cluster-L",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                },
+                "azurepolicy": {
+                    "enabled": true,
+                    "config": null,
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/azurepolicy-cluster-L",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                },
+                "httpApplicationRouting": {
+                    "enabled": false,
+                    "config": {
+                        "HTTPApplicationRoutingZoneName": "nnnn.eastus.aksapp.io"
+                    }
+                },
+                "kubeDashboard": {
+                    "enabled": false,
+                    "config": null
+                },
+                "omsagent": {
+                    "enabled": true,
+                    "config": {
+                        "logAnalyticsWorkspaceResourceID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.operationalinsights/workspaces/defaultworkspace-00000000-0000-0000-0000-000000000000-eus"
+                    },
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/omsagent-cluster-L",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                },
+                "openServiceMesh": {
+                    "enabled": true,
+                    "config": null,
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/openservicemesh-cluster-L",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                }
+            },
+            "nodeResourceGroup": "test-rg",
+            "enableRBAC": true,
+            "enablePodSecurityPolicy": false,
+            "networkProfile": {
+                "networkPlugin": "azure",
+                "networkPolicy": "azure",
+                "loadBalancerSku": "Standard",
+                "loadBalancerProfile": {
+                    "managedOutboundIPs": {
+                        "count": 1
+                    },
+                    "effectiveOutboundIPs": [
+                        {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/publicIP-A"
+                        }
+                    ]
+                },
+                "serviceCidr": "192.168.0.0/16",
+                "dnsServiceIP": "192.168.0.4",
+                "dockerBridgeCidr": "172.17.0.1/16",
+                "outboundType": "loadBalancer"
+            },
+            "aadProfile": {
+                "managed": true,
+                "adminGroupObjectIDs": null,
+                "enableAzureRBAC": true,
+                "tenantID": "00000000-0000-0000-0000-000000000000"
+            },
+            "maxAgentPools": 100,
+            "identityProfile": {
+                "kubeletidentity": {
+                    "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cluster-L-agentpool",
+                    "clientId": "00000000-0000-0000-0000-000000000000",
+                    "objectId": "00000000-0000-0000-0000-000000000000"
+                }
+            },
+            "autoScalerProfile": {
+                "balance-similar-node-groups": "false",
+                "expander": "random",
+                "max-empty-bulk-delete": "10",
+                "max-graceful-termination-sec": "600",
+                "max-node-provision-time": "15m",
+                "max-total-unready-percentage": "45",
+                "new-pod-scale-up-delay": "0s",
+                "ok-total-unready-count": "3",
+                "scale-down-delay-after-add": "10m",
+                "scale-down-delay-after-delete": "10s",
+                "scale-down-delay-after-failure": "3m",
+                "scale-down-unneeded-time": "10m",
+                "scale-down-unready-time": "20m",
+                "scale-down-utilization-threshold": "0.5",
+                "scan-interval": "10s",
+                "skip-nodes-with-local-storage": "false",
+                "skip-nodes-with-system-pods": "true"
+            },
+            "autoUpgradeProfile": {
+                "upgradeChannel": "rapid"
+            }
+        },
+        "identity": {
+            "type": "UserAssigned",
+            "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-A": {
+                    "clientId": "00000000-0000-0000-0000-000000000000",
+                    "principalId": "00000000-0000-0000-0000-000000000000"
+                }
+            }
+        },
+        "sku": {
+            "name": "Basic",
+            "tier": "Free"
+        }
     }
 ]


### PR DESCRIPTION
## PR Summary

- New rules:
  - Azure Kubernetes Service:
    - Check clusters have the HTTP application routing add-on disabled. #1131
    - Check clusters use the Secrets Store CSI Driver add-on. #992
    - Check clusters autorotation with the Secrets Store CSI Driver add-on. #993
- Update rules:
  - Azure Kubernetes Service:
    - Promoted `Azure.AKS.AutoUpgrade` to GA rule set. #1130

Fixes #992 
Fixes #993 
Fixes #1130 
Fixes #1131 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
