### PR TITLE
Pre-release v1.13.0-B2202090

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -12,7 +12,7 @@ See [troubleshooting guide] for a workaround to this issue.
   If you have this option configured, please update it to `AZURE_AKS_CLUSTER_MINIMUM_VERSION`.
   Support for `Azure_AKSMinimumVersion` will be removed in v2.
 
-## Unreleased
+## v1.13.0-B2202090 (pre-release)
 
 What's changed since pre-release v1.13.0-B2202063:
 


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.13.0-B2202063:

- Engineering:
  - Automatically build baseline docs. #1242
- Bug fixes:
  - Fixed empty value with strong type. #1258
- New rules:
  - Azure Cache for Redis:
    - Limit public access for Azure Cache for Redis instances. #935

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
