### PR TITLE
Pre-release v1.11.0-B2112112

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,10 +7,12 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.11.0-B2112112 (pre-release)
+
 What's changed since pre-release v1.11.0-B2112104:
 
-- New rules
-  - Azure Redis Cache
+- New rules:
+  - Azure Redis Cache:
     - Use availability zones for Azure Cache for Redis for regions that support it. [#1078](https://github.com/Azure/PSRule.Rules.Azure/issues/1078)
       - `Azure.Redis.AvailabilityZone`
       - `Azure.RedisEnterprise.Zones`


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.11.0-B2112104:

- New rules:
  - Azure Redis Cache:
    - Use availability zones for Azure Cache for Redis for regions that support it. #1078
      - `Azure.Redis.AvailabilityZone`
      - `Azure.RedisEnterprise.Zones`

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
