### PR TITLE
Fixes equals parameter count mismatch #1137

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,11 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since v1.10.1:
+
+- Bug fixes:
+  - Fixed template function `equals` parameter count mismatch. [#1137](https://github.com/Azure/PSRule.Rules.Azure/issues/1137)
+
 ## v1.10.1
 
 What's changed since v1.10.0:

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -1039,6 +1039,10 @@ namespace PSRule.Rules.Azure.Data.Template
             else if (ExpressionHelpers.TryLong(args[0], out long _) || ExpressionHelpers.TryLong(args[1], out long _))
                 return false;
 
+            // JTokens
+            if (args[0] is JToken t1 && args[1] is JToken t2)
+                return JTokenEquals(t1, t2);
+
             // Objects
             return ObjectEquals(args[0], args[1]);
         }
@@ -1569,6 +1573,11 @@ namespace PSRule.Rules.Azure.Data.Template
                     return false;
             }
             return true;
+        }
+
+        private static bool JTokenEquals(JToken t1, JToken t2)
+        {
+            return JToken.DeepEquals(t1, t2);
         }
 
         private static bool ObjectEquals(object o1, object o2)

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -693,24 +693,28 @@ namespace PSRule.Rules.Azure
             Assert.True(actual3);
 
             // string
-            var actual4 = (bool)Functions.Equals(context, new object[] { "Test1", "Test2" });
-            var actual5 = (bool)Functions.Equals(context, new object[] { "Test2", "Test1" });
-            var actual6 = (bool)Functions.Equals(context, new object[] { "Test1", "Test1" });
-            Assert.False(actual4);
-            Assert.False(actual5);
-            Assert.True(actual6);
+            actual1 = (bool)Functions.Equals(context, new object[] { "Test1", "Test2" });
+            actual2 = (bool)Functions.Equals(context, new object[] { "Test2", "Test1" });
+            actual3 = (bool)Functions.Equals(context, new object[] { "Test1", "Test1" });
+            Assert.False(actual1);
+            Assert.False(actual2);
+            Assert.True(actual3);
 
             // array
-            var actual7 = (bool)Functions.Equals(context, new object[] { new string[] { "a", "a" }, new string[] { "b", "b" } });
-            var actual8 = (bool)Functions.Equals(context, new object[] { new string[] { "a", "b" }, new string[] { "a", "b" } });
-            Assert.False(actual7);
-            Assert.True(actual8);
+            actual1 = (bool)Functions.Equals(context, new object[] { new string[] { "a", "a" }, new string[] { "b", "b" } });
+            actual2 = (bool)Functions.Equals(context, new object[] { new string[] { "a", "b" }, new string[] { "a", "b" } });
+            actual3 = (bool)Functions.Equals(context, new object[] { new JArray(), JToken.Parse("[]") });
+            Assert.False(actual1);
+            Assert.True(actual2);
+            Assert.True(actual3);
 
             // object
-            var actual9 = (bool)Functions.Equals(context, new object[] { new TestLengthObject() { propC = "four", propD = null }, new TestLengthObject() { propD = null } });
-            var actual10 = (bool)Functions.Equals(context, new object[] { new TestLengthObject() { propD = null }, new TestLengthObject() { propD = null } });
-            Assert.False(actual9);
-            Assert.True(actual10);
+            actual1 = (bool)Functions.Equals(context, new object[] { new TestLengthObject() { propC = "four", propD = null }, new TestLengthObject() { propD = null } });
+            actual2 = (bool)Functions.Equals(context, new object[] { new TestLengthObject() { propD = null }, new TestLengthObject() { propD = null } });
+            actual3 = (bool)Functions.Equals(context, new object[] { new JObject(), JToken.Parse("{}") });
+            Assert.False(actual1);
+            Assert.True(actual2);
+            Assert.True(actual3);
         }
 
         [Fact]

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -67,6 +67,9 @@
     <None Update="Template.Parsing.10.Parameters.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Template.Parsing.11.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Template.Parsing.2.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Rules.Azure.Tests/Template.Parsing.11.json
+++ b/tests/PSRule.Rules.Azure.Tests/Template.Parsing.11.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "value1": {
+            "type": "object",
+            "defaultValue": {},
+            "metadata": {
+                "description": "An object value"
+            }
+        }
+    },
+    "functions": [],
+    "variables": {},
+    "resources": [
+        {
+            "type": "Namespace/resourceType",
+            "apiVersion": "2020-05-01",
+            "name": "resource",
+            "location": "region",
+            "properties": {
+                "settings": "[if(equals(parameters('value1'), createObject()), json('null'), parameters('value1'))]"
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -268,6 +268,18 @@ namespace PSRule.Rules.Azure
             Assert.False(actual3["_PSRule"].Value<JObject>().ContainsKey("issue"));
         }
 
+        [Fact]
+        public void EqualsEmptyObject()
+        {
+            var resources = ProcessTemplate(GetSourcePath("Template.Parsing.11.json"), null);
+            Assert.NotNull(resources);
+            Assert.Equal(2, resources.Length);
+
+            var actual1 = resources[1];
+            Assert.Equal("Namespace/resourceType", actual1["type"].Value<string>());
+            Assert.Equal(JTokenType.Null, actual1["properties"]["settings"].Type);
+        }
+
         #region Helper methods
 
         private static string GetSourcePath(string fileName)


### PR DESCRIPTION
## PR Summary

- Fixed template function `equals` parameter count mismatch.

Fixes #1137

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
