### PR TITLE
Replace Compare-Object with SetOf assertion for LB and Public IP AZ rules

### DIFF
--- a/src/PSRule.Rules.Azure/rules/Azure.PublicIP.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.PublicIP.Rule.ps1
@@ -51,15 +51,15 @@ Rule 'Azure.PublicIP.AvailabilityZone' -Type 'Microsoft.Network/publicIPAddresse
         return $Assert.Pass();
     }
 
-    $zonesNotSet = $Assert.NullOrEmpty($TargetObject, 'zones').Result;
-    $zoneRedundant = -not ($TargetObject.zones -and (Compare-Object -ReferenceObject $availabilityZones -DifferenceObject $TargetObject.zones));
-
-    $Assert.Create(
-        (-not $zonesNotSet -and $zoneRedundant), 
+    $Assert.AllOf(
+        $Assert.HasFieldValue($TargetObject, 'zones'),
+        $Assert.SetOf($TargetObject, 'zones', @('1', '2', '3'))
+    ).Reason(
         $LocalizedData.PublicIPAvailabilityZone, 
         $TargetObject.name, 
         $TargetObject.Location
-    );
+    )
+
 } -Configure @{ AZURE_PUBLICIP_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST = @() }
 
 # Synopsis: Public IP addresses should be deployed with Standard SKU for production workloads.

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Automation.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Automation.Tests.ps1
@@ -54,14 +54,14 @@ Describe 'Azure.Automation' -Tag Automation {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'automation-b';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'automation-a', 'automation-b';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -Be 'automation-a', 'automation-c', 'automation-d', 'automation-e', 'automation-f', 'automation-g';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -Be 'automation-c', 'automation-d', 'automation-e', 'automation-f', 'automation-g';
         }
 
         It 'Azure.Automation.ManagedIdentity' {


### PR DESCRIPTION
## PR Summary

Just a small change to replace `Compare-Object` with assertions from LB and Public IP AZ rules.

Let me know if this looks ok to you.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [ ] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
