### PR TITLE
Refactored AKS powershell rules to YAML #1109

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -22,6 +22,14 @@ What's changed since pre-release v1.11.0-B2112073:
       - `Azure.FrontDoor.WAF.Mode`
       - `Azure.FrontDoor.WAF.Enabled`
       - `Azure.FrontDoor.WAF.Name`
+      - `Azure.AKS.MinNodeCount`
+      - `Azure.AKS.ManagedIdentity`
+      - `Azure.AKS.StandardLB`
+      - `Azure.AKS.AzurePolicyAddOn`
+      - `Azure.AKS.ManagedAAD`
+      - `Azure.AKS.AuthorizedIPs`
+      - `Azure.AKS.LocalAccounts`
+      - `Azure.AKS.AzureRBAC`
 - Bug fixes:
   - Fixed output of Bicep informational and warning messages in error stream. [#1157](https://github.com/Azure/PSRule.Rules.Azure/issues/1157)
   - Fixed obsolete flag for baseline `Azure.Preview_2021_12`. [#1166](https://github.com/Azure/PSRule.Rules.Azure/issues/1166)

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -5,11 +5,6 @@
 # Validation rules for Azure Kubernetes Service (AKS)
 #
 
-# Synopsis: AKS clusters should have minimum number of nodes for failover and updates
-Rule 'Azure.AKS.MinNodeCount' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $Assert.GreaterOrEqual($TargetObject, 'Properties.agentPoolProfiles[0].count', 3);
-}
-
 # Synopsis: AKS clusters should meet the minimum version
 Rule 'Azure.AKS.Version' -Type 'Microsoft.ContainerService/managedClusters', 'Microsoft.ContainerService/managedClusters/agentPools' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $minVersion = [Version]$Configuration.Azure_AKSMinimumVersion
@@ -90,41 +85,6 @@ Rule 'Azure.AKS.DNSPrefix' -Type 'Microsoft.ContainerService/managedClusters' -T
     # Alphanumerics and hyphens
     # Start and end with alphanumeric
     $Assert.Match($TargetObject, 'Properties.dnsPrefix', '^[A-Za-z0-9]((-|[A-Za-z0-9]){0,}[A-Za-z0-9]){0,}$');
-}
-
-# Synopsis: Configure AKS clusters to use managed identities for managing cluster infrastructure.
-Rule 'Azure.AKS.ManagedIdentity' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $Assert.In($TargetObject, 'Identity.Type', @('SystemAssigned', 'UserAssigned'));
-}
-
-# Synopsis: Use a Standard load-balancer with AKS clusters.
-Rule 'Azure.AKS.StandardLB' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $Assert.HasFieldValue($TargetObject, 'Properties.networkProfile.loadBalancerSku', 'standard');
-}
-
-# Synopsis: AKS clusters should use Azure Policy add-on.
-Rule 'Azure.AKS.AzurePolicyAddOn' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; ruleSet = '2020_12' } {
-    $Assert.HasFieldValue($TargetObject, 'Properties.addonProfiles.azurePolicy.enabled', $True);
-}
-
-# Synopsis: Use AKS-managed Azure AD to simplify authorization and improve security.
-Rule 'Azure.AKS.ManagedAAD' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; ruleSet = '2021_06'; } {
-    $Assert.HasFieldValue($TargetObject, 'Properties.aadProfile.managed', $True);
-}
-
-# Synopsis: Restrict access to API server endpoints to authorized IP addresses.
-Rule 'Azure.AKS.AuthorizedIPs' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; ruleSet = '2021_06'; } {
-    $Assert.GreaterOrEqual($TargetObject, 'Properties.apiServerAccessProfile.authorizedIPRanges', 1);
-}
-
-# Synopsis: Enforce named user accounts with RBAC assigned permissions.
-Rule 'Azure.AKS.LocalAccounts' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'preview'; ruleSet = '2021_06'; } {
-    $Assert.HasFieldValue($TargetObject, 'Properties.disableLocalAccounts', $True);
-}
-
-# Synopsis: Use Azure RBAC for Kubernetes Authorization with AKS clusters.
-Rule 'Azure.AKS.AzureRBAC' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; ruleSet = '2021_06'; } {
-    $Assert.HasFieldValue($TargetObject, 'Properties.aadProfile.enableAzureRbac', $True);
 }
 
 # Synopsis: Use Autoscaling to ensure AKS cluster is running efficiently with the right number of nodes for the workloads present.

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.yaml
@@ -8,6 +8,56 @@
 #region Rules
 
 ---
+# Synopsis: AKS clusters should have minimum number of nodes for failover and updates
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AKS.MinNodeCount
+  tags:
+    release: 'GA'
+    ruleSet: '2020_06'
+spec:
+  type:
+  - Microsoft.ContainerService/managedClusters
+  condition:
+    field: 'Properties.agentPoolProfiles[0].count'
+    greaterOrEquals: 3
+
+---
+# Synopsis: Configure AKS clusters to use managed identities for managing cluster infrastructure.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AKS.ManagedIdentity
+  tags:
+    release: 'GA'
+    ruleSet: '2020_06'
+spec:
+  type:
+  - Microsoft.ContainerService/managedClusters
+  condition:
+    field: 'Identity.Type'
+    in:
+      - 'SystemAssigned'
+      - 'UserAssigned'
+
+---
+# Synopsis: Use a Standard load-balancer with AKS clusters.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AKS.StandardLB
+  tags:
+    release: 'GA'
+    ruleSet: '2020_06'
+spec:
+  type:
+  - Microsoft.ContainerService/managedClusters
+  condition:
+    field: 'Properties.networkProfile.loadBalancerSku'
+    equals: 'standard'
+
+---
 # Synopsis: Deploy AKS clusters with Network Policies enabled.
 apiVersion: github.com/microsoft/PSRule/v1
 kind: Rule
@@ -24,6 +74,86 @@ spec:
     in:
     - azure
     - calico
+
+---
+# Synopsis: AKS clusters should use Azure Policy add-on.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AKS.AzurePolicyAddOn
+  tags:
+    release: 'GA'
+    ruleSet: '2020_12'
+spec:
+  type:
+  - Microsoft.ContainerService/managedClusters
+  condition:
+    field: 'Properties.addonProfiles.azurePolicy.enabled'
+    equals: true
+
+---
+# Synopsis: Use AKS-managed Azure AD to simplify authorization and improve security.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AKS.ManagedAAD
+  tags:
+    release: 'GA'
+    ruleSet: '2021_06'
+spec:
+  type:
+  - Microsoft.ContainerService/managedClusters
+  condition:
+    field: 'Properties.aadProfile.managed'
+    equals: true
+
+---
+# Synopsis: Restrict access to API server endpoints to authorized IP addresses.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AKS.AuthorizedIPs
+  tags:
+    release: 'GA'
+    ruleSet: '2021_06'
+spec:
+  type:
+  - Microsoft.ContainerService/managedClusters
+  condition:
+    field: 'Properties.apiServerAccessProfile.authorizedIPRanges'
+    greaterOrEquals: 1
+
+---
+# Synopsis: Enforce named user accounts with RBAC assigned permissions.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AKS.LocalAccounts
+  tags:
+    release: 'preview'
+    ruleSet: '2021_06'
+spec:
+  type:
+  - Microsoft.ContainerService/managedClusters
+  condition:
+    field: 'Properties.disableLocalAccounts'
+    equals: true
+
+---
+# Synopsis: Use Azure RBAC for Kubernetes Authorization with AKS clusters.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AKS.AzureRBAC
+  tags:
+    release: 'GA'
+    ruleSet: '2021_06'
+spec:
+  type:
+  - Microsoft.ContainerService/managedClusters
+  condition:
+    field: 'Properties.aadProfile.enableAzureRbac'
+    equals: true
 
 ---
 # Synopsis: Deploy AKS clusters with Secrets Store CSI Driver and store Secrets in Key Vayult.


### PR DESCRIPTION
## PR Summary

- Rule refactoring of AKS rules from PowerShell to YAML. #1109
  - The following rules where refactored:
    - `Azure.AKS.MinNodeCount`
    - `Azure.AKS.ManagedIdentity`
    - `Azure.AKS.StandardLB`
    - `Azure.AKS.AzurePolicyAddOn`
    - `Azure.AKS.ManagedAAD`
    - `Azure.AKS.AuthorizedIPs`
    - `Azure.AKS.LocalAccounts`
    - `Azure.AKS.AzureRBAC`

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [ ] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
