### PR TITLE
Release v1.11.1

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,10 +7,12 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.11.1
+
 What's changed since v1.11.0:
 
-- Big fixes:
-  - Ensure `Azure.AKS.CNISubnetSize` rule uses CNI selector. [#1178](https://github.com/Azure/PSRule.Rules.Azure/issues/1178)
+- Bug fixes:
+  - Fixed `Azure.AKS.CNISubnetSize` rule to use CNI selector. [#1178](https://github.com/Azure/PSRule.Rules.Azure/issues/1178)
 
 ## v1.11.0
 


### PR DESCRIPTION
## PR Summary

What's changed since v1.11.0:

- Bug fixes:
  - Fixed `Azure.AKS.CNISubnetSize` rule to use CNI selector. #1178

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
