### PR TITLE
Fixes VNET and ACR bugs #1303 #1304

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -14,6 +14,13 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since v1.13.3:
+
+- Bug fixes:
+  - Fixed virtual network without any subnets is invalid. [#1303](https://github.com/Azure/PSRule.Rules.Azure/issues/1303)
+  - Fixed container registry rules that require a premium tier. [#1304](https://github.com/Azure/PSRule.Rules.Azure/issues/1304)
+    - Rules `Azure.ACR.Retention` and `Azure.ACR.ContentTrust` are now only run against premium instances.
+
 ## v1.13.3
 
 What's changed since v1.13.2:

--- a/docs/en/rules/Azure.ACR.ContentTrust.md
+++ b/docs/en/rules/Azure.ACR.ContentTrust.md
@@ -17,6 +17,8 @@ Use container images signed by a trusted image publisher.
 Azure Container Registry (ACR) content trust enables pushing and pulling of signed images.
 Signed images provides additional assurance that they have been built on a trusted source.
 
+To enable content trust, the container registry must be using a Premium SKU.
+
 ## RECOMMENDATION
 
 Consider enabling content trust on registries, clients, and sign container images.

--- a/docs/en/rules/Azure.ACR.Retention.md
+++ b/docs/en/rules/Azure.ACR.Retention.md
@@ -21,6 +21,8 @@ A manifest is untagged when a more recent image is pushed using the same tag. i.
 The retention policy (in days) can be set to 0-365.
 The default is 7 days.
 
+To configure a retention policy, the container registry must be using a Premium SKU.
+
 ## RECOMMENDATION
 
 Consider enabling a retention policy for untagged manifests.

--- a/src/PSRule.Rules.Azure/rules/Azure.ACR.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.ACR.Rule.yaml
@@ -70,6 +70,8 @@ metadata:
     release: 'GA'
     ruleSet: '2020_12'
 spec:
+  with:
+  - Azure.ACR.IsPremiumSKU
   type:
   - Microsoft.ContainerRegistry/registries
   condition:
@@ -86,6 +88,8 @@ metadata:
     release: 'preview'
     ruleSet: '2020_12'
 spec:
+  with:
+  - Azure.ACR.IsPremiumSKU
   type:
   - Microsoft.ContainerRegistry/registries
   condition:
@@ -93,3 +97,24 @@ spec:
     equals: enabled
 
 #endregion Rules
+
+#region Selectors
+
+---
+# Synopsis: Azure Container Registries using a Premium SKU.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Azure.ACR.IsPremiumSKU
+spec:
+  if:
+    allOf:
+    - type: '.'
+      equals: 'Microsoft.ContainerRegistry/registries'
+    - anyOf:
+      - field: Sku.name
+        equals: 'Premium'
+      - field: Sku.tier
+        equals: 'Premium'
+
+#endregion Selectors

--- a/src/PSRule.Rules.Azure/rules/Azure.VNET.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VNET.Rule.ps1
@@ -13,7 +13,7 @@ Rule 'Azure.VNET.UseNSGs' -Type 'Microsoft.Network/virtualNetworks', 'Microsoft.
     if ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks') {
         # Get subnets
         $subnet = @($TargetObject.properties.subnets | Where-Object { $_.Name -notin 'GatewaySubnet', 'AzureFirewallSubnet', 'AzureFirewallManagementSubnet' });
-        if ($subnet.Length -eq 0) {
+        if ($subnet.Length -eq 0 -or !$Assert.HasFieldValue($TargetObject, 'properties.subnets').Result) {
             return $Assert.Pass();
         }
     }
@@ -74,7 +74,7 @@ Rule 'Azure.VNET.SubnetName' -Type 'Microsoft.Network/virtualNetworks', 'Microso
     # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftnetwork
     if ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks') {
         $subnets = @($TargetObject.Properties.subnets)
-        if ($subnets.Length -eq 0) {
+        if ($subnets.Length -eq 0 -or !$Assert.HasFieldValue($TargetObject, 'properties.subnets').Result) {
             $Assert.Pass();
         }
         else {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
@@ -43,14 +43,14 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'registry-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'registry-A', 'registry-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C', 'registry-E';
         }
 
         It 'Azure.ACR.MinSku' {
@@ -65,8 +65,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C', 'registry-D', 'registry-E';
         }
 
         It 'Azure.ACR.Quarantine' {
@@ -75,14 +75,14 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-B';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-B', 'registry-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'registry-C';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'registry-C' 'registry-E';
         }
 
         It 'Azure.ACR.ContentTrust' {
@@ -92,13 +92,19 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'registry-A';
+            $ruleResult.TargetName | Should -Be 'registry-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C';
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'registry-E';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-B', 'registry-C';
         }
 
         It 'Azure.ACR.Retention' {
@@ -108,13 +114,19 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'registry-A';
+            $ruleResult.TargetName | Should -Be 'registry-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C';
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'registry-E';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -Be 'registry-A', 'registry-B', 'registry-C';
         }
 
         It 'Azure.ACR.Usage' {
@@ -123,8 +135,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-B';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-B', 'registry-D', 'registry-E';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -139,8 +151,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'registry-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'registry-A', 'registry-D';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "The results for a valid assessment was not found.";
@@ -148,8 +160,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C', 'registry-E';
         }
 
         It 'Azure.ACR.ImageHealth' {
@@ -158,8 +170,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'registry-B';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-E';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "An assessment is reporting one or more issues.";
@@ -173,8 +185,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'registry-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'registry-A', 'registry-D';
         }
 
         It 'Azure.ACR.GeoReplica' {
@@ -183,14 +195,14 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'registry-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'registry-A', 'registry-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C', 'registry-E';
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
@@ -44,7 +44,7 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'registry-A', 'registry-D';
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -60,7 +60,7 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'registry-A';
+            $ruleResult.TargetName | Should -BeIn 'registry-A';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -82,7 +82,7 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'registry-C' 'registry-E';
+            $ruleResult.TargetName | Should -BeIn 'registry-C', 'registry-E';
         }
 
         It 'Azure.ACR.ContentTrust' {
@@ -92,7 +92,7 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'registry-D';
+            $ruleResult.TargetName | Should -BeIn 'registry-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -114,7 +114,7 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'registry-D';
+            $ruleResult.TargetName | Should -BeIn 'registry-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -126,7 +126,7 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -Be 'registry-A', 'registry-B', 'registry-C';
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-B', 'registry-C';
         }
 
         It 'Azure.ACR.Usage' {
@@ -142,7 +142,7 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'registry-C';
+            $ruleResult.TargetName | Should -BeIn 'registry-C';
         }
 
         It 'Azure.ACR.ContainerScan' {
@@ -152,7 +152,7 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'registry-A', 'registry-D';
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-D';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "The results for a valid assessment was not found.";
@@ -180,13 +180,13 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'registry-C';
+            $ruleResult.TargetName | Should -BeIn 'registry-C';
 
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'registry-A', 'registry-D';
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-D';
         }
 
         It 'Azure.ACR.GeoReplica' {
@@ -196,7 +196,7 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'registry-A', 'registry-D';
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VNET.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VNET.Tests.ps1
@@ -70,8 +70,8 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'vnet-A', 'vnet-E';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'vnet-A', 'vnet-E', 'vnet-F';
         }
 
         It 'Azure.VNET.SingleDNS' {
@@ -86,8 +86,8 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -Be 'vnet-A', 'vnet-C', 'vnet-D', 'vnet-E';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -Be 'vnet-A', 'vnet-C', 'vnet-D', 'vnet-E', 'vnet-F';
         }
 
         It 'Azure.VNET.LocalDNS' {
@@ -96,8 +96,8 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -Be 'vnet-B', 'vnet-D', 'vnet-E';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -Be 'vnet-B', 'vnet-D', 'vnet-E', 'vnet-F';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -124,8 +124,8 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' -and $_.TargetObject.ResourceType -eq 'Microsoft.Network/virtualNetworks' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'vnet-D', 'vnet-E';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -Be 'vnet-D', 'vnet-E', 'vnet-F';
         }
 
         It 'Azure.VNET.Name' {
@@ -138,8 +138,8 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -BeIn 'vnet-A', 'vnet-B', 'vnet-C', 'vnet-D', 'vnet-E';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'vnet-A', 'vnet-B', 'vnet-C', 'vnet-D', 'vnet-E', 'vnet-F';
         }
 
         It 'Azure.VNET.SubnetName' {
@@ -152,8 +152,8 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -BeIn 'vnet-A', 'vnet-B', 'vnet-C', 'vnet-D', 'vnet-E';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'vnet-A', 'vnet-B', 'vnet-C', 'vnet-D', 'vnet-E', 'vnet-F';
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Resources.ACR.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.ACR.json
@@ -327,5 +327,182 @@
                 "ETag": null
             }
         ]
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-D",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-D",
+        "Location": "region",
+        "ResourceName": "registry-D",
+        "Name": "registry-D",
+        "Properties": {
+            "loginServer": "registry-D.azurecr.io",
+            "adminUserEnabled": true
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.ContainerRegistry/registries",
+        "ResourceType": "Microsoft.ContainerRegistry/registries",
+        "Sku": {
+            "Name": "Premium",
+            "Tier": "Premium",
+            "Size": null,
+            "Family": null,
+            "Model": null,
+            "Capacity": null
+        },
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-E",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-E",
+        "Location": "region",
+        "ResourceName": "registry-E",
+        "Name": "registry-E",
+        "Properties": {
+            "loginServer": "registry-E.azurecr.io",
+            "adminUserEnabled": false,
+            "policies": {
+                "quarantinePolicy": {
+                    "status": "enabled"
+                },
+                "trustPolicy": {
+                    "type": "Notary",
+                    "status": "enabled"
+                },
+                "retentionPolicy": {
+                    "days": 180,
+                    "status": "enabled"
+                }
+            }
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.ContainerRegistry/registries",
+        "ResourceType": "Microsoft.ContainerRegistry/registries",
+        "Sku": {
+            "Name": "Premium",
+            "Tier": "Premium",
+            "Size": null,
+            "Family": null,
+            "Model": null,
+            "Capacity": null
+        },
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "resources": [
+            {
+                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-E/replications/region2",
+                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-E/replications/region2",
+                "Identity": null,
+                "Kind": null,
+                "Location": "region2",
+                "ManagedBy": null,
+                "ResourceName": "region2",
+                "Name": "region2",
+                "ExtensionResourceName": null,
+                "ParentResource": null,
+                "Plan": null,
+                "Properties": {
+                    "provisioningState": "Succeeded",
+                    "status": {
+                        "displayStatus": "Ready"
+                    },
+                    "regionEndpointEnabled": true
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.ContainerRegistry/registries/replications",
+                "ResourceType": "Microsoft.ContainerRegistry/registries/replications",
+                "ExtensionResourceType": null,
+                "Sku": null,
+                "Tags": null,
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "CreatedTime": null,
+                "ChangedTime": null,
+                "ETag": null
+            },
+            {
+                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-E/replications/region",
+                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-E/replications/region",
+                "Identity": null,
+                "Kind": null,
+                "Location": "region",
+                "ManagedBy": null,
+                "ResourceName": "region",
+                "Name": "region",
+                "ExtensionResourceName": null,
+                "ParentResource": null,
+                "Plan": null,
+                "Properties": {
+                    "provisioningState": "Succeeded",
+                    "status": {
+                        "displayStatus": "Ready"
+                    },
+                    "regionEndpointEnabled": true
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.ContainerRegistry/registries/replications",
+                "ResourceType": "Microsoft.ContainerRegistry/registries/replications",
+                "ExtensionResourceType": null,
+                "Sku": null,
+                "Tags": null,
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "CreatedTime": null,
+                "ChangedTime": null,
+                "ETag": null
+            },
+            {
+                "value": [
+                    {
+                        "name": "Size",
+                        "limit": 536870912000,
+                        "currentValue": 531502202880,
+                        "unit": "Bytes"
+                    },
+                    {
+                        "name": "Webhooks",
+                        "limit": 500,
+                        "currentValue": 0,
+                        "unit": "Count"
+                    }
+                ],
+                "ResourceType": "Microsoft.ContainerRegistry/registries/listUsages"
+            },
+            {
+                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-E/providers/Microsoft.Security/assessments/00000000-0000-0000-0000-000000000000",
+                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-E/providers/Microsoft.Security/assessments/00000000-0000-0000-0000-000000000000",
+                "Identity": null,
+                "Kind": null,
+                "Location": null,
+                "ManagedBy": null,
+                "ResourceName": "00000000-0000-0000-0000-000000000000",
+                "Name": "00000000-0000-0000-0000-000000000000",
+                "ExtensionResourceName": "00000000-0000-0000-0000-000000000000",
+                "ParentResource": null,
+                "Plan": null,
+                "Properties": {
+                    "resourceDetails": {
+                        "Source": "Azure",
+                        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-E"
+                    },
+                    "displayName": "Vulnerabilities in Azure Container Registry images should be remediated (powered by Qualys)",
+                    "status": {
+                        "code": "Unhealthy"
+                    },
+                    "additionalData": {
+                        "subAssessmentsLink": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-E/providers/Microsoft.Security/assessments/00000000-0000-0000-0000-000000000000/subAssessments"
+                    }
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.ContainerRegistry/registries",
+                "ResourceType": "Microsoft.ContainerRegistry/registries",
+                "ExtensionResourceType": "Microsoft.Security/assessments",
+                "Sku": null,
+                "Tags": null,
+                "TagsTable": null,
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "CreatedTime": null,
+                "ChangedTime": null,
+                "ETag": null
+            }
+        ]
     }
 ]

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
@@ -566,6 +566,34 @@
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
     },
     {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-F",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-F",
+        "Location": "region",
+        "ResourceName": "vnet-F",
+        "Name": "vnet-F",
+        "Properties": {
+            "addressSpace": {
+                "addressPrefixes": [
+                    "10.5.0.0/24"
+                ]
+            },
+            "dhcpOptions": {
+                "dnsServers": [
+                    "10.99.0.36",
+                    "10.99.0.37"
+                ]
+            },
+            "virtualNetworkPeerings": [],
+            "enableDdosProtection": false,
+            "enableVmProtection": false
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Network/virtualNetworks",
+        "ResourceType": "Microsoft.Network/virtualNetworks",
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+    },
+    {
         "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-A",
         "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-A",
         "Location": "region",


### PR DESCRIPTION
## PR Summary

- Fixed virtual network without any subnets is invalid. #1303
- Fixed container registry rules that require a premium tier. #1304
  - Rules `Azure.ACR.Retention` and `Azure.ACR.ContentTrust` are now only run against premium instances.

Fixes #1303 
Fixes #1304 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
