### PR TITLE
Fixes processing deployment outputs #1316 #1315

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -16,6 +16,10 @@ See [troubleshooting guide] for a workaround to this issue.
 
 What's changed since v1.13.3:
 
+- New features:
+  - Added support for referencing resources in template. [#1315](https://github.com/Azure/PSRule.Rules.Azure/issues/1315)
+    - The `reference()` function can be used to reference resources in template.
+    - A placeholder value is still used for resources outside of the template.
 - New rules:
   - SignalR Service:
     - Check services use Managed Identities. [#1306](https://github.com/Azure/PSRule.Rules.Azure/issues/1306)
@@ -23,6 +27,8 @@ What's changed since v1.13.3:
   - Web PubSub Service:
     - Check services use Managed Identities. [#1308](https://github.com/Azure/PSRule.Rules.Azure/issues/1308)
     - Check services use a SKU with an SLA. [#1309](https://github.com/Azure/PSRule.Rules.Azure/issues/1309)
+- Bug fixes:
+  - Fixed processing of deployment outputs. [#1316](https://github.com/Azure/PSRule.Rules.Azure/issues/1316)
 
 ## v1.13.4
 

--- a/docs/commands/Export-AzRuleTemplateData.md
+++ b/docs/commands/Export-AzRuleTemplateData.md
@@ -56,11 +56,13 @@ Currently the following limitations apply:
 Automatic nesting a sub-resource requires:
   - The parent resource is defined in the same template.
   - The sub-resource depends on the parent resource.
-- The `pickZones` template function is not supported.
 - The `environment` template function always returns values for Azure public cloud.
 - References to Key Vault secrets are not expanded.
 A placeholder value is used instead.
+- The `reference()` function will return objects for resources within the same template.
+  For resources that are not in the same template, a placeholder value is used instead.
 - Multi-line strings are not supported.
+- Template expressions up to a maximum of 100,000 characters are supported.
 
 ## EXAMPLES
 

--- a/docs/expanding-source-files.md
+++ b/docs/expanding-source-files.md
@@ -40,11 +40,11 @@ Source expansion is supported with:
 
 - **Azure template and parameter files** &mdash; Azure templates are expanded from parameter files.
   Link parameter files to templates by metadata or naming convention.
-  See [Using templates](using-templates.md) for a detailed explaination of how to do this.
+  See [Using templates](using-templates.md) for a detailed explanation of how to do this.
 - **Azure Bicep deployments** &mdash; Files with the `.bicep` extension are detected and expanded.
-  See [Using Bicep source](using-bicep.md) for a detailed explaination of how to do this.
+  See [Using Bicep source](using-bicep.md) for a detailed explanation of how to do this.
 - **Azure Bicep modules with tests** &mdash; Reusable Bicep modules can be expanded with tests.
-  See [Using Bicep source](using-bicep.md) for a detailed explaination of how to do this.
+  See [Using Bicep source](using-bicep.md) for a detailed explanation of how to do this.
 
 ### Limitations
 
@@ -60,6 +60,8 @@ Automatic nesting a sub-resource requires:
 - The `environment()` template function always returns values for Azure public cloud.
 - References to Key Vault secrets are not expanded.
   A placeholder value is used instead.
+- The `reference()` function will return objects for resources within the same template.
+  For resources that are not in the same template, a placeholder value is used instead.
 - Multi-line strings are not supported.
 - Template expressions up to a maximum of 100,000 characters are supported.
 
@@ -68,10 +70,12 @@ In addition, currently the following limitation apply to using Bicep source file
 - The Bicep CLI must be installed.
   When using GitHub Actions or Azure Pipelines the Bicep CLI is pre-installed.
 - Location of issues in Bicep source files is not supported.
-- Expansion of Bicep source files times out after 5 seconds.
+- Expansion of Bicep source files times out after 5 seconds by default.
+  The timeout can be overridden by setting the [AZURE_BICEP_FILE_EXPANSION_TIMEOUT][3] option.
 
   [1]: using-templates.md#featuresupport
   [2]: setup/configuring-expansion.md#excludingfiles
+  [3]: setup/setup-bicep.md#configuringtimeout
 
 ## Strong type
 
@@ -92,7 +96,7 @@ The strong type will be set to the resource type that the parameter will accept,
             "workspaceId": {
                 "type": "string",
                 "metadata": {
-                    "description": "The resource identifer for a Log Analytics workspace.",
+                    "description": "The resource identifier for a Log Analytics workspace.",
                     "strongType": "Microsoft.OperationalInsights/workspaces"
                 }
             }
@@ -106,7 +110,7 @@ The strong type will be set to the resource type that the parameter will accept,
     @metadata({
       strongType: 'Microsoft.OperationalInsights/workspaces'
     })
-    @description('The resource identifer for a Log Analytics workspace.')
+    @description('The resource identifier for a Log Analytics workspace.')
     param workspaceId string
     ```
 
@@ -116,13 +120,13 @@ Strong type also supports the following non-resource type values:
 
 ## Scope functions
 
-Azure deployments support a number of [scope functions][3] can be used within Infrastructure as Code.
+Azure deployments support a number of [scope functions][4] can be used within Infrastructure as Code.
 When using PSRule for Azure, these functions have a default meaning that can be configured.
 
 When configuring scope functions, only the properties you want to override has to be specified.
 Unspecified properties will inherit from the defaults.
 
-  [3]: https://docs.microsoft.com/azure/azure-resource-manager/templates/template-functions-scope
+  [4]: https://docs.microsoft.com/azure/azure-resource-manager/templates/template-functions-scope
 
 ### Subscription
 

--- a/src/PSRule.Rules.Azure/Common/JsonExtensions.cs
+++ b/src/PSRule.Rules.Azure/Common/JsonExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Linq;
@@ -40,7 +40,7 @@ namespace PSRule.Rules.Azure
 
     internal static class JsonExtensions
     {
-        private const string FIELD_DEPENDSON = "dependsOn";
+        private const string PROPERTY_DEPENDSON = "dependsOn";
         private const string TARGETINFO_KEY = "_PSRule";
         private const string TARGETINFO_SOURCE = "source";
         private const string TARGETINFO_FILE = "file";
@@ -99,6 +99,16 @@ namespace PSRule.Rules.Azure
             return false;
         }
 
+        internal static bool TryGetProperty(this JObject o, string propertyName, out string value)
+        {
+            value = null;
+            if (!TryGetProperty<JValue>(o, propertyName, out var v))
+                return false;
+
+            value = v.Value<string>();
+            return true;
+        }
+
         internal static void UseProperty<TValue>(this JObject o, string propertyName, out TValue value) where TValue : JToken, new()
         {
             if (!o.TryGetValue(propertyName, System.StringComparison.OrdinalIgnoreCase, out var v))
@@ -113,7 +123,7 @@ namespace PSRule.Rules.Azure
         internal static bool TryGetDependencies(this JObject resource, out string[] dependencies)
         {
             dependencies = null;
-            if (!(resource.ContainsKey(FIELD_DEPENDSON) && resource[FIELD_DEPENDSON] is JArray d && d.Count > 0))
+            if (!(resource.ContainsKey(PROPERTY_DEPENDSON) && resource[PROPERTY_DEPENDSON] is JArray d && d.Count > 0))
                 return false;
 
             dependencies = d.Values<string>().ToArray();

--- a/src/PSRule.Rules.Azure/Common/LazyValue.cs
+++ b/src/PSRule.Rules.Azure/Common/LazyValue.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace PSRule.Rules.Azure
+{
+    internal interface ILazyValue
+    {
+        object GetValue();
+    }
+
+    internal interface ILazyObject
+    {
+        bool TryProperty(string propertyName, out object value);
+    }
+
+    internal sealed class LazyValue : ILazyValue
+    {
+        private readonly Func<object> _Value;
+
+        public LazyValue(Func<object> value)
+        {
+            _Value = value;
+        }
+
+        public object GetValue()
+        {
+            return _Value();
+        }
+    }
+}

--- a/src/PSRule.Rules.Azure/Common/ResourceDependencyComparer.cs
+++ b/src/PSRule.Rules.Azure/Common/ResourceDependencyComparer.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using PSRule.Rules.Azure.Data.Template;
+
+namespace PSRule.Rules.Azure
+{
+    internal sealed class ResourceDependencyComparer : IComparer<IResourceValue>
+    {
+        public int Compare(IResourceValue x, IResourceValue y)
+        {
+            if (x.DependsOn(y))
+                return 1;
+
+            return y.DependsOn(x) ? -1 : 0;
+        }
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
@@ -178,10 +178,10 @@ namespace PSRule.Rules.Azure.Data.Template
                 return property.Value<object>();
             }
 
-            if (result is MockNode mockNode)
-                return mockNode.GetMember(propertyName);
+            if (result is ILazyObject lazy && lazy.TryProperty(propertyName, out var value))
+                return value;
 
-            if (TryPropertyOrField(result, propertyName, out var value))
+            if (TryPropertyOrField(result, propertyName, out value))
                 return value;
 
             throw new ExpressionReferenceException(propertyName, string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.PropertyNotFound, propertyName));

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -22,6 +22,17 @@ namespace PSRule.Rules.Azure.Data.Template
     /// </summary>
     internal static class Functions
     {
+        private const string PROPERTY_FULL = "Full";
+        private const string PROPERTY_PROPERTIES = "properties";
+        private const string PROPERTY_RESOURCETYPE = "resourceType";
+        private const string PROPERTY_PROVIDERNAMESPACE = "providerNamespace";
+        private const string PROPERTY_LOCATION = "location";
+        private const string PROPERTY_NUMBEROFZONES = "numberOfZones";
+        private const string PROPERTY_OFFSET = "offset";
+        private const string PROPERTY_OPERAND1 = "operand1";
+        private const string PROPERTY_OPERAND2 = "operand2";
+        private const string PROPERTY_VALUETOCONVERT = "valueToConvert";
+
         internal readonly static IFunctionDescriptor[] Builtin = new IFunctionDescriptor[]
         {
             // Array and object
@@ -697,21 +708,21 @@ namespace PSRule.Rules.Azure.Data.Template
                 throw ArgumentsOutOfRange(nameof(PickZones), args);
 
             if (!ExpressionHelpers.TryString(args[0], out var providerNamespace))
-                throw ArgumentInvalidString(nameof(PickZones), "providerNamespace");
+                throw ArgumentInvalidString(nameof(PickZones), PROPERTY_PROVIDERNAMESPACE);
 
             if (!ExpressionHelpers.TryString(args[1], out var resourceType))
-                throw ArgumentInvalidString(nameof(PickZones), "resourceType");
+                throw ArgumentInvalidString(nameof(PickZones), PROPERTY_RESOURCETYPE);
 
             if (!ExpressionHelpers.TryString(args[2], out var location))
-                throw ArgumentInvalidString(nameof(PickZones), "location");
+                throw ArgumentInvalidString(nameof(PickZones), PROPERTY_LOCATION);
 
             var numberOfZones = 1;
             if (argCount > 3 && !ExpressionHelpers.TryInt(args[3], out numberOfZones))
-                throw ArgumentInvalidInteger(nameof(PickZones), "numberOfZones");
+                throw ArgumentInvalidInteger(nameof(PickZones), PROPERTY_NUMBEROFZONES);
 
             var offset = 0;
             if (argCount > 4 && !ExpressionHelpers.TryInt(args[4], out offset))
-                throw ArgumentInvalidInteger(nameof(PickZones), "offset");
+                throw ArgumentInvalidInteger(nameof(PickZones), PROPERTY_OFFSET);
 
             var resourceTypes = context.GetResourceType(providerNamespace, resourceType);
             if (resourceTypes == null || resourceTypes.Length == 0)
@@ -763,7 +774,7 @@ namespace PSRule.Rules.Azure.Data.Template
             if (!ExpressionHelpers.TryString(args[0], out var resourceId))
                 throw ArgumentFormatInvalid(nameof(Reference));
 
-            var full = argCount == 3 && ExpressionHelpers.TryString(args[2], out var fullValue) && string.Equals(fullValue, "Full", StringComparison.OrdinalIgnoreCase);
+            var full = argCount == 3 && ExpressionHelpers.TryString(args[2], out var fullValue) && string.Equals(fullValue, PROPERTY_FULL, StringComparison.OrdinalIgnoreCase);
             if (argCount == 3 && !full)
                 throw ArgumentFormatInvalid(nameof(Reference));
 
@@ -778,7 +789,7 @@ namespace PSRule.Rules.Azure.Data.Template
             if (resource is DeploymentValue deployment)
                 return full ? deployment : deployment.Properties;
 
-            return full ? resource.Value : resource.Value["properties"].Value<JObject>();
+            return full ? resource.Value : resource.Value[PROPERTY_PROPERTIES].Value<JObject>();
         }
 
         /// <summary>
@@ -929,10 +940,10 @@ namespace PSRule.Rules.Azure.Data.Template
                 throw ArgumentsOutOfRange(nameof(Add), args);
 
             if (!ExpressionHelpers.TryConvertLong(args[0], out var operand1))
-                throw ArgumentInvalidInteger(nameof(Add), "operand1");
+                throw ArgumentInvalidInteger(nameof(Add), PROPERTY_OPERAND1);
 
             if (!ExpressionHelpers.TryConvertLong(args[1], out var operand2))
-                throw ArgumentInvalidInteger(nameof(Add), "operand2");
+                throw ArgumentInvalidInteger(nameof(Add), PROPERTY_OPERAND2);
 
             return operand1 + operand2;
         }
@@ -956,10 +967,10 @@ namespace PSRule.Rules.Azure.Data.Template
                 throw ArgumentsOutOfRange(nameof(Div), args);
 
             if (!ExpressionHelpers.TryConvertLong(args[0], out var operand1))
-                throw ArgumentInvalidInteger(nameof(Div), "operand1");
+                throw ArgumentInvalidInteger(nameof(Div), PROPERTY_OPERAND1);
 
             if (!ExpressionHelpers.TryConvertLong(args[1], out var operand2))
-                throw ArgumentInvalidInteger(nameof(Div), "operand2");
+                throw ArgumentInvalidInteger(nameof(Div), PROPERTY_OPERAND2);
 
             if (operand2 == 0)
                 throw new DivideByZeroException();
@@ -975,9 +986,9 @@ namespace PSRule.Rules.Azure.Data.Template
             if (ExpressionHelpers.TryConvertLong(args[0], out var ivalue))
                 return (float)ivalue;
             else if (ExpressionHelpers.TryString(args[0], out var svalue))
-                return float.Parse(svalue, new CultureInfo("en-us"));
+                return float.Parse(svalue, AzureCulture);
 
-            throw ArgumentInvalidInteger(nameof(Float), "valueToConvert");
+            throw ArgumentInvalidInteger(nameof(Float), PROPERTY_VALUETOCONVERT);
         }
 
         internal static object Int(ITemplateContext context, object[] args)
@@ -988,7 +999,7 @@ namespace PSRule.Rules.Azure.Data.Template
             if (ExpressionHelpers.TryConvertLong(args[0], out var value))
                 return value;
 
-            throw ArgumentInvalidInteger(nameof(Int), "valueToConvert");
+            throw ArgumentInvalidInteger(nameof(Int), PROPERTY_VALUETOCONVERT);
         }
 
         internal static object Mod(ITemplateContext context, object[] args)
@@ -997,10 +1008,10 @@ namespace PSRule.Rules.Azure.Data.Template
                 throw ArgumentsOutOfRange(nameof(Mod), args);
 
             if (!ExpressionHelpers.TryConvertLong(args[0], out var operand1))
-                throw ArgumentInvalidInteger(nameof(Mod), "operand1");
+                throw ArgumentInvalidInteger(nameof(Mod), PROPERTY_OPERAND1);
 
             if (!ExpressionHelpers.TryConvertLong(args[1], out var operand2))
-                throw ArgumentInvalidInteger(nameof(Mod), "operand2");
+                throw ArgumentInvalidInteger(nameof(Mod), PROPERTY_OPERAND2);
 
             if (operand2 == 0)
                 throw new DivideByZeroException();
@@ -1014,10 +1025,10 @@ namespace PSRule.Rules.Azure.Data.Template
                 throw ArgumentsOutOfRange(nameof(Mul), args);
 
             if (!ExpressionHelpers.TryConvertLong(args[0], out var operand1))
-                throw ArgumentInvalidInteger(nameof(Mul), "operand1");
+                throw ArgumentInvalidInteger(nameof(Mul), PROPERTY_OPERAND1);
 
             if (!ExpressionHelpers.TryConvertLong(args[1], out var operand2))
-                throw ArgumentInvalidInteger(nameof(Mul), "operand2");
+                throw ArgumentInvalidInteger(nameof(Mul), PROPERTY_OPERAND2);
 
             return operand1 * operand2;
         }
@@ -1028,10 +1039,10 @@ namespace PSRule.Rules.Azure.Data.Template
                 throw ArgumentsOutOfRange(nameof(Sub), args);
 
             if (!ExpressionHelpers.TryConvertLong(args[0], out var operand1))
-                throw ArgumentInvalidInteger(nameof(Sub), "operand1");
+                throw ArgumentInvalidInteger(nameof(Sub), PROPERTY_OPERAND1);
 
             if (!ExpressionHelpers.TryConvertLong(args[1], out var operand2))
-                throw ArgumentInvalidInteger(nameof(Sub), "operand2");
+                throw ArgumentInvalidInteger(nameof(Sub), PROPERTY_OPERAND2);
 
             return operand1 - operand2;
         }
@@ -1420,7 +1431,7 @@ namespace PSRule.Rules.Azure.Data.Template
             if (ExpressionHelpers.TryString(args[0], out var svalue))
                 return svalue.PadLeft(totalLength, paddingCharacter[0]);
             else if (ExpressionHelpers.TryInt(args[1], out var ivalue))
-                return ivalue.ToString(new CultureInfo("en-us")).PadLeft(totalLength, paddingCharacter[0]);
+                return ivalue.ToString(AzureCulture).PadLeft(totalLength, paddingCharacter[0]);
 
             throw new ArgumentException();
         }

--- a/src/PSRule.Rules.Azure/Data/Template/Models.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Models.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -135,7 +135,7 @@ namespace PSRule.Rules.Azure.Data.Template
         public string storage { get; set; }
     }
 
-    public abstract class MockNode
+    public abstract class MockNode : ILazyObject
     {
         protected MockNode(MockNode parent)
         {
@@ -166,6 +166,12 @@ namespace PSRule.Rules.Azure.Data.Template
         }
 
         protected abstract string GetString();
+
+        bool ILazyObject.TryProperty(string propertyName, out object value)
+        {
+            value = GetMember(propertyName);
+            return true;
+        }
     }
 
     public sealed class MockResource : MockNode

--- a/src/PSRule.Rules.Azure/Data/Template/ResourceValue.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ResourceValue.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Newtonsoft.Json.Linq;
+using static PSRule.Rules.Azure.Data.Template.TemplateVisitor;
+
+namespace PSRule.Rules.Azure.Data.Template
+{
+    internal interface IResourceValue
+    {
+        JObject Value { get; }
+
+        string Id { get; }
+
+        string Type { get; }
+
+        TemplateContext.CopyIndexState Copy { get; }
+
+        bool DependsOn(string id);
+    }
+
+    internal static class ResourceValueExtensions
+    {
+        public static bool DependsOn(this IResourceValue resource, IResourceValue other)
+        {
+            return resource.DependsOn(other.Id);
+        }
+    }
+
+    [DebuggerDisplay("{Id}")]
+    internal sealed class ResourceValue : IResourceValue
+    {
+        private readonly HashSet<string> _Dependencies;
+
+        internal ResourceValue(string id, string type, JObject value, string[] dependencies, TemplateContext.CopyIndexState copy)
+        {
+            Id = id;
+            Type = type;
+            Value = value;
+            Copy = copy;
+            _Dependencies = dependencies == null || dependencies.Length == 0 ? null : new HashSet<string>(dependencies, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public JObject Value { get; }
+
+        public string Id { get; }
+
+        public string Type { get; }
+
+        public TemplateContext.CopyIndexState Copy { get; }
+
+        public bool DependsOn(string id)
+        {
+            return _Dependencies != null && _Dependencies.Contains(id);
+        }
+    }
+
+    [DebuggerDisplay("{Id}")]
+    internal sealed class DeploymentValue : IResourceValue, ILazyObject
+    {
+        private const string RESOURCETYPE_DEPLOYMENT = "Microsoft.Resources/deployments";
+
+        private readonly HashSet<string> _Dependencies;
+        private readonly Lazy<JObject> _Value;
+        private readonly Dictionary<string, ILazyValue> _Outputs;
+
+        internal DeploymentValue(string id, JObject value, string[] dependencies, TemplateContext.CopyIndexState copy)
+            : this(id, () => value, dependencies, copy) { }
+
+        internal DeploymentValue(string id, Func<JObject> value, string[] dependencies, TemplateContext.CopyIndexState copy)
+        {
+            Id = id;
+            _Value = new Lazy<JObject>(value);
+            Copy = copy;
+            _Dependencies = dependencies == null || dependencies.Length == 0 ? null : new HashSet<string>(dependencies, StringComparer.OrdinalIgnoreCase);
+            Properties = new DeploymentProperties(this);
+            _Outputs = new Dictionary<string, ILazyValue>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private sealed class DeploymentProperties : ILazyObject
+        {
+            private readonly DeploymentValue _Deployment;
+            private readonly JObject _Properties;
+            private readonly DeploymentOutputs _Outputs;
+
+            public DeploymentProperties(DeploymentValue deployment)
+            {
+                _Deployment = deployment;
+                _Deployment.Value.TryGetProperty("properties", out _Properties);
+                _Outputs = new DeploymentOutputs(deployment);
+            }
+
+            public bool TryProperty(string propertyName, out object value)
+            {
+                value = null;
+                if (StringComparer.OrdinalIgnoreCase.Equals(propertyName, "outputs"))
+                    value = _Outputs;
+                else if (_Properties.TryGetProperty<JToken>(propertyName, out var token))
+                    value = token;
+
+                return value != null;
+            }
+        }
+
+        private sealed class DeploymentOutputs : ILazyObject
+        {
+            private readonly DeploymentValue _Deployment;
+
+            public DeploymentOutputs(DeploymentValue deployment)
+            {
+                _Deployment = deployment;
+            }
+
+            public bool TryProperty(string propertyName, out object value)
+            {
+                value = null;
+                if (!_Deployment._Outputs.TryGetValue(propertyName, out var lazy))
+                    return false;
+
+                value = lazy.GetValue();
+                return true;
+            }
+        }
+
+        public JObject Value => _Value.Value;
+
+        public string Id { get; }
+
+        public string Type => RESOURCETYPE_DEPLOYMENT;
+
+        public TemplateContext.CopyIndexState Copy { get; }
+
+        public ILazyObject Properties { get; }
+
+        public bool DependsOn(string id)
+        {
+            return _Dependencies != null && _Dependencies.Contains(id);
+        }
+
+        public void AddOutput(string name, ILazyValue output)
+        {
+            _Outputs.Add(name, output);
+        }
+
+        public bool TryProperty(string propertyName, out object value)
+        {
+            value = null;
+            if (StringComparer.OrdinalIgnoreCase.Equals(propertyName, "properties"))
+                value = Properties;
+            else if (Value.TryGetProperty<JToken>(propertyName, out var token))
+                value = token;
+
+            return value != null;
+        }
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Template/ResourceValue.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ResourceValue.cs
@@ -63,6 +63,9 @@ namespace PSRule.Rules.Azure.Data.Template
     {
         private const string RESOURCETYPE_DEPLOYMENT = "Microsoft.Resources/deployments";
 
+        private const string PROPERTY_PROPERTIES = "properties";
+        private const string PROPERTY_OUTPUTS = "outputs";
+
         private readonly HashSet<string> _Dependencies;
         private readonly Lazy<JObject> _Value;
         private readonly Dictionary<string, ILazyValue> _Outputs;
@@ -89,14 +92,14 @@ namespace PSRule.Rules.Azure.Data.Template
             public DeploymentProperties(DeploymentValue deployment)
             {
                 _Deployment = deployment;
-                _Deployment.Value.TryGetProperty("properties", out _Properties);
+                _Deployment.Value.TryGetProperty(PROPERTY_PROPERTIES, out _Properties);
                 _Outputs = new DeploymentOutputs(deployment);
             }
 
             public bool TryProperty(string propertyName, out object value)
             {
                 value = null;
-                if (StringComparer.OrdinalIgnoreCase.Equals(propertyName, "outputs"))
+                if (StringComparer.OrdinalIgnoreCase.Equals(propertyName, PROPERTY_OUTPUTS))
                     value = _Outputs;
                 else if (_Properties.TryGetProperty<JToken>(propertyName, out var token))
                     value = token;
@@ -148,7 +151,7 @@ namespace PSRule.Rules.Azure.Data.Template
         public bool TryProperty(string propertyName, out object value)
         {
             value = null;
-            if (StringComparer.OrdinalIgnoreCase.Equals(propertyName, "properties"))
+            if (StringComparer.OrdinalIgnoreCase.Equals(propertyName, PROPERTY_PROPERTIES))
                 value = Properties;
             else if (Value.TryGetProperty<JToken>(propertyName, out var token))
                 value = token;

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json.Linq;
 using PSRule.Rules.Azure.Configuration;
 using PSRule.Rules.Azure.Pipeline;
 using PSRule.Rules.Azure.Resources;
+using static PSRule.Rules.Azure.Data.Template.TemplateVisitor;
 
 namespace PSRule.Rules.Azure.Data.Template
 {
@@ -17,9 +18,9 @@ namespace PSRule.Rules.Azure.Data.Template
 
     internal interface ITemplateContext
     {
-        TemplateVisitor.TemplateContext.CopyIndexStore CopyIndex { get; }
+        TemplateContext.CopyIndexStore CopyIndex { get; }
 
-        JObject Deployment { get; }
+        DeploymentValue Deployment { get; }
 
         string TemplateFile { get; }
 
@@ -42,6 +43,8 @@ namespace PSRule.Rules.Azure.Data.Template
         ResourceProviderType[] GetResourceType(string providerNamespace, string resourceType);
 
         bool TryVariable(string variableName, out object value);
+
+        bool TryGetResource(string resourceId, out IResourceValue resource);
 
         void WriteDebug(string message, params object[] args);
 
@@ -90,6 +93,8 @@ namespace PSRule.Rules.Azure.Data.Template
         private const string PROPERTY_OUTPUT = "output";
         private const string PROPERTY_METADATA = "metadata";
         private const string PROPERTY_GENERATOR = "_generator";
+        private const string PROPERTY_CONDITION = "condition";
+        private const string PROPERTY_DEPENDSON = "dependsOn";
 
         internal sealed class TemplateContext : ITemplateContext
         {
@@ -100,24 +105,24 @@ namespace PSRule.Rules.Azure.Data.Template
 
             internal readonly PipelineContext Pipeline;
 
-            private readonly Stack<JObject> _Deployment;
+            private readonly Stack<DeploymentValue> _Deployment;
             private readonly ExpressionFactory _ExpressionFactory;
             private readonly ExpressionBuilder _ExpressionBuilder;
-            private readonly List<ResourceValue> _Resources;
-            private readonly Dictionary<string, ResourceValue> _ResourceIds;
+            private readonly List<IResourceValue> _Resources;
+            private readonly Dictionary<string, IResourceValue> _ResourceIds;
             private readonly ResourceProviderHelper _ResourceProviderHelper;
             private readonly Dictionary<string, JToken> _ParameterAssignments;
             private readonly TemplateValidator _Validator;
 
-            private JObject _CurrentDeployment;
+            private DeploymentValue _CurrentDeployment;
             private bool? _IsGenerated;
             private JObject _Parameters;
             private Dictionary<string, CloudEnvironment> _Environments;
 
             internal TemplateContext()
             {
-                _Resources = new List<ResourceValue>();
-                _ResourceIds = new Dictionary<string, ResourceValue>(StringComparer.OrdinalIgnoreCase);
+                _Resources = new List<IResourceValue>();
+                _ResourceIds = new Dictionary<string, IResourceValue>(StringComparer.OrdinalIgnoreCase);
                 Parameters = new Dictionary<string, IParameterValue>(StringComparer.OrdinalIgnoreCase);
                 Variables = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
                 CopyIndex = new CopyIndexStore();
@@ -125,7 +130,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 Subscription = SubscriptionOption.Default;
                 Tenant = TenantOption.Default;
                 ManagementGroup = ManagementGroupOption.Default;
-                _Deployment = new Stack<JObject>();
+                _Deployment = new Stack<DeploymentValue>();
                 _ExpressionFactory = new ExpressionFactory();
                 _ExpressionBuilder = new ExpressionBuilder(_ExpressionFactory);
                 _ResourceProviderHelper = new ResourceProviderHelper();
@@ -190,7 +195,7 @@ namespace PSRule.Rules.Azure.Data.Template
 
             public ParameterDefaultsOption ParameterDefaults { get; private set; }
 
-            public JObject Deployment => _Deployment.Peek();
+            public DeploymentValue Deployment => _Deployment.Peek();
 
             public string TemplateFile { get; private set; }
 
@@ -204,46 +209,47 @@ namespace PSRule.Rules.Azure.Data.Template
                 return _ExpressionBuilder.Build(s);
             }
 
-            public void AddResource(JObject resource)
+            public void AddResource(IResourceValue resource)
             {
                 if (resource == null)
                     return;
 
-                GetResourceNameType(resource, out var nameParts, out var typeParts);
-                var resourceId = GetResourceId(nameParts, typeParts);
-                AddResource(new ResourceValue(resourceId, resource));
-            }
-
-            private void AddResource(ResourceValue resource)
-            {
                 _Resources.Add(resource);
-                _ResourceIds[resource.ResourceId] = resource;
+                _ResourceIds[resource.Id] = resource;
             }
 
-            public void AddResource(ResourceValue[] resource)
+            public void AddResource(IResourceValue[] resource)
             {
                 for (var i = 0; resource != null && i < resource.Length; i++)
                     AddResource(resource[i]);
             }
 
-            public ResourceValue[] GetResources()
+            public IResourceValue[] GetResources()
             {
                 return _Resources.ToArray();
             }
 
-            public void RemoveResource(ResourceValue resource)
+            public void RemoveResource(IResourceValue resource)
             {
                 _Resources.Remove(resource);
-                _ResourceIds.Remove(resource.ResourceId);
+                _ResourceIds.Remove(resource.Id);
             }
 
-            public bool TryGetResource(string resourceId, out ResourceValue resource)
+            public bool TryGetResource(string resourceId, out IResourceValue resource)
             {
                 if (_ResourceIds.TryGetValue(resourceId, out resource))
                     return true;
 
                 resource = null;
                 return false;
+            }
+
+            public void AddOutput(string name, JObject output)
+            {
+                if (string.IsNullOrEmpty(name) || output == null || _CurrentDeployment == null)
+                    return;
+
+                _CurrentDeployment.AddOutput(name, new LazyOutput(this, output));
             }
 
             public void WriteDebug(string message, params object[] args)
@@ -267,60 +273,37 @@ namespace PSRule.Rules.Azure.Data.Template
                 }
             }
 
-            private static string GetResourceId(string[] nameParts, string[] typeParts, int depth = -1)
-            {
-                if (depth == -1)
-                    depth = nameParts.Length;
-
-                var name = new string[2 * depth + 1];
-                var nameIndex = 0;
-                var typeIndex = 0;
-                name[0] = typeParts[typeIndex++];
-                name[1] = typeParts[typeIndex++];
-                name[2] = nameParts[nameIndex++];
-                for (var i = 3; i < 2 * depth + 1; i += 2)
-                {
-                    name[i] = typeParts[typeIndex++];
-                    name[i + 1] = nameParts[nameIndex++];
-                }
-                return string.Join("/", name);
-            }
-
-            internal static bool TryParentResourceId(JObject resource, out string[] resourceId)
+            internal bool TryParentResourceId(JObject resource, out string[] resourceId)
             {
                 if (GetResourceScope(resource, out resourceId))
                     return true;
 
-                if (!GetResourceNameType(resource, out var nameParts, out var typeParts))
+                if (!GetResourceNameType(resource, out var name, out var type) ||
+                    !ResourceHelper.TryResourceIdComponents(type, name, out var resourceTypeComponents, out var nameComponents))
                     return false;
 
-                resourceId = new string[nameParts.Length - 1];
-                for (var i = 0; i < nameParts.Length - 1; i++)
-                    resourceId[i] = GetResourceId(nameParts, typeParts, i + 1);
+                resourceId = new string[nameComponents.Length - 1];
+                for (var i = 0; i < nameComponents.Length - 1; i++)
+                    resourceId[i] = ResourceHelper.CombineResourceId(Subscription.SubscriptionId, ResourceGroup.Name, resourceTypeComponents, nameComponents, depth: i);
 
                 return true;
             }
 
-            private static bool GetResourceNameType(JObject resource, out string[] nameParts, out string[] typeParts)
+            private static bool GetResourceNameType(JObject resource, out string name, out string type)
             {
-                var name = resource[PROPERTY_NAME].Value<string>();
-                nameParts = name.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-                typeParts = null;
-                if (nameParts == null || nameParts.Length == 0)
-                    return false;
-
-                var type = resource[PROPERTY_TYPE].Value<string>();
-                typeParts = type.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-                return typeParts != null && typeParts.Length == nameParts.Length + 1;
+                name = null;
+                type = null;
+                return resource != null && resource.TryGetProperty(PROPERTY_NAME, out name) && resource.TryGetProperty(PROPERTY_TYPE, out type);
             }
 
-            private static bool GetResourceScope(JObject resource, out string[] resourceId)
+            private bool GetResourceScope(JObject resource, out string[] resourceId)
             {
                 resourceId = null;
                 if (!resource.ContainsKey(PROPERTY_SCOPE))
                     return false;
 
-                resourceId = new string[] { resource[PROPERTY_SCOPE].Value<string>() };
+                var parentId = ResourceGroup?.Id ?? Subscription.Id;
+                resourceId = new string[] { string.Concat(parentId, "/providers/", resource[PROPERTY_SCOPE].Value<string>()) };
                 return true;
             }
 
@@ -400,6 +383,17 @@ namespace PSRule.Rules.Azure.Data.Template
                 internal T CloneInput<T>() where T : JToken
                 {
                     return Input == null ? null : (T)Input.CloneTemplateJToken();
+                }
+
+                internal CopyIndexState Clone()
+                {
+                    return new CopyIndexState
+                    {
+                        Index = Index,
+                        Count = Count,
+                        Input = Input,
+                        Name = Name
+                    };
                 }
             }
 
@@ -481,7 +475,8 @@ namespace PSRule.Rules.Azure.Data.Template
                     { PROPERTY_PARAMETERS, _Parameters },
                     { PROPERTY_MODE, "Incremental" },
                     { PROPERTY_PROVISIONINGSTATE, "Accepted" },
-                    { PROPERTY_TEMPLATEHASH, templateHash }
+                    { PROPERTY_TEMPLATEHASH, templateHash },
+                    { PROPERTY_OUTPUTS, new JObject() }
                 };
 
                 var deployment = new JObject
@@ -491,13 +486,13 @@ namespace PSRule.Rules.Azure.Data.Template
                     { PROPERTY_PROPERTIES, properties },
                     { PROPERTY_LOCATION, ResourceGroup.Location },
                     { PROPERTY_TYPE, RESOURCETYPE_DEPLOYMENT },
-                    { PROPERTY_METADATA, metadata },
+                    { PROPERTY_METADATA, metadata }
                 };
-
                 deployment.SetTargetInfo(TemplateFile, ParameterFile);
-                AddResource(new ResourceValue(string.Concat(RESOURCETYPE_DEPLOYMENT, "/", deploymentName), deployment));
-                _CurrentDeployment = deployment;
-                _Deployment.Push(deployment);
+                var deploymentValue = new DeploymentValue(string.Concat(ResourceGroup.Id, "/providers/", RESOURCETYPE_DEPLOYMENT, "/", deploymentName), deployment, null, null);
+                AddResource(deploymentValue);
+                _CurrentDeployment = deploymentValue;
+                _Deployment.Push(deploymentValue);
             }
 
             internal void ExitDeployment()
@@ -511,7 +506,7 @@ namespace PSRule.Rules.Azure.Data.Template
             {
                 if (!_IsGenerated.HasValue)
                 {
-                    _IsGenerated = TryObjectProperty(_CurrentDeployment, PROPERTY_METADATA, out var metadata) &&
+                    _IsGenerated = TryObjectProperty(_CurrentDeployment.Value, PROPERTY_METADATA, out var metadata) &&
                         TryObjectProperty(metadata, PROPERTY_GENERATOR, out var generator) &&
                         TryStringProperty(generator, PROPERTY_NAME, out _);
                 }
@@ -534,7 +529,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 if (!Parameters.TryGetValue(parameterName, out var pv))
                     return false;
 
-                value = pv.GetValue(this);
+                value = pv.GetValue();
                 return true;
             }
 
@@ -585,7 +580,7 @@ namespace PSRule.Rules.Azure.Data.Template
 
                 if (value is ILazyValue weakValue)
                 {
-                    value = weakValue.GetValue(this);
+                    value = weakValue.GetValue();
                     Variables[variableName] = value;
                 }
                 return true;
@@ -623,7 +618,7 @@ namespace PSRule.Rules.Azure.Data.Template
 
             public void AddValidationIssue(string issueId, string name, string message, params object[] args)
             {
-                _CurrentDeployment.SetValidationIssue(issueId, name, message, args);
+                _CurrentDeployment.Value.SetValidationIssue(issueId, name, message, args);
             }
 
             internal void CheckParameter(string parameterName, JObject parameter)
@@ -631,8 +626,8 @@ namespace PSRule.Rules.Azure.Data.Template
                 if (!Parameters.TryGetValue(parameterName, out var value))
                     return;
 
-                if (value.Type == ParameterType.String && !string.IsNullOrEmpty(value.GetValue(this) as string))
-                    _Validator.ValidateParameter(this, parameterName, parameter, value.GetValue(this) as string);
+                if (value.Type == ParameterType.String && !string.IsNullOrEmpty(value.GetValue() as string))
+                    _Validator.ValidateParameter(this, parameterName, parameter, value.GetValue() as string);
             }
         }
 
@@ -649,7 +644,7 @@ namespace PSRule.Rules.Azure.Data.Template
 
             public TemplateContext.CopyIndexStore CopyIndex => _Inner.CopyIndex;
 
-            public JObject Deployment => throw new NotImplementedException();
+            public DeploymentValue Deployment => throw new NotImplementedException();
 
             public string TemplateFile => _Inner.TemplateFile;
 
@@ -689,6 +684,11 @@ namespace PSRule.Rules.Azure.Data.Template
                 return false;
             }
 
+            public bool TryGetResource(string resourceId, out IResourceValue resource)
+            {
+                return _Inner.TryGetResource(resourceId, out resource);
+            }
+
             public void WriteDebug(string message, params object[] args)
             {
                 _Inner.WriteDebug(message, args);
@@ -711,26 +711,13 @@ namespace PSRule.Rules.Azure.Data.Template
             }
         }
 
-        [DebuggerDisplay("{ResourceId}")]
-        internal sealed class ResourceValue
-        {
-            internal readonly string ResourceId;
-            internal readonly JObject Value;
-
-            internal ResourceValue(string resourceId, JObject value)
-            {
-                ResourceId = resourceId;
-                Value = value;
-            }
-        }
-
         internal interface IParameterValue
         {
             string Name { get; }
 
             ParameterType Type { get; }
 
-            object GetValue(TemplateContext context);
+            object GetValue();
         }
 
         internal sealed class SimpleParameterValue : IParameterValue
@@ -748,25 +735,22 @@ namespace PSRule.Rules.Azure.Data.Template
 
             public ParameterType Type { get; }
 
-            public object GetValue(TemplateContext context)
+            public object GetValue()
             {
                 return _Value;
             }
         }
 
-        internal interface ILazyValue
-        {
-            object GetValue(TemplateContext context);
-        }
-
         private sealed class LazyParameter<T> : ILazyValue, IParameterValue
         {
+            private readonly TemplateContext _Context;
             private readonly JToken _LazyValue;
             private T _Value;
             private bool _Resolved;
 
-            public LazyParameter(string name, ParameterType type, JToken defaultValue)
+            public LazyParameter(TemplateContext context, string name, ParameterType type, JToken defaultValue)
             {
+                _Context = context;
                 Name = name;
                 Type = type;
                 _LazyValue = defaultValue;
@@ -776,11 +760,11 @@ namespace PSRule.Rules.Azure.Data.Template
 
             public ParameterType Type { get; }
 
-            public object GetValue(TemplateContext context)
+            public object GetValue()
             {
                 if (!_Resolved)
                 {
-                    _Value = ExpandProperty<T>(context, _LazyValue);
+                    _Value = ExpandProperty<T>(_Context, _LazyValue);
                     _Resolved = true;
                 }
                 return _Value;
@@ -789,31 +773,36 @@ namespace PSRule.Rules.Azure.Data.Template
 
         private sealed class LazyVariable : ILazyValue
         {
-            internal readonly JToken _Value;
+            private readonly TemplateContext _Context;
+            private readonly JToken _Value;
 
-            public LazyVariable(JToken value)
+            public LazyVariable(TemplateContext context, JToken value)
             {
+                _Context = context;
                 _Value = value;
             }
 
-            public object GetValue(TemplateContext context)
+            public object GetValue()
             {
-                return ResolveVariable(context, _Value);
+                return ResolveVariable(_Context, _Value);
             }
         }
 
         private sealed class LazyOutput : ILazyValue
         {
-            internal readonly JToken _Value;
+            private readonly TemplateContext _Context;
+            private readonly JObject _Value;
 
-            public LazyOutput(JToken value)
+            public LazyOutput(TemplateContext context, JObject value)
             {
+                _Context = context;
                 _Value = value;
             }
 
-            public object GetValue(TemplateContext context)
+            public object GetValue()
             {
-                return ResolveVariable(context, _Value);
+                ResolveProperty(_Context, _Value, PROPERTY_VALUE);
+                return _Value;
             }
         }
 
@@ -899,7 +888,10 @@ namespace PSRule.Rules.Azure.Data.Template
 
         private static bool TryParameter(TemplateContext context, string parameterName, JObject parameter)
         {
-            return parameter == null || TryParameterAssignment(context, parameterName, parameter) || TryParameterDefaultValue(context, parameterName, parameter) || TryParameterDefault(context, parameterName, parameter);
+            return parameter == null ||
+                TryParameterAssignment(context, parameterName, parameter) ||
+                TryParameterDefaultValue(context, parameterName, parameter) ||
+                TryParameterDefault(context, parameterName, parameter);
         }
 
         private static bool TryParameterAssignment(TemplateContext context, string parameterName, JObject parameter)
@@ -944,15 +936,15 @@ namespace PSRule.Rules.Azure.Data.Template
         private static void AddParameterFromType(TemplateContext context, string parameterName, ParameterType type, JToken value)
         {
             if (type == ParameterType.Bool)
-                context.Parameter(new LazyParameter<bool>(parameterName, type, value));
+                context.Parameter(new LazyParameter<bool>(context, parameterName, type, value));
             else if (type == ParameterType.Int)
-                context.Parameter(new LazyParameter<long>(parameterName, type, value));
+                context.Parameter(new LazyParameter<long>(context, parameterName, type, value));
             else if (type == ParameterType.String)
-                context.Parameter(new LazyParameter<string>(parameterName, type, value));
+                context.Parameter(new LazyParameter<string>(context, parameterName, type, value));
             else if (type == ParameterType.Array)
-                context.Parameter(new LazyParameter<JArray>(parameterName, type, value));
+                context.Parameter(new LazyParameter<JArray>(context, parameterName, type, value));
             else if (type == ParameterType.Object)
-                context.Parameter(new LazyParameter<JObject>(parameterName, type, value));
+                context.Parameter(new LazyParameter<JObject>(context, parameterName, type, value));
             else
                 context.Parameter(parameterName, type, ExpandPropertyToken(context, value));
         }
@@ -1011,36 +1003,66 @@ namespace PSRule.Rules.Azure.Data.Template
             if (resources == null || resources.Length == 0)
                 return;
 
-            resources = SortResources(context, resources);
+            var expanded = new List<ResourceValue>();
             for (var i = 0; i < resources.Length; i++)
-                ResourceOuter(context, resources[i]);
+                expanded.AddRange(ResourceExpand(context, resources[i]));
+
+            var sorted = SortResources(context, expanded.ToArray());
+            for (var i = 0; i < sorted.Length; i++)
+                ResourceOuter(context, sorted[i]);
         }
 
-        private void ResourceOuter(TemplateContext context, JObject resource)
+        /// <summary>
+        /// Expand copied resources.
+        /// </summary>
+        private static IEnumerable<ResourceValue> ResourceExpand(TemplateContext context, JObject resource)
         {
             var copyIndex = GetResourceIterator(context, resource);
             while (copyIndex.Next())
             {
                 var instance = copyIndex.CloneInput<JObject>();
-                var condition = !resource.ContainsKey("condition") || ExpandProperty<bool>(context, resource, "condition");
+                var condition = !resource.ContainsKey(PROPERTY_CONDITION) || ExpandProperty<bool>(context, resource, PROPERTY_CONDITION);
                 if (!condition)
                     continue;
 
-                Resource(context, instance);
+                yield return ResourceInstance(context, instance, copyIndex);
             }
             if (copyIndex.IsCopy())
                 context.CopyIndex.Pop();
         }
 
-        protected virtual void Resource(TemplateContext context, JObject resource)
+        private static ResourceValue ResourceInstance(TemplateContext context, JObject resource, TemplateContext.CopyIndexState copyIndex)
+        {
+            if (resource.TryGetProperty<JValue>(PROPERTY_NAME, out var nameValue))
+                resource[PROPERTY_NAME] = ResolveToken(context, nameValue);
+
+            if (resource.TryGetProperty<JArray>(PROPERTY_DEPENDSON, out var dependsOn))
+                resource[PROPERTY_DEPENDSON] = ExpandArray(context, dependsOn);
+
+            resource.TryGetProperty(PROPERTY_NAME, out var name);
+            resource.TryGetProperty(PROPERTY_TYPE, out var type);
+            resource.TryGetDependencies(out var dependencies);
+            var resourceId = ResourceHelper.CombineResourceId(context.Subscription.SubscriptionId, context.ResourceGroup.Name, type, name);
+            return new ResourceValue(resourceId, type, resource, dependencies, copyIndex.Clone());
+        }
+
+        private void ResourceOuter(TemplateContext context, IResourceValue resource)
+        {
+            var copyIndex = RestoreResourceIterator(context, resource);
+            Resource(context, resource);
+            if (copyIndex != null && copyIndex.IsCopy())
+                context.CopyIndex.Pop();
+        }
+
+        protected virtual void Resource(TemplateContext context, IResourceValue resource)
         {
             // Get resource type
-            if (TryDeploymentResource(context, resource))
+            if (TryDeploymentResource(context, resource.Value))
                 return;
 
             // Expand resource properties
-            foreach (var property in resource.Properties())
-                ResolveProperty(context, resource, property.Name);
+            foreach (var property in resource.Value.Properties())
+                ResolveProperty(context, resource.Value, property.Name);
 
             Emit(context, resource);
         }
@@ -1122,7 +1144,6 @@ namespace PSRule.Rules.Azure.Data.Template
                 }
                 deploymentContext.Load(properties);
             }
-
             deploymentContext.SetSource(context.TemplateFile, context.ParameterFile);
             return deploymentContext;
         }
@@ -1161,7 +1182,7 @@ namespace PSRule.Rules.Azure.Data.Template
 
         protected virtual void Variable(TemplateContext context, string variableName, JToken value)
         {
-            context.Variable(variableName, new LazyVariable(value));
+            context.Variable(variableName, new LazyVariable(context, value));
         }
 
         protected virtual JToken VariableInstance(TemplateContext context, JToken value)
@@ -1197,9 +1218,18 @@ namespace PSRule.Rules.Azure.Data.Template
 
         #region Outputs
 
-        protected virtual void Outputs(TemplateContext context, JObject outputs)
+        protected void Outputs(TemplateContext context, JObject outputs)
         {
+            if (outputs == null || outputs.Count == 0)
+                return;
 
+            foreach (var output in outputs)
+                Output(context, output.Key, output.Value as JObject);
+        }
+
+        protected virtual void Output(TemplateContext context, string name, JObject output)
+        {
+            context.AddOutput(name, output);
         }
 
         #endregion Outputs
@@ -1417,6 +1447,15 @@ namespace PSRule.Rules.Azure.Data.Template
             return result;
         }
 
+        private static TemplateContext.CopyIndexState RestoreResourceIterator(TemplateContext context, IResourceValue value)
+        {
+            var state = value.Copy;
+            if (state != null && state.IsCopy())
+                context.CopyIndex.PushResourceType(state);
+
+            return state;
+        }
+
         private static JToken ExpandObject(ITemplateContext context, JObject obj)
         {
             foreach (var copyIndex in GetPropertyIterator(context, obj))
@@ -1544,14 +1583,18 @@ namespace PSRule.Rules.Azure.Data.Template
         /// <summary>
         /// Emit a resource object.
         /// </summary>
-        protected virtual void Emit(TemplateContext context, JObject resource)
+        protected virtual void Emit(TemplateContext context, IResourceValue resource)
         {
-            resource.SetTargetInfo(context.TemplateFile, context.ParameterFile);
+            resource.Value.SetTargetInfo(context.TemplateFile, context.ParameterFile);
             context.AddResource(resource);
         }
 
-        protected virtual JObject[] SortResources(TemplateContext context, JObject[] resources)
+        /// <summary>
+        /// Sort resources by dependencies.
+        /// </summary>
+        protected virtual IResourceValue[] SortResources(TemplateContext context, IResourceValue[] resources)
         {
+            Array.Sort(resources, new ResourceDependencyComparer());
             return resources;
         }
     }
@@ -1561,26 +1604,26 @@ namespace PSRule.Rules.Azure.Data.Template
     /// </summary>
     internal sealed class RuleDataExportVisitor : TemplateVisitor
     {
-        private const string FIELD_DEPENDSON = "dependsOn";
-        private const string FIELD_COMMENTS = "comments";
-        private const string FIELD_APIVERSION = "apiVersion";
-        private const string FIELD_CONDITION = "condition";
-        private const string FIELD_RESOURCES = "resources";
+        private const string PROPERTY_DEPENDSON = "dependsOn";
+        private const string PROPERTY_COMMENTS = "comments";
+        private const string PROPERTY_APIVERSION = "apiVersion";
+        private const string PROPERTY_CONDITION = "condition";
+        private const string PROPERTY_RESOURCES = "resources";
 
-        protected override void Resource(TemplateContext context, JObject resource)
+        protected override void Resource(TemplateContext context, IResourceValue resource)
         {
             // Remove resource properties that not required in rule data
-            if (resource.ContainsKey(FIELD_APIVERSION))
-                resource.Remove(FIELD_APIVERSION);
+            if (resource.Value.ContainsKey(PROPERTY_APIVERSION))
+                resource.Value.Remove(PROPERTY_APIVERSION);
 
-            if (resource.ContainsKey(FIELD_CONDITION))
-                resource.Remove(FIELD_CONDITION);
+            if (resource.Value.ContainsKey(PROPERTY_CONDITION))
+                resource.Value.Remove(PROPERTY_CONDITION);
 
-            if (resource.ContainsKey(FIELD_COMMENTS))
-                resource.Remove(FIELD_COMMENTS);
+            if (resource.Value.ContainsKey(PROPERTY_COMMENTS))
+                resource.Value.Remove(PROPERTY_COMMENTS);
 
-            if (!resource.TryGetDependencies(out _))
-                resource.Remove(FIELD_DEPENDSON);
+            if (!resource.Value.TryGetDependencies(out _))
+                resource.Value.Remove(PROPERTY_DEPENDSON);
 
             base.Resource(context, resource);
         }
@@ -1592,14 +1635,14 @@ namespace PSRule.Rules.Azure.Data.Template
             {
                 if (resources[i].Value.TryGetDependencies(out var dependencies))
                 {
-                    resources[i].Value.Remove(FIELD_DEPENDSON);
-                    if (TemplateContext.TryParentResourceId(resources[i].Value, out var parentResourceId))
+                    resources[i].Value.Remove(PROPERTY_DEPENDSON);
+                    if (context.TryParentResourceId(resources[i].Value, out var parentResourceId))
                     {
                         for (var j = 0; j < parentResourceId.Length; j++)
                         {
                             if (context.TryGetResource(parentResourceId[j], out var resource))
                             {
-                                resource.Value.UseProperty(FIELD_RESOURCES, out JArray innerResources);
+                                resource.Value.UseProperty(PROPERTY_RESOURCES, out JArray innerResources);
                                 innerResources.Add(resources[i].Value);
                                 context.RemoveResource(resources[i]);
                             }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -831,12 +831,12 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult | Should -HaveCount 3;
             $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterE';
 
-            $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[0].Reason | Should -BeExactly "The agent pool (agentpool1) deployed to region (eastus) should use following availability zones [1, 2, 3].";
-            $ruleResult[1].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[1].Reason | Should -BeExactly "The agent pool (agentpool1) deployed to region (eastus) should use following availability zones [1, 2, 3].";
-            $ruleResult[2].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[2].Reason | Should -BeExactly "The agent pool (clusterE/agentpool2) deployed to region (eastus) should use following availability zones [1, 2, 3].";
+            ($ruleResult | Where-Object { $_.TargetName -eq 'clusterA' }).Reason | Should -Not -BeNullOrEmpty;
+            ($ruleResult | Where-Object { $_.TargetName -eq 'clusterA' }).Reason | Should -BeExactly "The agent pool (agentpool1) deployed to region (eastus) should use following availability zones [1, 2, 3].";
+            ($ruleResult | Where-Object { $_.TargetName -eq 'clusterB' }).Reason | Should -Not -BeNullOrEmpty;
+            ($ruleResult | Where-Object { $_.TargetName -eq 'clusterB' }).Reason | Should -BeExactly "The agent pool (agentpool1) deployed to region (eastus) should use following availability zones [1, 2, 3].";
+            ($ruleResult | Where-Object { $_.TargetName -eq 'clusterE' }).Reason | Should -Not -BeNullOrEmpty;
+            ($ruleResult | Where-Object { $_.TargetName -eq 'clusterE' }).Reason | Should -BeExactly "The agent pool (clusterE/agentpool2) deployed to region (eastus) should use following availability zones [1, 2, 3].";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -873,7 +873,7 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "The diagnostic setting (clusterA/Microsoft.Insights/service) logs should enable at least one of (kube-audit, kube-audit-admin) and guard.";
             $ruleResult[1].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[1].Reason | Should -BeExactly "The diagnostic setting (clusterE/Microsoft.Insights/service) logs should enable at least one of (kube-audit, kube-audit-admin) and guard.";
+            $ruleResult[1].Reason | Should -BeExactly "The diagnostic setting (clusterB/Microsoft.Insights/service) logs should enable at least one of (kube-audit, kube-audit-admin) and guard.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -891,12 +891,12 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult | Should -HaveCount 3;
             $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterB', 'clusterD';
 
-            $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[0].Reason | Should -BeExactly "The diagnostic setting (clusterA/Microsoft.Insights/service) logs should enable (cluster-autoscaler, kube-apiserver, kube-controller-manager, kube-scheduler, AllMetrics).";
-            $ruleResult[1].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[1].Reason | Should -BeExactly "The diagnostic setting (clusterE/Microsoft.Insights/service) logs should enable (cluster-autoscaler, kube-apiserver, kube-controller-manager, kube-scheduler, AllMetrics).";
-            $ruleResult[2].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[2].Reason | Should -BeExactly "The diagnostic setting (clusterD/Microsoft.Insights/service) logs should enable (cluster-autoscaler, kube-apiserver, kube-controller-manager, kube-scheduler, AllMetrics).";
+            ($ruleResult | Where-Object { $_.TargetName -eq 'clusterA' }).Reason | Should -Not -BeNullOrEmpty;
+            ($ruleResult | Where-Object { $_.TargetName -eq 'clusterA' }).Reason | Should -BeExactly "The diagnostic setting (clusterA/Microsoft.Insights/service) logs should enable (cluster-autoscaler, kube-apiserver, kube-controller-manager, kube-scheduler, AllMetrics).";
+            ($ruleResult | Where-Object { $_.TargetName -eq 'clusterB' }).Reason | Should -Not -BeNullOrEmpty;
+            ($ruleResult | Where-Object { $_.TargetName -eq 'clusterB' }).Reason | Should -BeExactly "The diagnostic setting (clusterB/Microsoft.Insights/service) logs should enable (cluster-autoscaler, kube-apiserver, kube-controller-manager, kube-scheduler, AllMetrics).";
+            ($ruleResult | Where-Object { $_.TargetName -eq 'clusterD' }).Reason | Should -Not -BeNullOrEmpty;
+            ($ruleResult | Where-Object { $_.TargetName -eq 'clusterD' }).Reason | Should -BeExactly "The diagnostic setting (clusterD/Microsoft.Insights/service) logs should enable (cluster-autoscaler, kube-apiserver, kube-controller-manager, kube-scheduler, AllMetrics).";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
@@ -283,15 +283,16 @@ Describe 'Export-AzRuleTemplateData' -Tag 'Cmdlet','Export-AzRuleTemplateData' {
             $result = Get-Content -Path $outputFile -Raw | ConvertFrom-Json;
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 11;
-            $result[1].name | Should -Be 'vnet-001';
-            $result[1].properties.addressSpace.addressPrefixes | Should -Be "10.1.0.0/24";
-            $result[1].properties.subnets.Length | Should -Be 3;
-            $result[1].properties.subnets[0].name | Should -Be 'GatewaySubnet';
-            $result[1].properties.subnets[0].properties.addressPrefix | Should -Be '10.1.0.0/27';
-            $result[1].properties.subnets[2].name | Should -Be 'subnet2';
-            $result[1].properties.subnets[2].properties.addressPrefix | Should -Be '10.1.0.64/28';
-            $result[1].properties.subnets[2].properties.networkSecurityGroup.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/networkSecurityGroups/nsg-subnet2$';
-            $result[1].properties.subnets[2].properties.routeTable.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/routeTables/route-subnet2$';
+            $filteredResult = $result | Where-Object { $_.name -eq 'vnet-001' };
+            $filteredResult | Should -Not -BeNullOrEmpty;
+            $filteredResult.properties.addressSpace.addressPrefixes | Should -Be "10.1.0.0/24";
+            $filteredResult.properties.subnets.Length | Should -Be 3;
+            $filteredResult.properties.subnets[0].name | Should -Be 'GatewaySubnet';
+            $filteredResult.properties.subnets[0].properties.addressPrefix | Should -Be '10.1.0.0/27';
+            $filteredResult.properties.subnets[2].name | Should -Be 'subnet2';
+            $filteredResult.properties.subnets[2].properties.addressPrefix | Should -Be '10.1.0.64/28';
+            $filteredResult.properties.subnets[2].properties.networkSecurityGroup.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/networkSecurityGroups/nsg-subnet2$';
+            $filteredResult.properties.subnets[2].properties.routeTable.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/routeTables/route-subnet2$';
         }
 
         It 'Returns file not found' {
@@ -322,14 +323,15 @@ Describe 'Export-AzRuleTemplateData' -Tag 'Cmdlet','Export-AzRuleTemplateData' {
             $result = @(Export-AzRuleTemplateData @exportParams -PassThru);
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 11;
-            $result[1].name | Should -Be 'vnet-001';
-            $result[1].properties.subnets.Length | Should -Be 3;
-            $result[1].properties.subnets[0].name | Should -Be 'GatewaySubnet';
-            $result[1].properties.subnets[0].properties.addressPrefix | Should -Be '10.1.0.0/27';
-            $result[1].properties.subnets[2].name | Should -Be 'subnet2';
-            $result[1].properties.subnets[2].properties.addressPrefix | Should -Be '10.1.0.64/28';
-            $result[1].properties.subnets[2].properties.networkSecurityGroup.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/networkSecurityGroups/nsg-subnet2$';
-            $result[1].properties.subnets[2].properties.routeTable.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/routeTables/route-subnet2$';
+            $filteredResult = $result | Where-Object { $_.name -eq 'vnet-001' };
+            $filteredResult | Should -Not -BeNullOrEmpty;
+            $filteredResult.properties.subnets.Length | Should -Be 3;
+            $filteredResult.properties.subnets[0].name | Should -Be 'GatewaySubnet';
+            $filteredResult.properties.subnets[0].properties.addressPrefix | Should -Be '10.1.0.0/27';
+            $filteredResult.properties.subnets[2].name | Should -Be 'subnet2';
+            $filteredResult.properties.subnets[2].properties.addressPrefix | Should -Be '10.1.0.64/28';
+            $filteredResult.properties.subnets[2].properties.networkSecurityGroup.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/networkSecurityGroups/nsg-subnet2$';
+            $filteredResult.properties.subnets[2].properties.routeTable.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/routeTables/route-subnet2$';
         }
     }
 
@@ -352,10 +354,12 @@ Describe 'Export-AzRuleTemplateData' -Tag 'Cmdlet','Export-AzRuleTemplateData' {
             $result = Export-AzRuleTemplateData @exportParams -PassThru;
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 11;
-            $result[1].properties.subnets.Length | Should -Be 3;
-            $result[1].properties.subnets[2].properties.networkSecurityGroup.id | Should -Match '^/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/networkSecurityGroups/nsg-subnet2$';
-            $result[1].properties.subnets[2].properties.routeTable.id | Should -Match '^/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/routeTables/route-subnet2$';
-            $result[1].tags.role | Should -Match 'Networking';
+            $filteredResult = $result | Where-Object { $_.name -eq 'vnet-001' };
+            $filteredResult | Should -Not -BeNullOrEmpty;
+            $filteredResult.properties.subnets.Length | Should -Be 3;
+            $filteredResult.properties.subnets[2].properties.networkSecurityGroup.id | Should -Match '^/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/networkSecurityGroups/nsg-subnet2$';
+            $filteredResult.properties.subnets[2].properties.routeTable.id | Should -Match '^/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/routeTables/route-subnet2$';
+            $filteredResult.tags.role | Should -Match 'Networking';
         }
     }
 
@@ -372,7 +376,9 @@ Describe 'Export-AzRuleTemplateData' -Tag 'Cmdlet','Export-AzRuleTemplateData' {
             $result = Export-AzRuleTemplateData @exportParams -PassThru;
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 11;
-            $result[1].tags.role | Should -Be 'Custom';
+            $filteredResult = $result | Where-Object { $_.name -eq 'vnet-001' };
+            $filteredResult | Should -Not -BeNullOrEmpty;
+            $filteredResult.tags.role | Should -Be 'Custom';
         }
     }
 
@@ -398,9 +404,11 @@ Describe 'Export-AzRuleTemplateData' -Tag 'Cmdlet','Export-AzRuleTemplateData' {
             $result = Export-AzRuleTemplateData @exportParams -PassThru;
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 11;
-            $result[1].properties.subnets.Length | Should -Be 3;
-            $result[1].properties.subnets[2].properties.networkSecurityGroup.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/test-rg/providers/Microsoft\.Network/networkSecurityGroups/nsg-subnet2$';
-            $result[1].properties.subnets[2].properties.routeTable.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/test-rg/providers/Microsoft\.Network/routeTables/route-subnet2$';
+            $filteredResult = $result | Where-Object { $_.name -eq 'vnet-001' };
+            $filteredResult | Should -Not -BeNullOrEmpty;
+            $filteredResult.properties.subnets.Length | Should -Be 3;
+            $filteredResult.properties.subnets[2].properties.networkSecurityGroup.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/test-rg/providers/Microsoft\.Network/networkSecurityGroups/nsg-subnet2$';
+            $filteredResult.properties.subnets[2].properties.routeTable.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/test-rg/providers/Microsoft\.Network/routeTables/route-subnet2$';
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -723,10 +723,10 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
             context.EnterDeployment("unit-test", JObject.Parse("{ \"contentVersion\": \"1.0.0.0\" }"), isNested: false);
 
-            var actual1 = Functions.Deployment(context, null) as JObject;
-            Assert.Equal("unit-test", actual1["name"]);
-            Assert.Equal("1.0.0.0", actual1["properties"]["template"]["contentVersion"]);
-            Assert.Equal("abcdef", actual1["properties"]["parameters"]["name"]["value"]);
+            var actual1 = Functions.Deployment(context, null) as DeploymentValue;
+            Assert.Equal("unit-test", actual1.Value["name"]);
+            Assert.Equal("1.0.0.0", actual1.Value["properties"]["template"]["contentVersion"]);
+            Assert.Equal("abcdef", actual1.Value["properties"]["parameters"]["name"]["value"]);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Deployment(context, new object[] { 123 }));
         }

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -130,6 +130,9 @@
     <None Update="Tests.Bicep.1.Parameters.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Tests.Bicep.2.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/PSRule.Rules.Azure.Tests/ResourceDependencyComparerTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/ResourceDependencyComparerTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Newtonsoft.Json.Linq;
+using PSRule.Rules.Azure.Data.Template;
+using Xunit;
+using static PSRule.Rules.Azure.Data.Template.TemplateVisitor;
+
+namespace PSRule.Rules.Azure
+{
+    public sealed class ResourceDependencyComparerTests
+    {
+        [Fact]
+        public void SortWithComparer()
+        {
+            var context = new TemplateContext();
+            var comparer = new ResourceDependencyComparer();
+            var resources = new IResourceValue[]
+            {
+                GetResourceValue(context, JObject.Parse("{ \"type\": \"Microsoft.Network/virtualNetworks\", \"name\": \"vnet-001\", \"dependsOn\": [ \"/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/ps-rule-test-rg/providers/Microsoft.Network/routeTables/rt-001\", \"/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/ps-rule-test-rg/providers/Microsoft.Network/routeTables/rt-002\" ] }")),
+                GetResourceValue(context, JObject.Parse("{ \"type\": \"Microsoft.Network/routeTables\", \"name\": \"rt-001\", \"dependsOn\": [ ] }")),
+                GetResourceValue(context, JObject.Parse("{ \"type\": \"Microsoft.Network/routeTables\", \"name\": \"rt-002\" }")),
+                GetResourceValue(context, JObject.Parse("{ \"type\": \"Microsoft.Network/virtualNetworks/subnets\", \"name\": \"vnet-001/subnet-001\", \"dependsOn\": [ \"/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/ps-rule-test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001\" ] }")),
+            };
+            Array.Sort(resources, comparer);
+
+            var actual = resources[0];
+            Assert.Equal("rt-001", actual.Value["name"].Value<string>());
+
+            actual = resources[1];
+            Assert.Equal("rt-002", actual.Value["name"].Value<string>());
+
+            actual = resources[2];
+            Assert.Equal("vnet-001", actual.Value["name"].Value<string>());
+
+            actual = resources[3];
+            Assert.Equal("vnet-001/subnet-001", actual.Value["name"].Value<string>());
+        }
+
+        #region Helper methods
+
+        private static IResourceValue GetResourceValue(TemplateContext context, JObject resource)
+        {
+            resource.TryGetProperty("name", out var name);
+            resource.TryGetProperty("type", out var type);
+            resource.TryGetDependencies(out var dependencies);
+            var resourceId = ResourceHelper.CombineResourceId(context.Subscription.SubscriptionId, context.ResourceGroup.Name, type, name);
+            return new ResourceValue(resourceId, type, resource, dependencies, null);
+        }
+
+        #endregion Helper methods
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -306,7 +306,7 @@
                 {
                     "apiVersion": "2016-09-01",
                     "type": "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings",
-                    "name": "[concat(parameters('clusterName5'), '/Microsoft.Insights/service')]",
+                    "name": "[concat(parameters('clusterName2'), '/Microsoft.Insights/service')]",
                     "properties": {
                         "workspaceId": "[parameters('workspaceId')]",
                         "logs": [
@@ -937,7 +937,7 @@
                 {
                     "apiVersion": "2016-09-01",
                     "type": "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings",
-                    "name": "[concat(parameters('clusterName5'), '/Microsoft.Insights/service')]",
+                    "name": "[concat(parameters('clusterName6'), '/Microsoft.Insights/service')]",
                     "properties": {
                         "workspaceId": "[parameters('workspaceId')]",
                         "logs": [

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
@@ -195,7 +195,10 @@
                         }
                     ]
                 }
-            }
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', parameters('VNETName'))]"
+            ]
         },
         {
             "condition": "[empty(null())]",

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.1.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.1.bicep
@@ -7,7 +7,12 @@ param name string
 @description('The Azure location to deploy resources.')
 param location string = resourceGroup().location
 
-// An example Storage Account
+@description('One or more tags to use.')
+param tags object = {
+  env: 'test'
+}
+
+@description('An example Storage Account.')
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' = {
   name: name
   location: location
@@ -25,4 +30,11 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' = {
       defaultAction: 'Deny'
     }
   }
+  tags: tags
 }
+
+@description('A unique resource Id for the storage account.')
+output id string = storageAccount.id
+
+@description('Any tags set on the storage account.')
+output tags object = storageAccount.tags

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.2.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.2.bicep
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+@description('The name of the first Storage Account.')
+param storageName1 string = 'sabicep001'
+
+@description('The name of the second Storage Account.')
+param storageName2 string = 'sabicep002'
+
+param location string = resourceGroup().location
+
+module storage3 './Tests.Bicep.1.bicep' = {
+  name: 'storage3'
+  params: {
+    name: '${split(storage1.outputs.id, '/')[8]}a'
+    location: location
+    tags: storage1.outputs.tags
+  }
+}
+
+module storage1 './Tests.Bicep.1.bicep' = {
+  name: 'storage1'
+  params: {
+    name: storageName1
+    location: location
+  }
+}
+
+module storage2 './Tests.Bicep.1.bicep' = {
+  name: 'storage2'
+  params: {
+    name: storageName2
+    location: location
+    tags: storage1.outputs.tags
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.2.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.2.json
@@ -1,0 +1,333 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1318.3566",
+      "templateHash": "6224506516782372373"
+    }
+  },
+  "parameters": {
+    "storageName1": {
+      "type": "string",
+      "defaultValue": "sabicep001",
+      "metadata": {
+        "description": "The name of the first Storage Account."
+      }
+    },
+    "storageName2": {
+      "type": "string",
+      "defaultValue": "sabicep002",
+      "metadata": {
+        "description": "The name of the second Storage Account."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "storage3",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[format('{0}a', split(reference(resourceId('Microsoft.Resources/deployments', 'storage1')).outputs.id.value, '/')[8])]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storage1')).outputs.tags.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1318.3566",
+              "templateHash": "15881295888691004764"
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Storage Account."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "The Azure location to deploy resources."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {
+                "env": "test"
+              },
+              "metadata": {
+                "description": "One or more tags to use."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "apiVersion": "2021-06-01",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "sku": {
+                "name": "Standard_GRS"
+              },
+              "kind": "StorageV2",
+              "properties": {
+                "allowBlobPublicAccess": false,
+                "supportsHttpsTrafficOnly": true,
+                "minimumTlsVersion": "TLS1_2",
+                "accessTier": "Hot",
+                "allowSharedKeyAccess": false,
+                "networkAcls": {
+                  "defaultAction": "Deny"
+                }
+              },
+              "tags": "[parameters('tags')]",
+              "metadata": {
+                "description": "An example Storage Account."
+              }
+            }
+          ],
+          "outputs": {
+            "id": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]",
+              "metadata": {
+                "description": "A unique resource Id for the storage account."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "value": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('name')), '2021-06-01', 'full').tags]",
+              "metadata": {
+                "description": "Any tags set on the storage account."
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'storage1')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "storage1",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[parameters('storageName1')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1318.3566",
+              "templateHash": "15881295888691004764"
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Storage Account."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "The Azure location to deploy resources."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {
+                "env": "test"
+              },
+              "metadata": {
+                "description": "One or more tags to use."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "apiVersion": "2021-06-01",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "sku": {
+                "name": "Standard_GRS"
+              },
+              "kind": "StorageV2",
+              "properties": {
+                "allowBlobPublicAccess": false,
+                "supportsHttpsTrafficOnly": true,
+                "minimumTlsVersion": "TLS1_2",
+                "accessTier": "Hot",
+                "allowSharedKeyAccess": false,
+                "networkAcls": {
+                  "defaultAction": "Deny"
+                }
+              },
+              "tags": "[parameters('tags')]",
+              "metadata": {
+                "description": "An example Storage Account."
+              }
+            }
+          ],
+          "outputs": {
+            "id": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]",
+              "metadata": {
+                "description": "A unique resource Id for the storage account."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "value": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('name')), '2021-06-01', 'full').tags]",
+              "metadata": {
+                "description": "Any tags set on the storage account."
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "storage2",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[parameters('storageName2')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'storage1')).outputs.tags.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1318.3566",
+              "templateHash": "15881295888691004764"
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Storage Account."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "The Azure location to deploy resources."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {
+                "env": "test"
+              },
+              "metadata": {
+                "description": "One or more tags to use."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "apiVersion": "2021-06-01",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "sku": {
+                "name": "Standard_GRS"
+              },
+              "kind": "StorageV2",
+              "properties": {
+                "allowBlobPublicAccess": false,
+                "supportsHttpsTrafficOnly": true,
+                "minimumTlsVersion": "TLS1_2",
+                "accessTier": "Hot",
+                "allowSharedKeyAccess": false,
+                "networkAcls": {
+                  "defaultAction": "Deny"
+                }
+              },
+              "tags": "[parameters('tags')]",
+              "metadata": {
+                "description": "An example Storage Account."
+              }
+            }
+          ],
+          "outputs": {
+            "id": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]",
+              "metadata": {
+                "description": "A unique resource Id for the storage account."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "value": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('name')), '2021-06-01', 'full').tags]",
+              "metadata": {
+                "description": "Any tags set on the storage account."
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'storage1')]"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## PR Summary

- Added support for referencing resources in template. #1315
  - The `reference()` function can be used to reference resources in template.
  - A placeholder value is still used for resources outside of the template.
- Fixed processing of deployment outputs. #1316

Fixes #1315 
Fixes #1316 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
