### PR TITLE
Pre-release v1.12.0-B2201054

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -13,7 +13,8 @@ See [troubleshooting guide] for a workaround to this issue.
   Support for `Azure_AKSMinimumVersion` will be removed in v2.
 
 ## Unreleased
-  
+
+## v1.12.0-B2201054 (pre-release)
 
 What's changed since v1.11.1:
 
@@ -23,7 +24,7 @@ What's changed since v1.11.1:
       - Pinned latest GA baseline `Azure.GA_2021_12` to previous version `1.20.5`.
       - Use `AZURE_AKS_CLUSTER_MINIMUM_VERSION` to configure the minimum version of the cluster.
   - Azure API Management:
-    - Disable use of insecure ciphers.
+    - Check service disabled insecure ciphers.
     [#1128](https://github.com/Azure/PSRule.Rules.Azure/issues/1128)
     - Refactored the cipher and protocol rule into individual rules.
       - `Azure.APIM.Protocols`
@@ -121,7 +122,6 @@ What's changed since pre-release v1.11.0-B2112112:
 
 - New features:
   - Bicep support promoted from experimental to generally available (GA). [#1176](https://github.com/Azure/PSRule.Rules.Azure/issues/1176)
-
 
 ## v1.11.0-B2112112 (pre-release)
 

--- a/docs/en/baselines/Azure.All.md
+++ b/docs/en/baselines/Azure.All.md
@@ -4,7 +4,7 @@ Includes all Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.All`. This baseline includes a total of 257 rules.
+The following rules are included within `Azure.All`. This baseline includes a total of 258 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -48,6 +48,7 @@ Name | Synopsis | Severity
 [Azure.APIM.APIDescriptors](../rules/Azure.APIM.APIDescriptors.md) | API Management APIs should have a display name and description. | Awareness
 [Azure.APIM.AvailabilityZone](../rules/Azure.APIM.AvailabilityZone.md) | API management services deployed with Premium SKU should use availability zones in supported regions for high availability. | Important
 [Azure.APIM.CertificateExpiry](../rules/Azure.APIM.CertificateExpiry.md) | Renew certificates used for custom domain bindings. | Important
+[Azure.APIM.Ciphers](../rules/Azure.APIM.Ciphers.md) | API Management should not accept weak or deprecated ciphers. | Important
 [Azure.APIM.EncryptValues](../rules/Azure.APIM.EncryptValues.md) | API Management named values should be encrypted. | Important
 [Azure.APIM.HTTPBackend](../rules/Azure.APIM.HTTPBackend.md) | Use HTTPS for communication to backend services. | Critical
 [Azure.APIM.HTTPEndpoint](../rules/Azure.APIM.HTTPEndpoint.md) | Enforce HTTPS for communication to API clients. | Important

--- a/docs/en/baselines/Azure.Default.md
+++ b/docs/en/baselines/Azure.Default.md
@@ -4,7 +4,7 @@ Default baseline for Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.Default`. This baseline includes a total of 252 rules.
+The following rules are included within `Azure.Default`. This baseline includes a total of 253 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -44,6 +44,7 @@ Name | Synopsis | Severity
 [Azure.APIM.APIDescriptors](../rules/Azure.APIM.APIDescriptors.md) | API Management APIs should have a display name and description. | Awareness
 [Azure.APIM.AvailabilityZone](../rules/Azure.APIM.AvailabilityZone.md) | API management services deployed with Premium SKU should use availability zones in supported regions for high availability. | Important
 [Azure.APIM.CertificateExpiry](../rules/Azure.APIM.CertificateExpiry.md) | Renew certificates used for custom domain bindings. | Important
+[Azure.APIM.Ciphers](../rules/Azure.APIM.Ciphers.md) | API Management should not accept weak or deprecated ciphers. | Important
 [Azure.APIM.EncryptValues](../rules/Azure.APIM.EncryptValues.md) | API Management named values should be encrypted. | Important
 [Azure.APIM.HTTPBackend](../rules/Azure.APIM.HTTPBackend.md) | Use HTTPS for communication to backend services. | Critical
 [Azure.APIM.HTTPEndpoint](../rules/Azure.APIM.HTTPEndpoint.md) | Enforce HTTPS for communication to API clients. | Important

--- a/docs/en/baselines/Azure.GA_2021_12.md
+++ b/docs/en/baselines/Azure.GA_2021_12.md
@@ -1,6 +1,6 @@
 # Azure.GA_2021_12
 
-Include rules released Decmber 2021 or prior for Azure GA features.
+Include rules released December 2021 or prior for Azure GA features.
 
 ## Rules
 

--- a/docs/en/baselines/Azure.Preview.md
+++ b/docs/en/baselines/Azure.Preview.md
@@ -4,7 +4,7 @@ Includes rules for Azure GA and preview features.
 
 ## Rules
 
-The following rules are included within `Azure.Preview`. This baseline includes a total of 257 rules.
+The following rules are included within `Azure.Preview`. This baseline includes a total of 258 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -48,6 +48,7 @@ Name | Synopsis | Severity
 [Azure.APIM.APIDescriptors](../rules/Azure.APIM.APIDescriptors.md) | API Management APIs should have a display name and description. | Awareness
 [Azure.APIM.AvailabilityZone](../rules/Azure.APIM.AvailabilityZone.md) | API management services deployed with Premium SKU should use availability zones in supported regions for high availability. | Important
 [Azure.APIM.CertificateExpiry](../rules/Azure.APIM.CertificateExpiry.md) | Renew certificates used for custom domain bindings. | Important
+[Azure.APIM.Ciphers](../rules/Azure.APIM.Ciphers.md) | API Management should not accept weak or deprecated ciphers. | Important
 [Azure.APIM.EncryptValues](../rules/Azure.APIM.EncryptValues.md) | API Management named values should be encrypted. | Important
 [Azure.APIM.HTTPBackend](../rules/Azure.APIM.HTTPBackend.md) | Use HTTPS for communication to backend services. | Critical
 [Azure.APIM.HTTPEndpoint](../rules/Azure.APIM.HTTPEndpoint.md) | Enforce HTTPS for communication to API clients. | Important

--- a/docs/en/rules/module.md
+++ b/docs/en/rules/module.md
@@ -319,6 +319,7 @@ Name | Synopsis | Severity
 Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.ACR.ContentTrust](Azure.ACR.ContentTrust.md) | Use container images signed by a trusted image publisher. | Important
+[Azure.APIM.Ciphers](Azure.APIM.Ciphers.md) | API Management should not accept weak or deprecated ciphers. | Important
 [Azure.APIM.EncryptValues](Azure.APIM.EncryptValues.md) | API Management named values should be encrypted. | Important
 [Azure.APIM.HTTPBackend](Azure.APIM.HTTPBackend.md) | Use HTTPS for communication to backend services. | Critical
 [Azure.APIM.HTTPEndpoint](Azure.APIM.HTTPEndpoint.md) | Enforce HTTPS for communication to API clients. | Important

--- a/docs/en/rules/resource.md
+++ b/docs/en/rules/resource.md
@@ -44,6 +44,7 @@ Name | Synopsis | Severity
 [Azure.APIM.APIDescriptors](Azure.APIM.APIDescriptors.md) | API Management APIs should have a display name and description. | Awareness
 [Azure.APIM.AvailabilityZone](Azure.APIM.AvailabilityZone.md) | API management services deployed with Premium SKU should use availability zones in supported regions for high availability. | Important
 [Azure.APIM.CertificateExpiry](Azure.APIM.CertificateExpiry.md) | Renew certificates used for custom domain bindings. | Important
+[Azure.APIM.Ciphers](Azure.APIM.Ciphers.md) | API Management should not accept weak or deprecated ciphers. | Important
 [Azure.APIM.EncryptValues](Azure.APIM.EncryptValues.md) | API Management named values should be encrypted. | Important
 [Azure.APIM.HTTPBackend](Azure.APIM.HTTPBackend.md) | Use HTTPS for communication to backend services. | Critical
 [Azure.APIM.HTTPEndpoint](Azure.APIM.HTTPEndpoint.md) | Enforce HTTPS for communication to API clients. | Important


### PR DESCRIPTION
## PR Summary

What's changed since v1.11.1:

- Updated rules:
  - Azure Kubernetes Service:
    - Updated `Azure.AKS.Version` to use latest stable version `1.21.7`. #1188
      - Pinned latest GA baseline `Azure.GA_2021_12` to previous version `1.20.5`.
      - Use `AZURE_AKS_CLUSTER_MINIMUM_VERSION` to configure the minimum version of the cluster.
  - Azure API Management:
    - Check service disabled insecure ciphers.
    #1128
    - Refactored the cipher and protocol rule into individual rules.
      - `Azure.APIM.Protocols`
      - `Azure.APIM.Ciphers`
- General improvements:
  - **Important change:** Replaced `Azure_AKSMinimumVersion` option with `AZURE_AKS_CLUSTER_MINIMUM_VERSION`. #941
    - For compatibility, if `Azure_AKSMinimumVersion` is set it will be used instead of `AZURE_AKS_CLUSTER_MINIMUM_VERSION`.
    - If only `AZURE_AKS_CLUSTER_MINIMUM_VERSION` is set, this value will be used.
    - The default will be used neither options are configured.
    - If `Azure_AKSMinimumVersion` is set a warning will be generated until the configuration is removed.
    - Support for `Azure_AKSMinimumVersion` is deprecated and will be removed in v2.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
