### PR TITLE
Updated AKS version to latest #1188 #941

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -1,11 +1,34 @@
 # Change log
 
+See [upgrade notes][1] for helpful information when upgrading from previous versions.
+
+  [1]: https://azure.github.io/PSRule.Rules.Azure/upgrade-notes/
+
 **Important notes**:
 
 - Issue #741: `Could not load file or assembly YamlDotNet`.
 See [troubleshooting guide] for a workaround to this issue.
+- The configuration option `Azure_AKSMinimumVersion` is replaced with `AZURE_AKS_CLUSTER_MINIMUM_VERSION`.
+  If you have this option configured, please update it to `AZURE_AKS_CLUSTER_MINIMUM_VERSION`.
+  Support for `Azure_AKSMinimumVersion` will be removed in v2.
 
 ## Unreleased
+
+What's changed since v1.11.1:
+
+- Updated rules:
+  - Azure Kubernetes Service:
+    - Updated `Azure.AKS.Version` to use latest stable version `1.21.7`. [#1188](https://github.com/Azure/PSRule.Rules.Azure/issues/1188)
+      - Pinned latest GA baseline `Azure.GA_2021_12` to previous set version `1.20.5`.
+      - Use `AZURE_AKS_CLUSTER_MINIMUM_VERSION` to configure the minimum version of the cluster.
+- General improvements:
+  - **Important change:** Replaced `Azure_AKSMinimumVersion` option with `AZURE_AKS_CLUSTER_MINIMUM_VERSION`. [#941](https://github.com/Azure/PSRule.Rules.Azure/issues/941)
+    - For compatiblity, if `Azure_AKSMinimumVersion` is set it will be used instead of `AZURE_AKS_CLUSTER_MINIMUM_VERSION`.
+    - If only `AZURE_AKS_CLUSTER_MINIMUM_VERSION` is set, this value will be used.
+    - The default will be used neither options are configured.
+    - If `Azure_AKSMinimumVersion` is set a warning will be generated until the configuration is removed.
+    - Support for `Azure_AKSMinimumVersion` is deprecated and will be removed in v2.
+    - See [upgrade notes][1] for details.
 
 ## v1.11.1
 

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -23,7 +23,7 @@ What's changed since v1.11.1:
       - Use `AZURE_AKS_CLUSTER_MINIMUM_VERSION` to configure the minimum version of the cluster.
 - General improvements:
   - **Important change:** Replaced `Azure_AKSMinimumVersion` option with `AZURE_AKS_CLUSTER_MINIMUM_VERSION`. [#941](https://github.com/Azure/PSRule.Rules.Azure/issues/941)
-    - For compatiblity, if `Azure_AKSMinimumVersion` is set it will be used instead of `AZURE_AKS_CLUSTER_MINIMUM_VERSION`.
+    - For compatibility, if `Azure_AKSMinimumVersion` is set it will be used instead of `AZURE_AKS_CLUSTER_MINIMUM_VERSION`.
     - If only `AZURE_AKS_CLUSTER_MINIMUM_VERSION` is set, this value will be used.
     - The default will be used neither options are configured.
     - If `Azure_AKSMinimumVersion` is set a warning will be generated until the configuration is removed.

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -2,7 +2,7 @@
 
 See [upgrade notes][1] for helpful information when upgrading from previous versions.
 
-  [1]: https://azure.github.io/PSRule.Rules.Azure/upgrade-notes/
+  [1]: upgrade-notes.md
 
 **Important notes**:
 
@@ -19,7 +19,7 @@ What's changed since v1.11.1:
 - Updated rules:
   - Azure Kubernetes Service:
     - Updated `Azure.AKS.Version` to use latest stable version `1.21.7`. [#1188](https://github.com/Azure/PSRule.Rules.Azure/issues/1188)
-      - Pinned latest GA baseline `Azure.GA_2021_12` to previous set version `1.20.5`.
+      - Pinned latest GA baseline `Azure.GA_2021_12` to previous version `1.20.5`.
       - Use `AZURE_AKS_CLUSTER_MINIMUM_VERSION` to configure the minimum version of the cluster.
 - General improvements:
   - **Important change:** Replaced `Azure_AKSMinimumVersion` option with `AZURE_AKS_CLUSTER_MINIMUM_VERSION`. [#941](https://github.com/Azure/PSRule.Rules.Azure/issues/941)

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -17,7 +17,7 @@ Until v2, the old option names are still work and will take precedence if new an
 
 New name                                  | Old name                             | Available from
 --------                                  | --------                             | --------------
-`AZURE_AKS_CLUSTER_MINIMUM_VERSION`       | `Azure_AKSMinimumVersion`            | v1.12.0 - see [upgrade notes][1] for details.
+`AZURE_AKS_CLUSTER_MINIMUM_VERSION`       | `Azure_AKSMinimumVersion`            | :octicons-milestone-24: v1.12.0
 `AZURE_AKS_POOL_MINIMUM_MAXPODS`          | `Azure_AKSNodeMinimumMaxPods`        | _TBA - not available_
 `AZURE_RESOURCE_ALLOWED_LOCATIONS`        | `Azure_AllowedRegions`               | _TBA - not available_
 `AZURE_APIM_MINIMUM_CERTIFICATE_LIFETIME` | `Azure_MinimumCertificateLifetime`   | _TBA - not available_
@@ -25,10 +25,12 @@ New name                                  | Old name                            
 !!! Note
     Configuration options marked _TBA_ are not available yet.
     Please use the old names until they are available.
-    Check the change log and the release notes for more information on a future release.
+    Check the [change log][1] and the [upgrade notes][2] for more information on a future release.
 
 !!! Important
     New option names will work from the release specified by _Available from_.
     Configuring these options prior to that release will have no affect.
+    For details on configuring these options see [upgrade notes][2] for details.
 
-  [1]: upgrade-notes.md#realigned-configuration-option-names
+  [1]: CHANGELOG-v1.md
+  [2]: upgrade-notes.md#realigned-configuration-option-names

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -8,7 +8,7 @@ author: BernieWhite
 
 ### Realigned configuration option names
 
-The following configuration options will be renamed in upcomming releases of PSRule for Azure.
+The following configuration options will be renamed in upcoming releases of PSRule for Azure.
 This is part of a ongoing effort to align the naming of configuration options across PSRule for Azure.
 
 We plan to have all the old option names renamed and they will not longer work from v2.

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,0 +1,34 @@
+---
+author: BernieWhite
+---
+
+# Deprecations
+
+## Deprecations for v2.0.0
+
+### Realigned configuration option names
+
+The following configuration options will be renamed in upcomming releases of PSRule for Azure.
+This is part of a ongoing effort to align the naming of configuration options across PSRule for Azure.
+
+We plan to have all the old option names renamed and they will not longer work from v2.
+To upgrade use the new names instead.
+Until v2, the old option names are still work and will take precedence if new and old are configured.
+
+New name                                  | Old name                             | Available from
+--------                                  | --------                             | --------------
+`AZURE_AKS_CLUSTER_MINIMUM_VERSION`       | `Azure_AKSMinimumVersion`            | v1.12.0 - see [upgrade notes][1] for details.
+`AZURE_AKS_POOL_MINIMUM_MAXPODS`          | `Azure_AKSNodeMinimumMaxPods`        | _TBA - not available_
+`AZURE_RESOURCE_ALLOWED_LOCATIONS`        | `Azure_AllowedRegions`               | _TBA - not available_
+`AZURE_APIM_MINIMUM_CERTIFICATE_LIFETIME` | `Azure_MinimumCertificateLifetime`   | _TBA - not available_
+
+!!! Note
+    Configuration options marked _TBA_ are not available yet.
+    Please use the old names until they are available.
+    Check the change log and the release notes for more information on a future release.
+
+!!! Important
+    New option names will work from the release specified by _Available from_.
+    Configuring these options prior to that release will have no affect.
+
+  [1]: upgrade-notes.md#realigned-configuration-option-names

--- a/docs/en/rules/Azure.AKS.Version.md
+++ b/docs/en/rules/Azure.AKS.Version.md
@@ -1,7 +1,7 @@
 ---
 severity: Important
 pillar: Reliability
-category: Design
+category: Requirements
 resource: Azure Kubernetes Service
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AKS.Version/
 ms-content-id: b0bd4e66-af2f-4d0a-82ae-e4738418bb7e
@@ -18,31 +18,183 @@ AKS control plane and nodes pools should use a current stable release.
 The AKS support policy for Kubernetes is include N-2 stable minor releases.
 Additionally two patch releases for each minor version are supported.
 
-A list of available Kubernetes versions can be found using the `az aks get-versions -o table --location <location>` CLI command.
-
 ## RECOMMENDATION
 
 Consider upgrading AKS control plane and nodes pools to the latest stable version of Kubernetes.
 
 ## EXAMPLES
 
+### Configure with Azure template
+
+To deploy AKS clusters that pass this rule:
+
+- Set `Properties.kubernetesVersion` to a newer stable version.
+
+For example:
+
+```json
+{
+    "type": "Microsoft.ContainerService/managedClusters",
+    "apiVersion": "2021-10-01",
+    "name": "[parameters('clusterName')]",
+    "location": "[parameters('location')]",
+    "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+            "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')))]": {}
+        }
+    },
+    "properties": {
+        "kubernetesVersion": "1.21.7",
+        "enableRBAC": true,
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": "[variables('allPools')]",
+        "aadProfile": {
+            "managed": true,
+            "enableAzureRBAC": true,
+            "adminGroupObjectIDs": "[parameters('clusterAdmins')]",
+            "tenantID": "[subscription().tenantId]"
+        },
+        "networkProfile": {
+            "networkPlugin": "azure",
+            "networkPolicy": "azure",
+            "loadBalancerSku": "standard",
+            "serviceCidr": "[variables('serviceCidr')]",
+            "dnsServiceIP": "[variables('dnsServiceIP')]",
+            "dockerBridgeCidr": "[variables('dockerBridgeCidr')]"
+        },
+        "autoUpgradeProfile": {
+            "upgradeChannel": "stable"
+        },
+        "addonProfiles": {
+            "httpApplicationRouting": {
+                "enabled": false
+            },
+            "azurepolicy": {
+                "enabled": true,
+                "config": {
+                    "version": "v2"
+                }
+            },
+            "omsagent": {
+                "enabled": true,
+                "config": {
+                    "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
+                }
+            },
+            "kubeDashboard": {
+                "enabled": false
+            },
+            "azureKeyvaultSecretsProvider": {
+                "enabled": true,
+                "config": {
+                    "enableSecretRotation": "true"
+                }
+            }
+        },
+        "podIdentityProfile": {
+            "enabled": true
+        }
+    },
+    "tags": "[parameters('tags')]",
+    "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
+    ]
+}
+```
+
+### Configure with Bicep
+
+To deploy AKS clusters that pass this rule:
+
+- Set `Properties.kubernetesVersion` to a newer stable version.
+
+For example:
+
+```bicep
+resource cluster 'Microsoft.ContainerService/managedClusters@2021-10-01' = {
+  location: location
+  name: clusterName
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${identity.id}': {}
+    }
+  }
+  properties: {
+    kubernetesVersion: '1.21.7'
+    enableRBAC: true
+    dnsPrefix: dnsPrefix
+    agentPoolProfiles: allPools
+    aadProfile: {
+      managed: true
+      enableAzureRBAC: true
+      adminGroupObjectIDs: clusterAdmins
+      tenantID: subscription().tenantId
+    }
+    networkProfile: {
+      networkPlugin: 'azure'
+      networkPolicy: 'azure'
+      loadBalancerSku: 'standard'
+      serviceCidr: serviceCidr
+      dnsServiceIP: dnsServiceIP
+      dockerBridgeCidr: dockerBridgeCidr
+    }
+    autoUpgradeProfile: {
+      upgradeChannel: 'stable'
+    }
+    addonProfiles: {
+      httpApplicationRouting: {
+        enabled: false
+      }
+      azurepolicy: {
+        enabled: true
+        config: {
+          version: 'v2'
+        }
+      }
+      omsagent: {
+        enabled: true
+        config: {
+          logAnalyticsWorkspaceResourceID: workspaceId
+        }
+      }
+      kubeDashboard: {
+        enabled: false
+      }
+      azureKeyvaultSecretsProvider: {
+        enabled: true
+        config: {
+          enableSecretRotation: 'true'
+        }
+      }
+    }
+    podIdentityProfile: {
+      enabled: true
+    }
+  }
+  tags: tags
+}
+```
+
 ### Configure with Azure CLI
 
 ```bash
-az aks upgrade -n '<name>' -g '<resource_group>' --kubernetes-version '<version>'
+az aks upgrade -n '<name>' -g '<resource_group>' --kubernetes-version '1.21.7'
 ```
 
 ### Configure with Azure PowerShell
 
 ```powershell
-Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -KubernetesVersion '<version>'
+Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -KubernetesVersion '1.21.7'
 ```
 
 ## NOTES
 
+A list of available Kubernetes versions can be found using the `az aks get-versions -o table --location <location>` CLI command.
 To configure this rule:
 
-- Override the `Azure_AKSMinimumVersion` configuration value with the minimum Kubernetes version.
+- Override the `AZURE_AKS_CLUSTER_MINIMUM_VERSION` configuration value with the minimum Kubernetes version.
 
 ## LINKS
 

--- a/docs/en/rules/module.md
+++ b/docs/en/rules/module.md
@@ -235,7 +235,6 @@ Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.AKS.AvailabilityZone](Azure.AKS.AvailabilityZone.md) | AKS clusters deployed with virtual machine scale sets should use availability zones in supported regions for high availability. | Important
 [Azure.AKS.PoolVersion](Azure.AKS.PoolVersion.md) | AKS node pools should match Kubernetes control plane version. | Important
-[Azure.AKS.Version](Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important
 [Azure.APIM.AvailabilityZone](Azure.APIM.AvailabilityZone.md) | API management services deployed with Premium SKU should use availability zones in supported regions for high availability. | Important
 [Azure.AppGw.AvailabilityZone](Azure.AppGw.AvailabilityZone.md) | Application gateways deployed with V2 SKU(Standard_v2, WAF_v2) should use availability zones in supported regions for high availability. | Important
 [Azure.LB.AvailabilityZone](Azure.LB.AvailabilityZone.md) | Load balancers deployed with Standard SKU should be zone-redundant for high availability. | Important
@@ -266,6 +265,7 @@ Name | Synopsis | Severity
 Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.ACR.MinSku](Azure.ACR.MinSku.md) | ACR should use the Premium or Standard SKU for production deployments. | Important
+[Azure.AKS.Version](Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important
 [Azure.AppConfig.SKU](Azure.AppConfig.SKU.md) | App Configuration should use a minimum size of Standard. | Important
 
 ### Resiliency and dependencies

--- a/docs/examples-aks.bicep
+++ b/docs/examples-aks.bicep
@@ -46,7 +46,7 @@ param systemPoolMin int
 param systemPoolMax int = 3
 
 @description('The version of Kubernetes.')
-param kubernetesVersion string = '1.19.7'
+param kubernetesVersion string = '1.21.7'
 
 @description('Maximum number of pods that can run on nodes in the system pool.')
 @minValue(30)
@@ -148,7 +148,7 @@ resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' 
 }
 
 // Cluster
-resource cluster 'Microsoft.ContainerService/managedClusters@2021-07-01' = {
+resource cluster 'Microsoft.ContainerService/managedClusters@2021-10-01' = {
   location: location
   name: clusterName
   identity: {

--- a/docs/examples-aks.json
+++ b/docs/examples-aks.json
@@ -1,269 +1,268 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "metadata": {
-        "_generator": {
-            "name": "bicep",
-            "version": "0.4.1008.15138",
-            "templateHash": "12910428772196393994"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1124.51302",
+      "templateHash": "5068084259558245402"
+    }
+  },
+  "parameters": {
+    "clusterName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the AKS cluster."
+      }
     },
-    "parameters": {
-        "clusterName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the AKS cluster."
-            }
-        },
-        "location": {
-            "type": "string",
-            "defaultValue": "[resourceGroup().location]",
-            "metadata": {
-                "description": "Optional. The Azure region to deploy to.",
-                "strongType": "location",
-                "example": "EastUS",
-                "ignore": true
-            }
-        },
-        "identityName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the user assigned identity to used for cluster control plane."
-            }
-        },
-        "dnsPrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "A DNS prefix to use with hosted Kubernetes API server FQDN."
-            }
-        },
-        "osDiskSizeGB": {
-            "type": "int",
-            "defaultValue": 32,
-            "minValue": 0,
-            "metadata": {
-                "description": "Disk size (in GiB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize."
-            }
-        },
-        "systemVMSize": {
-            "type": "string",
-            "defaultValue": "Standard_D2s_v3",
-            "metadata": {
-                "description": "The size of cluster VM instances."
-            }
-        },
-        "systemPoolMin": {
-            "type": "int",
-            "maxValue": 50,
-            "minValue": 1,
-            "metadata": {
-                "description": "The minimum number of agent nodes for the system pool.",
-                "example": 3
-            }
-        },
-        "systemPoolMax": {
-            "type": "int",
-            "defaultValue": 3,
-            "maxValue": 50,
-            "minValue": 1,
-            "metadata": {
-                "description": "The maximum number of agent nodes for the system pool.",
-                "example": 3
-            }
-        },
-        "kubernetesVersion": {
-            "type": "string",
-            "defaultValue": "1.19.7",
-            "metadata": {
-                "description": "The version of Kubernetes."
-            }
-        },
-        "systemPoolMaxPods": {
-            "type": "int",
-            "defaultValue": 50,
-            "minValue": 30,
-            "metadata": {
-                "description": "Maximum number of pods that can run on nodes in the system pool."
-            }
-        },
-        "workspaceId": {
-            "type": "string",
-            "metadata": {
-                "description": "Specify the resource id of the OMS workspace.",
-                "strongType": "Microsoft.OperationalInsights/workspaces"
-            }
-        },
-        "vnetId": {
-            "type": "string",
-            "metadata": {
-                "description": "The resource Id for the virtual network where the cluster and ACI will be deployed into.",
-                "strongType": "Microsoft.Network/virtualNetworks"
-            }
-        },
-        "systemPoolSubnet": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the subnet do deploy cluster resources."
-            }
-        },
-        "clusterAdmins": {
-            "type": "array",
-            "defaultValue": [],
-            "metadata": {
-                "description": "The object Ids of groups that will be added with the cluster admin role."
-            }
-        },
-        "pools": {
-            "type": "array",
-            "defaultValue": [],
-            "metadata": {
-                "description": "User cluster pools.",
-                "example": [
-                    {
-                        "name": "",
-                        "priority": "Regular",
-                        "osType": "Linux",
-                        "minCount": 0,
-                        "maxCount": 2,
-                        "vmSize": "Standard_D2s_v3"
-                    }
-                ]
-            }
-        },
-        "tags": {
-            "type": "object",
-            "metadata": {
-                "description": "Tags to apply to the resource.",
-                "example": {
-                    "service": "container-platform",
-                    "env": "prod"
-                }
-            }
-        }
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Optional. The Azure region to deploy to.",
+        "strongType": "location",
+        "example": "EastUS",
+        "ignore": true
+      }
     },
-    "functions": [],
-    "variables": {
-        "copy": [
-            {
-                "name": "userPools",
-                "count": "[length(range(0, length(parameters('pools'))))]",
-                "input": {
-                    "name": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].name]",
-                    "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
-                    "count": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].minCount]",
-                    "minCount": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].minCount]",
-                    "maxCount": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].maxCount]",
-                    "enableAutoScaling": true,
-                    "maxPods": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].maxPods]",
-                    "vmSize": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].vmSize]",
-                    "osType": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].osType]",
-                    "type": "VirtualMachineScaleSets",
-                    "vnetSubnetID": "[variables('clusterSubnetId')]",
-                    "mode": "User",
-                    "osDiskType": "Ephemeral",
-                    "scaleSetPriority": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].priority]"
-                }
-            }
-        ],
-        "serviceCidr": "192.168.0.0/16",
-        "dnsServiceIP": "192.168.0.4",
-        "dockerBridgeCidr": "172.17.0.1/16",
-        "clusterSubnetId": "[format('{0}/subnets/{1}', parameters('vnetId'), parameters('systemPoolSubnet'))]",
-        "allPools": "[union(variables('systemPools'), variables('userPools'))]",
-        "systemPools": [
-            {
-                "name": "system",
-                "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
-                "count": "[parameters('systemPoolMin')]",
-                "minCount": "[parameters('systemPoolMin')]",
-                "maxCount": "[parameters('systemPoolMax')]",
-                "enableAutoScaling": true,
-                "maxPods": "[parameters('systemPoolMaxPods')]",
-                "vmSize": "[parameters('systemVMSize')]",
-                "osType": "Linux",
-                "type": "VirtualMachineScaleSets",
-                "vnetSubnetID": "[variables('clusterSubnetId')]",
-                "mode": "System",
-                "osDiskType": "Ephemeral",
-                "scaleSetPriority": "Regular"
-            }
+    "identityName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the user assigned identity to used for cluster control plane."
+      }
+    },
+    "dnsPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "A DNS prefix to use with hosted Kubernetes API server FQDN."
+      }
+    },
+    "osDiskSizeGB": {
+      "type": "int",
+      "defaultValue": 32,
+      "minValue": 0,
+      "metadata": {
+        "description": "Disk size (in GiB) to provision for each of the agent pool nodes. This value ranges from 0 to 1023. Specifying 0 will apply the default disk size for that agentVMSize."
+      }
+    },
+    "systemVMSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2s_v3",
+      "metadata": {
+        "description": "The size of cluster VM instances."
+      }
+    },
+    "systemPoolMin": {
+      "type": "int",
+      "maxValue": 50,
+      "minValue": 1,
+      "metadata": {
+        "description": "The minimum number of agent nodes for the system pool.",
+        "example": 3
+      }
+    },
+    "systemPoolMax": {
+      "type": "int",
+      "defaultValue": 3,
+      "maxValue": 50,
+      "minValue": 1,
+      "metadata": {
+        "description": "The maximum number of agent nodes for the system pool.",
+        "example": 3
+      }
+    },
+    "kubernetesVersion": {
+      "type": "string",
+      "defaultValue": "1.21.7",
+      "metadata": {
+        "description": "The version of Kubernetes."
+      }
+    },
+    "systemPoolMaxPods": {
+      "type": "int",
+      "defaultValue": 50,
+      "minValue": 30,
+      "metadata": {
+        "description": "Maximum number of pods that can run on nodes in the system pool."
+      }
+    },
+    "workspaceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specify the resource id of the OMS workspace.",
+        "strongType": "Microsoft.OperationalInsights/workspaces"
+      }
+    },
+    "vnetId": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource Id for the virtual network where the cluster and ACI will be deployed into.",
+        "strongType": "Microsoft.Network/virtualNetworks"
+      }
+    },
+    "systemPoolSubnet": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the subnet do deploy cluster resources."
+      }
+    },
+    "clusterAdmins": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "The object Ids of groups that will be added with the cluster admin role."
+      }
+    },
+    "pools": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "User cluster pools.",
+        "example": [
+          {
+            "name": "",
+            "priority": "Regular",
+            "osType": "Linux",
+            "minCount": 0,
+            "maxCount": 2,
+            "vmSize": "Standard_D2s_v3"
+          }
         ]
+      }
     },
-    "resources": [
-        {
-            "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
-            "apiVersion": "2018-11-30",
-            "name": "[parameters('identityName')]",
-            "location": "[parameters('location')]",
-            "tags": "[parameters('tags')]"
-        },
-        {
-            "type": "Microsoft.ContainerService/managedClusters",
-            "apiVersion": "2021-07-01",
-            "name": "[parameters('clusterName')]",
-            "location": "[parameters('location')]",
-            "identity": {
-                "type": "UserAssigned",
-                "userAssignedIdentities": {
-                    "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')))]": {}
-                }
-            },
-            "properties": {
-                "kubernetesVersion": "[parameters('kubernetesVersion')]",
-                "enableRBAC": true,
-                "dnsPrefix": "[parameters('dnsPrefix')]",
-                "agentPoolProfiles": "[variables('allPools')]",
-                "aadProfile": {
-                    "managed": true,
-                    "enableAzureRBAC": true,
-                    "adminGroupObjectIDs": "[parameters('clusterAdmins')]",
-                    "tenantID": "[subscription().tenantId]"
-                },
-                "networkProfile": {
-                    "networkPlugin": "azure",
-                    "networkPolicy": "azure",
-                    "loadBalancerSku": "standard",
-                    "serviceCidr": "[variables('serviceCidr')]",
-                    "dnsServiceIP": "[variables('dnsServiceIP')]",
-                    "dockerBridgeCidr": "[variables('dockerBridgeCidr')]"
-                },
-                "autoUpgradeProfile": {
-                    "upgradeChannel": "stable"
-                },
-                "addonProfiles": {
-                    "httpApplicationRouting": {
-                        "enabled": false
-                    },
-                    "azurepolicy": {
-                        "enabled": true,
-                        "config": {
-                            "version": "v2"
-                        }
-                    },
-                    "omsagent": {
-                        "enabled": true,
-                        "config": {
-                            "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
-                        }
-                    },
-                    "kubeDashboard": {
-                        "enabled": false
-                    },
-                    "azureKeyvaultSecretsProvider": {
-                        "enabled": true,
-                        "config": {
-                            "enableSecretRotation": "true"
-                        }
-                    }
-                },
-                "podIdentityProfile": {
-                    "enabled": true
-                }
-            },
-            "tags": "[parameters('tags')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
-            ]
+    "tags": {
+      "type": "object",
+      "metadata": {
+        "description": "Tags to apply to the resource.",
+        "example": {
+          "service": "container-platform",
+          "env": "prod"
         }
+      }
+    }
+  },
+  "variables": {
+    "copy": [
+      {
+        "name": "userPools",
+        "count": "[length(range(0, length(parameters('pools'))))]",
+        "input": {
+          "name": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].name]",
+          "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+          "count": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].minCount]",
+          "minCount": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].minCount]",
+          "maxCount": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].maxCount]",
+          "enableAutoScaling": true,
+          "maxPods": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].maxPods]",
+          "vmSize": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].vmSize]",
+          "osType": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].osType]",
+          "type": "VirtualMachineScaleSets",
+          "vnetSubnetID": "[variables('clusterSubnetId')]",
+          "mode": "User",
+          "osDiskType": "Ephemeral",
+          "scaleSetPriority": "[parameters('pools')[range(0, length(parameters('pools')))[copyIndex('userPools')]].priority]"
+        }
+      }
+    ],
+    "serviceCidr": "192.168.0.0/16",
+    "dnsServiceIP": "192.168.0.4",
+    "dockerBridgeCidr": "172.17.0.1/16",
+    "clusterSubnetId": "[format('{0}/subnets/{1}', parameters('vnetId'), parameters('systemPoolSubnet'))]",
+    "allPools": "[union(variables('systemPools'), variables('userPools'))]",
+    "systemPools": [
+      {
+        "name": "system",
+        "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+        "count": "[parameters('systemPoolMin')]",
+        "minCount": "[parameters('systemPoolMin')]",
+        "maxCount": "[parameters('systemPoolMax')]",
+        "enableAutoScaling": true,
+        "maxPods": "[parameters('systemPoolMaxPods')]",
+        "vmSize": "[parameters('systemVMSize')]",
+        "osType": "Linux",
+        "type": "VirtualMachineScaleSets",
+        "vnetSubnetID": "[variables('clusterSubnetId')]",
+        "mode": "System",
+        "osDiskType": "Ephemeral",
+        "scaleSetPriority": "Regular"
+      }
     ]
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2018-11-30",
+      "name": "[parameters('identityName')]",
+      "location": "[parameters('location')]",
+      "tags": "[parameters('tags')]"
+    },
+    {
+      "type": "Microsoft.ContainerService/managedClusters",
+      "apiVersion": "2021-10-01",
+      "name": "[parameters('clusterName')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')))]": {}
+        }
+      },
+      "properties": {
+        "kubernetesVersion": "[parameters('kubernetesVersion')]",
+        "enableRBAC": true,
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": "[variables('allPools')]",
+        "aadProfile": {
+          "managed": true,
+          "enableAzureRBAC": true,
+          "adminGroupObjectIDs": "[parameters('clusterAdmins')]",
+          "tenantID": "[subscription().tenantId]"
+        },
+        "networkProfile": {
+          "networkPlugin": "azure",
+          "networkPolicy": "azure",
+          "loadBalancerSku": "standard",
+          "serviceCidr": "[variables('serviceCidr')]",
+          "dnsServiceIP": "[variables('dnsServiceIP')]",
+          "dockerBridgeCidr": "[variables('dockerBridgeCidr')]"
+        },
+        "autoUpgradeProfile": {
+          "upgradeChannel": "stable"
+        },
+        "addonProfiles": {
+          "httpApplicationRouting": {
+            "enabled": false
+          },
+          "azurepolicy": {
+            "enabled": true,
+            "config": {
+              "version": "v2"
+            }
+          },
+          "omsagent": {
+            "enabled": true,
+            "config": {
+              "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
+            }
+          },
+          "kubeDashboard": {
+            "enabled": false
+          },
+          "azureKeyvaultSecretsProvider": {
+            "enabled": true,
+            "config": {
+              "enableSecretRotation": "true"
+            }
+          }
+        },
+        "podIdentityProfile": {
+          "enabled": true
+        }
+      },
+      "tags": "[parameters('tags')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
+      ]
+    }
+  ]
 }

--- a/docs/setup/configuring-options.md
+++ b/docs/setup/configuring-options.md
@@ -31,6 +31,9 @@ configuration:
   # Enable expansion of Azure Bicep files.
   AZURE_BICEP_FILE_EXPANSION: true
 
+  # Configure the minimum AKS cluster version.
+  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.22.4
+
 rule:
   # Enable custom rules that don't exist in the baseline
   includeLocal: true

--- a/docs/setup/configuring-rules.md
+++ b/docs/setup/configuring-rules.md
@@ -17,6 +17,8 @@ Setting these values overrides the default configuration with organization speci
 
 ### AKS minimum Kubernetes version
 
+:octicons-milestone-24: v1.12.0
+
 This configuration option determines the minimum version of Kubernetes for AKS clusters and node pools.
 Rules that check the Kubernetes version fail when the version is older than the version specified.
 

--- a/docs/setup/configuring-rules.md
+++ b/docs/setup/configuring-rules.md
@@ -24,23 +24,23 @@ Syntax:
 
 ```yaml
 configuration:
-  Azure_AKSMinimumVersion: string # A version string
+  AZURE_AKS_CLUSTER_MINIMUM_VERSION: string # A version string
 ```
 
 Default:
 
 ```yaml
-# YAML: The default Azure_AKSMinimumVersion configuration option
+# YAML: The default AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option
 configuration:
-  Azure_AKSMinimumVersion: 1.20.5
+  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.21.7
 ```
 
 Example:
 
 ```yaml
-# YAML: Set the Azure_AKSMinimumVersion configuration option to 1.19.7
+# YAML: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.22.4
 configuration:
-  Azure_AKSMinimumVersion: 1.19.7
+  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.22.4
 ```
 
 ### AKS minimum max pods

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -23,9 +23,9 @@ The old option names may be set in:
 
 To locate any configurations, search for the old option names within your Infrasturcture as Code repo.
 
-New name                                  | Old name
---------                                  | ---------
-`AZURE_AKS_CLUSTER_MINIMUM_VERSION`       | `Azure_AKSMinimumVersion`
+New name                                  | Old name                             | Available from
+--------                                  | --------                             | --------------
+`AZURE_AKS_CLUSTER_MINIMUM_VERSION`       | `Azure_AKSMinimumVersion`            | :octicons-milestone-24: v1.12.0
 
 To update your configuration, use the new name instead.
 

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -9,11 +9,11 @@ It's not yet available, but you can take these steps to proactively prepare for 
 
 ### Realigned configuration option names
 
-Several configuration options will be renamed in upcomming releases of PSRule for Azure.
+Several configuration options will be renamed in upcoming releases of PSRule for Azure.
 This is part of a ongoing effort to align the naming of configuration options across PSRule for Azure.
 For information on other options that will be renamed see [deprecations][1].
 
-You **only** need to take action if you have explictly set old configuration option names.
+You **only** need to take action if you have explicitly set old configuration option names.
 
 The old option names may be set in:
 
@@ -21,7 +21,7 @@ The old option names may be set in:
 - A custom baseline.
 - An environment variable.
 
-To locate any configurations, search for the old option names within your Infrasturcture as Code repo.
+To locate any configurations, search for the old option names within your Infrastructure as Code repo.
 
 New name                                  | Old name                             | Available from
 --------                                  | --------                             | --------------

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -1,0 +1,75 @@
+# Upgrade notes
+
+This document contains notes to help upgrade from previous versions of PSRule for Azure.
+
+## Upgrading to v2.0.0
+
+PSRule for Azure v2.0.0 is a planned _future_ release.
+It's not yet available, but you can take these steps to proactively prepare for the release.
+
+### Realigned configuration option names
+
+Several configuration options will be renamed in upcomming releases of PSRule for Azure.
+This is part of a ongoing effort to align the naming of configuration options across PSRule for Azure.
+For information on other options that will be renamed see [deprecations][1].
+
+You **only** need to take action if you have explictly set old configuration option names.
+
+The old option names may be set in:
+
+- An option file such as `ps-rule.yaml`.
+- A custom baseline.
+- An environment variable.
+
+To locate any configurations, search for the old option names within your Infrasturcture as Code repo.
+
+New name                                  | Old name
+--------                                  | ---------
+`AZURE_AKS_CLUSTER_MINIMUM_VERSION`       | `Azure_AKSMinimumVersion`
+
+To update your configuration, use the new name instead.
+
+  [1]: deprecations.md#realigned-configuration-option-names
+
+!!! Note
+    Environment variables are prefixed by `PSRULE_CONFIGURATION_` and are case sensitive.
+
+=== "Options file"
+
+    Set the `AZURE_AKS_CLUSTER_MINIMUM_VERSION` option in `ps-rule.yaml`.
+
+    ```yaml
+    # YAML: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.22.4
+    configuration:
+      AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.22.4
+    ```
+
+=== "Bash"
+
+    Set the `PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION` environment variable.
+
+    ```bash
+    # Bash: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.22.4
+    export PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION=1.22.4
+    ```
+
+=== "GitHub Actions"
+
+    Set the `PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION` environment variable.
+
+    ```yaml
+    # GitHub Actions: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.22.4
+    env:
+      PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.22.4'
+    ```
+
+=== "Azure Pipelines"
+
+    Set the `PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION` environment variable.
+
+    ```yaml
+    # Azure Pipelines: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.22.4
+    variables:
+    - name: PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION
+      value: '1.22.4'
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,8 +61,8 @@ nav:
       - Change log:
         - v1: 'CHANGELOG-v1.md'
         - v0: 'CHANGELOG-v0.md'
-      # - Upgrade guide: upgrading.md
-      # - Deprecations: deprecations.md
+      - Upgrade notes: upgrading-notes.md
+      - Deprecations: deprecations.md
     - Support: support.md
   - Setup:
     - Configuring options: setup/configuring-options.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,7 +61,7 @@ nav:
       - Change log:
         - v1: 'CHANGELOG-v1.md'
         - v0: 'CHANGELOG-v0.md'
-      - Upgrade notes: upgrading-notes.md
+      - Upgrade notes: upgrade-notes.md
       - Deprecations: deprecations.md
     - Support: support.md
   - Setup:

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -59,4 +59,5 @@
     TemplateResourceWithoutDescription = "The template ({0}) has ({1}) resource/s without descriptions."
     PremiumRedisCacheAvailabilityZone = "The premium redis cache ({0}) deployed to region ({1}) should use a minimum of two availability zones from the following [{2}]."
     EnterpriseRedisCacheAvailabilityZone = "The enterprise redis cache ({0}) deployed to region ({1}) should be zone-redundant."
+    AKSMinimumVersionReplace = "The configuration option 'Azure_AKSMinimumVersion' has been replaced with 'AZURE_AKS_CLUSTER_MINIMUM_VERSION'. The option 'Azure_AKSMinimumVersion' is deprecated and will no longer work in the next major version. Please update your configuration to the new name. See https://aka.ms/ps-rule-azure/upgrade."
 }

--- a/src/PSRule.Rules.Azure/rules/Baseline.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Baseline.Rule.yaml
@@ -163,12 +163,15 @@ spec:
       - '2021_09'
 
 ---
-# Synopsis: Include rules released Decmber 2021 or prior for Azure GA features.
+# Synopsis: Include rules released December 2021 or prior for Azure GA features.
 apiVersion: github.com/microsoft/PSRule/v1
 kind: Baseline
 metadata:
   name: Azure.GA_2021_12
 spec:
+  configuration:
+    # Configure minimum AKS cluster version
+    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.20.5'
   rule:
     tag:
       release: GA

--- a/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
@@ -28,8 +28,12 @@ spec:
     AZURE_PARAMETER_FILE_EXPANSION: false
     AZURE_PARAMETER_FILE_METADATA_LINK: false
     AZURE_BICEP_FILE_EXPANSION: false
+
+    # Configure minimum AKS cluster version
+    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.21.7'
   convention:
     include:
+    - 'Azure.DeprecatedOptions'
     - 'Azure.ExpandTemplate'
     - 'Azure.BicepInstall'
     - 'Azure.ExpandBicep'

--- a/src/PSRule.Rules.Azure/rules/Conventions.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Conventions.Rule.ps1
@@ -5,6 +5,14 @@
 # Conventions definitions
 #
 
+# Synopsis: Flags warnings for deprecated options.
+Export-PSRuleConvention 'Azure.DeprecatedOptions' -Initialize {
+    $aksMinimumVersion = $Configuration.GetValueOrDefault('Azure_AKSMinimumVersion', $Null);
+    if ($Null -ne $aksMinimumVersion) {
+        Write-Warning -Message $LocalizedData.AKSMinimumVersionReplace;
+    }
+}
+
 # Synopsis: Expand Azure resources from parameter files.
 Export-PSRuleConvention 'Azure.ExpandTemplate' -If { $Configuration.AZURE_PARAMETER_FILE_EXPANSION -eq $True -and $TargetObject.Extension -eq '.json' -and $Assert.HasJsonSchema($PSRule.GetContentFirstOrDefault($TargetObject), @(
     "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json`#"

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -50,7 +50,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.20.5",
+                "kubernetesVersion": "1.21.7",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -210,7 +210,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.20.5",
+                "kubernetesVersion": "1.21.7",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -395,7 +395,7 @@
                 "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-03')]",
                 "maxPods": 50,
                 "type": "VirtualMachineScaleSets",
-                "orchestratorVersion": "1.20.5",
+                "orchestratorVersion": "1.21.7",
                 "osType": "Linux",
                 "enableAutoScaling": false
             }
@@ -427,7 +427,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.20.5",
+                "kubernetesVersion": "1.21.7",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -628,7 +628,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.20.5",
+                "kubernetesVersion": "1.21.7",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName5'))]",
                 "agentPoolProfiles": [
                     {
@@ -831,7 +831,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.20.5",
+                "kubernetesVersion": "1.21.7",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName6'))]",
                 "agentPoolProfiles": [
                     {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -6,7 +6,7 @@
         "ResourceName": "cluster-A",
         "Name": "cluster-A",
         "Properties": {
-            "kubernetesVersion": "1.20.5",
+            "kubernetesVersion": "1.21.7",
             "dnsPrefix": "cluster-A",
             "fqdn": "cluster-A-00000000.nnn.region.azmk8s.io",
             "agentPoolProfiles": [
@@ -18,7 +18,7 @@
                     "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
                     "maxPods": 30,
                     "type": "AvailabilitySet",
-                    "orchestratorVersion": "1.20.5",
+                    "orchestratorVersion": "1.21.7",
                     "osType": "Linux",
                     "enableAutoScaling": false,
                     "availabilityZones": null
@@ -164,7 +164,7 @@
         "ParentResource": null,
         "Properties": {
             "provisioningState": "Succeeded",
-            "kubernetesVersion": "1.20.5",
+            "kubernetesVersion": "1.21.7",
             "dnsPrefix": "cluster-C",
             "fqdn": "cluster-C-00000000.nnn.region.azmk8s.io",
             "agentPoolProfiles": [
@@ -177,7 +177,7 @@
                     "maxPods": 50,
                     "type": "VirtualMachineScaleSets",
                     "provisioningState": "Succeeded",
-                    "orchestratorVersion": "1.20.5",
+                    "orchestratorVersion": "1.21.7",
                     "osType": "Linux",
                     "enableAutoScaling": false
                 }
@@ -283,7 +283,7 @@
         "Plan": null,
         "Properties": {
             "provisioningState": "Succeeded",
-            "kubernetesVersion": "1.20.5",
+            "kubernetesVersion": "1.21.7",
             "dnsPrefix": "cluster-D",
             "fqdn": "cluster-D-nnnnnnnn.hcp.region.azmk8s.io",
             "agentPoolProfiles": [
@@ -296,7 +296,7 @@
                     "maxPods": 50,
                     "type": "VirtualMachineScaleSets",
                     "provisioningState": "Succeeded",
-                    "orchestratorVersion": "1.20.5",
+                    "orchestratorVersion": "1.21.7",
                     "nodeLabels": {},
                     "mode": "System",
                     "osType": "Linux",
@@ -470,7 +470,7 @@
             "powerState": {
                 "code": "Running"
             },
-            "orchestratorVersion": "1.20.5",
+            "orchestratorVersion": "1.21.7",
             "nodeLabels": {},
             "mode": "System",
             "osType": "Linux",
@@ -540,7 +540,7 @@
             "powerState": {
                 "code": "Running"
             },
-            "kubernetesVersion": "1.20.5",
+            "kubernetesVersion": "1.21.7",
             "dnsPrefix": "cluster-F",
             "fqdn": "cluster-F-00000000.hcp.region.azmk8s.io",
             "azurePortalFQDN": "cluster-F-00000000.portal.hcp.region.azmk8s.io",
@@ -561,7 +561,7 @@
                     "powerState": {
                         "code": "Running"
                     },
-                    "orchestratorVersion": "1.20.5",
+                    "orchestratorVersion": "1.21.7",
                     "nodeLabels": {},
                     "mode": "System",
                     "osType": "Linux",
@@ -768,7 +768,7 @@
         "ResourceName": "cluster-G",
         "Name": "cluster-G",
         "Properties": {
-            "kubernetesVersion": "1.20.5",
+            "kubernetesVersion": "1.21.7",
             "dnsPrefix": "cluster-G",
             "fqdn": "cluster-G-00000000.nnn.region.azmk8s.io",
             "agentPoolProfiles": [
@@ -780,7 +780,7 @@
                     "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
                     "maxPods": 30,
                     "type": "VirtualMachineScaleSets",
-                    "orchestratorVersion": "1.20.5",
+                    "orchestratorVersion": "1.21.7",
                     "osType": "Linux",
                     "enableAutoScaling": false,
                     "availabilityZones": null
@@ -942,7 +942,7 @@
         "ResourceName": "cluster-H",
         "Name": "cluster-H",
         "Properties": {
-            "kubernetesVersion": "1.20.5",
+            "kubernetesVersion": "1.21.7",
             "dnsPrefix": "cluster-H",
             "fqdn": "cluster-H-00000000.nnn.region.azmk8s.io",
             "agentPoolProfiles": [
@@ -954,7 +954,7 @@
                     "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
                     "maxPods": 30,
                     "type": "VirtualMachineScaleSets",
-                    "orchestratorVersion": "1.20.5",
+                    "orchestratorVersion": "1.21.7",
                     "osType": "Linux",
                     "enableAutoScaling": false,
                     "availabilityZones": []
@@ -1116,7 +1116,7 @@
         "ResourceName": "cluster-I",
         "Name": "cluster-I",
         "Properties": {
-            "kubernetesVersion": "1.20.5",
+            "kubernetesVersion": "1.21.7",
             "dnsPrefix": "cluster-I",
             "fqdn": "cluster-I-00000000.nnn.region.azmk8s.io",
             "agentPoolProfiles": [
@@ -1128,7 +1128,7 @@
                     "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
                     "maxPods": 30,
                     "type": "VirtualMachineScaleSets",
-                    "orchestratorVersion": "1.20.5",
+                    "orchestratorVersion": "1.21.7",
                     "osType": "Linux",
                     "enableAutoScaling": false,
                     "availabilityZones": null
@@ -1290,7 +1290,7 @@
         "ResourceName": "cluster-J",
         "Name": "cluster-J",
         "Properties": {
-            "kubernetesVersion": "1.20.5",
+            "kubernetesVersion": "1.21.7",
             "dnsPrefix": "cluster-J",
             "fqdn": "cluster-J-00000000.nnn.region.azmk8s.io",
             "agentPoolProfiles": [
@@ -1302,7 +1302,7 @@
                     "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
                     "maxPods": 30,
                     "type": "VirtualMachineScaleSets",
-                    "orchestratorVersion": "1.20.5",
+                    "orchestratorVersion": "1.21.7",
                     "osType": "Linux",
                     "enableAutoScaling": false,
                     "availabilityZones": null
@@ -1462,7 +1462,7 @@
             "powerState": {
                 "code": "Running"
             },
-            "kubernetesVersion": "1.21.2",
+            "kubernetesVersion": "1.21.7",
             "dnsPrefix": "cluster-K",
             "fqdn": "cluster-K-00000000.hcp.eastus.azmk8s.io",
             "azurePortalFQDN": "cluster-K-00000000.portal.hcp.eastus.azmk8s.io",
@@ -1484,7 +1484,7 @@
                     "powerState": {
                         "code": "Running"
                     },
-                    "orchestratorVersion": "1.21.2",
+                    "orchestratorVersion": "1.21.7",
                     "mode": "System",
                     "osType": "Linux",
                     "osSKU": "Ubuntu",
@@ -1640,7 +1640,7 @@
             "powerState": {
                 "code": "Running"
             },
-            "kubernetesVersion": "1.21.2",
+            "kubernetesVersion": "1.22.4",
             "dnsPrefix": "nnn-cluster-L",
             "fqdn": "nnn-cluster-L-00000000.hcp.eastus.azmk8s.io",
             "azurePortalFQDN": "nnn-cluster-L-00000000.portal.hcp.eastus.azmk8s.io",
@@ -1662,7 +1662,7 @@
                     "powerState": {
                         "code": "Running"
                     },
-                    "orchestratorVersion": "1.21.2",
+                    "orchestratorVersion": "1.22.4",
                     "mode": "System",
                     "osType": "Linux",
                     "osSKU": "Ubuntu",

--- a/tests/PSRule.Rules.Azure.Tests/ps-rule-options.yaml
+++ b/tests/PSRule.Rules.Azure.Tests/ps-rule-options.yaml
@@ -21,6 +21,7 @@ configuration:
     name: 'unit-test-mg'
     properties:
       displayName: 'My test management group'
+  AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.22.4'
   AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST:
   - location: 'Antarctica North'
     zones:

--- a/tests/PSRule.Rules.Azure.Tests/ps-rule-options2.yaml
+++ b/tests/PSRule.Rules.Azure.Tests/ps-rule-options2.yaml
@@ -1,0 +1,5 @@
+# PSRule options for unit testing
+
+configuration:
+  AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.0.0'
+  Azure_AKSMinimumVersion: '1.22.4'


### PR DESCRIPTION
## PR Summary

- Updated `Azure.AKS.Version` to use latest stable version `1.21.7`. #1188
  - Pinned latest GA baseline `Azure.GA_2021_12` to previous version `1.20.5`.
  - Use `AZURE_AKS_CLUSTER_MINIMUM_VERSION` to configure the minimum version of the cluster.
- **Important change:** Replaced `Azure_AKSMinimumVersion` option with `AZURE_AKS_CLUSTER_MINIMUM_VERSION`. #941
  - For compatiblity, if `Azure_AKSMinimumVersion` is set it will be used instead of `AZURE_AKS_CLUSTER_MINIMUM_VERSION`.
  - If only `AZURE_AKS_CLUSTER_MINIMUM_VERSION` is set, this value will be used.
  - The default will be used neither options are configured.
  - If `Azure_AKSMinimumVersion` is set a warning will be generated until the configuration is removed.
  - Support for `Azure_AKSMinimumVersion` is deprecated and will be removed in v2.

Fixes #1188 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
