### PR TITLE
Fixes expand of runtime properties #1324

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -14,6 +14,11 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since pre-release v1.14.0-B2203066:
+
+- Bug fixes:
+  - Fixed expand of runtime properties on reference objects. [#1324](https://github.com/Azure/PSRule.Rules.Azure/issues/1324)
+
 ## v1.14.0-B2203066 (pre-release)
 
 What's changed since v1.13.4:

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -141,10 +141,10 @@ namespace PSRule.Rules.Azure.Data.Template
                 return property;
             }
 
-            if (source is MockNode mockNode && ExpressionHelpers.TryConvertString(indexResult, out var memberName))
-                return mockNode.GetMember(memberName);
+            if (source is ILazyObject lazy && ExpressionHelpers.TryConvertString(indexResult, out var memberName) && lazy.TryProperty(memberName, out var value))
+                return value;
 
-            if (ExpressionHelpers.TryString(indexResult, out propertyName) && TryPropertyOrField(source, propertyName, out var value))
+            if (ExpressionHelpers.TryString(indexResult, out propertyName) && TryPropertyOrField(source, propertyName, out value))
                 return value;
 
             throw new InvalidOperationException(string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.IndexInvalid, indexResult));

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
@@ -30,9 +30,9 @@ namespace PSRule.Rules.Azure.Data.Template
                 value = token.Value<string>();
                 return true;
             }
-            else if (o is MockNode mockNode)
+            else if (o is IMock mock)
             {
-                value = mockNode.BuildString();
+                value = mock.ToString();
                 return true;
             }
             value = null;
@@ -44,9 +44,9 @@ namespace PSRule.Rules.Azure.Data.Template
             if (TryString(o, out value))
                 return true;
 
-            if (TryLong(o, out var ivalue))
+            if (TryLong(o, out var i))
             {
-                value = ivalue.ToString(Thread.CurrentThread.CurrentCulture);
+                value = i.ToString(Thread.CurrentThread.CurrentCulture);
                 return true;
             }
             return false;
@@ -88,6 +88,11 @@ namespace PSRule.Rules.Azure.Data.Template
                 value = token.Value<long>();
                 return true;
             }
+            else if (o is MockInteger mock)
+            {
+                value = mock.Value;
+                return true;
+            }
             value = default(long);
             return false;
         }
@@ -127,6 +132,11 @@ namespace PSRule.Rules.Azure.Data.Template
                 value = token.Value<int>();
                 return true;
             }
+            else if (o is MockInteger mock)
+            {
+                value = (int)mock.Value;
+                return true;
+            }
             value = default(int);
             return false;
         }
@@ -139,13 +149,13 @@ namespace PSRule.Rules.Azure.Data.Template
             if (TryInt(o, out value))
                 return true;
 
-            if (TryLong(o, out var lvalue))
+            if (TryLong(o, out var l))
             {
-                value = (int)lvalue;
+                value = (int)l;
                 return true;
             }
 
-            if (TryString(o, out var svalue) && int.TryParse(svalue, out value))
+            if (TryString(o, out var s) && int.TryParse(s, out value))
                 return true;
 
             value = default(int);
@@ -157,14 +167,19 @@ namespace PSRule.Rules.Azure.Data.Template
         /// </summary>
         internal static bool TryBool(object o, out bool value)
         {
-            if (o is bool bvalue)
+            if (o is bool b)
             {
-                value = bvalue;
+                value = b;
                 return true;
             }
             else if (o is JToken token && token.Type == JTokenType.Boolean)
             {
                 value = token.Value<bool>();
+                return true;
+            }
+            else if (o is MockBool mock)
+            {
+                value = mock.Value;
                 return true;
             }
             value = default(bool);
@@ -236,7 +251,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 return JObject.FromObject(hashtable);
 
             if (value is MockMember mockMember)
-                return new JValue(mockMember.BuildString());
+                return new JValue(mockMember.ToString());
 
             return new JValue(value);
         }
@@ -272,11 +287,9 @@ namespace PSRule.Rules.Azure.Data.Template
         {
             var hash = GetUnique(args);
             var builder = new StringBuilder();
-            var culture = new CultureInfo("en-us");
             for (var i = 0; i < hash.Length && i < 7; i++)
-            {
-                builder.Append(hash[i].ToString("x2", culture));
-            }
+                builder.Append(hash[i].ToString("x2", AzureCulture));
+
             return builder.ToString();
         }
 

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -765,12 +765,16 @@ namespace PSRule.Rules.Azure.Data.Template
             return resourceTypes[0];
         }
 
+        /// <summary>
+        /// reference(resourceName or resourceIdentifier, [apiVersion], ['Full'])
+        /// </summary>
         internal static object Reference(ITemplateContext context, object[] args)
         {
             var argCount = CountArgs(args);
             if (argCount < 1 || argCount > 3)
                 throw ArgumentsOutOfRange(nameof(Reference), args);
 
+            // Resource type
             if (!ExpressionHelpers.TryString(args[0], out var resourceId))
                 throw ArgumentFormatInvalid(nameof(Reference));
 
@@ -789,7 +793,7 @@ namespace PSRule.Rules.Azure.Data.Template
             if (resource is DeploymentValue deployment)
                 return full ? deployment : deployment.Properties;
 
-            return full ? resource.Value : resource.Value[PROPERTY_PROPERTIES].Value<JObject>();
+            return new MockObject(full ? resource.Value : resource.Value[PROPERTY_PROPERTIES].Value<JObject>());
         }
 
         /// <summary>

--- a/src/PSRule.Rules.Azure/Data/Template/Mocks.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Mocks.cs
@@ -1,0 +1,329 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace PSRule.Rules.Azure.Data.Template
+{
+    internal interface IMock
+    {
+        IMock Parent { get; }
+
+        bool TryProperty(string propertyName, out IMock value);
+
+        bool TryGetIndex(int index, out IMock value);
+
+        bool TryGetValue(out object value);
+    }
+
+    internal abstract class MockLiteral<T> : IMock
+    {
+        protected MockLiteral(T value, IMock parent)
+        {
+            Value = value;
+            Parent = parent;
+        }
+
+        public IMock Parent { get; }
+
+        public T Value { get; }
+
+        public bool TryProperty(string propertyName, out IMock value)
+        {
+            value = null;
+            return false;
+        }
+
+        public bool TryGetIndex(int index, out IMock value)
+        {
+            value = null;
+            return false;
+        }
+
+        public bool TryGetValue(out object value)
+        {
+            value = Value;
+            return true;
+        }
+
+        public override string ToString()
+        {
+            return TryGetValue(out var value) ? value.ToString() : string.Empty;
+        }
+    }
+
+    internal sealed class MockString : MockLiteral<string>
+    {
+        public MockString(string value, IMock parent = null)
+            : base(value, parent) { }
+    }
+
+    internal sealed class MockInteger : MockLiteral<long>
+    {
+        public MockInteger(long value, IMock parent = null)
+            : base(value, parent) { }
+    }
+
+    internal sealed class MockBool : MockLiteral<bool>
+    {
+        public MockBool(bool value, IMock parent = null)
+            : base(value, parent) { }
+    }
+
+    internal abstract class MockNode : ILazyObject, IMock
+    {
+        protected MockNode(IMock parent)
+        {
+            Parent = parent;
+        }
+
+        public IMock Parent { get; }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            builder.Insert(0, GetString());
+            var parent = Parent as MockNode;
+            while (parent != null)
+            {
+                builder.Insert(0, ".");
+                builder.Insert(0, parent.GetString());
+                parent = parent.Parent as MockNode;
+            }
+            builder.Insert(0, "{{");
+            builder.Append("}}");
+            return builder.ToString();
+        }
+
+        public virtual bool TryProperty(string propertyName, out IMock value)
+        {
+            value = null;
+            return false;
+        }
+
+        public virtual bool TryGetIndex(int index, out IMock value)
+        {
+            value = null;
+            return false;
+        }
+
+        public virtual bool TryGetValue(out object value)
+        {
+            value = null;
+            return false;
+        }
+
+        protected abstract string GetString();
+
+        protected MockString Mock(string value)
+        {
+            return new MockString(value, this);
+        }
+
+        protected MockInteger Mock(long value)
+        {
+            return new MockInteger(value, this);
+        }
+
+        protected MockBool Mock(bool value)
+        {
+            return new MockBool(value, this);
+        }
+
+        protected MockArray MockArray(JArray value)
+        {
+            return new MockArray(value, this);
+        }
+
+        protected MockObject MockObject(JObject value)
+        {
+            return new MockObject(value, this);
+        }
+
+        internal MockMember MockMember(string name)
+        {
+            return new MockMember(null, this, name);
+        }
+
+        bool ILazyObject.TryProperty(string propertyName, out object value)
+        {
+            value = MockMember(propertyName);
+            return true;
+        }
+    }
+
+    internal sealed class MockArray : MockNode, IMock
+    {
+        public MockArray(JArray value, IMock parent = null)
+            : base(parent)
+        {
+            Value = value;
+        }
+
+        public JArray Value { get; }
+
+        public override bool TryGetIndex(int index, out IMock value)
+        {
+            if (TryGetIndexFromValue(index, out value))
+                return true;
+
+            return false;
+        }
+
+        protected override string GetString()
+        {
+            return ToString();
+        }
+
+        public override string ToString()
+        {
+            return TryGetValue(out var value) ? value.ToString() : string.Empty;
+        }
+
+        private bool TryGetIndexFromValue(int index, out IMock value)
+        {
+            value = null;
+            if (Value == null || index < 0 || index > Value.Count - 1)
+                return false;
+
+            var token = Value[index];
+            if (token.Type == JTokenType.String)
+                value = Mock(token.Value<string>());
+
+            if (token.Type == JTokenType.Integer)
+                value = Mock(token.Value<long>());
+
+            if (token.Type == JTokenType.Boolean)
+                value = Mock(token.Value<bool>());
+
+            if (token.Type == JTokenType.Array)
+                value = MockArray(token.Value<JArray>());
+
+            if (token.Type == JTokenType.Object)
+                value = MockObject(token.Value<JObject>());
+
+            return true;
+        }
+    }
+
+    internal abstract class MockObjectBase : MockNode, IMock, ILazyObject
+    {
+        internal MockObjectBase(MockNode parent)
+            : base(parent) { }
+
+        public JObject Value { get; protected set; }
+
+        public override bool TryProperty(string propertyName, out IMock value)
+        {
+            if (TryGetPropertyFromValue(propertyName, out value))
+                return true;
+
+            return false;
+        }
+
+        public override bool TryGetValue(out object value)
+        {
+            value = Value;
+            return value != null;
+        }
+
+        private bool TryGetPropertyFromValue(string propertyName, out IMock value)
+        {
+            value = null;
+            if (Value == null || !Value.TryGetProperty(propertyName, out JToken token))
+                return false;
+
+            if (token.Type == JTokenType.String)
+                value = Mock(token.Value<string>());
+
+            if (token.Type == JTokenType.Integer)
+                value = Mock(token.Value<long>());
+
+            if (token.Type == JTokenType.Boolean)
+                value = Mock(token.Value<bool>());
+
+            if (token.Type == JTokenType.Array)
+                value = MockArray(token.Value<JArray>());
+
+            if (token.Type == JTokenType.Object)
+                value = MockObject(token.Value<JObject>());
+
+            return true;
+        }
+
+        public bool TryProperty(string propertyName, out object value)
+        {
+            value = null;
+            if (TryProperty(propertyName, out IMock fake))
+                value = fake;
+
+            if (value == null)
+                value = MockObject(null);
+
+            return value != null;
+        }
+    }
+
+    internal sealed class MockObject : MockObjectBase
+    {
+        internal MockObject(JObject o, MockNode parent = null)
+            : base(parent)
+        {
+            Value = o;
+        }
+
+        protected override string GetString()
+        {
+            return "Object";
+        }
+    }
+
+    internal sealed class MockList : MockNode
+    {
+        internal MockList(string resourceId)
+            : base(null)
+        {
+            ResourceId = resourceId;
+        }
+
+        public string ResourceId { get; }
+
+        protected override string GetString()
+        {
+            return "List";
+        }
+    }
+
+    internal sealed class MockMember : MockNode
+    {
+        internal MockMember(JToken token, MockNode parent, string name)
+            : base(parent)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+
+        protected override string GetString()
+        {
+            return Name;
+        }
+    }
+
+    internal sealed class MockResource : MockObjectBase
+    {
+        internal MockResource(string resourceType)
+            : base(null)
+        {
+            ResourceType = resourceType;
+        }
+
+        public string ResourceType { get; }
+
+        protected override string GetString()
+        {
+            return "Resource";
+        }
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Template/Models.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Models.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -133,92 +132,5 @@ namespace PSRule.Rules.Azure.Data.Template
 
         [JsonProperty(PropertyName = "storage")]
         public string storage { get; set; }
-    }
-
-    public abstract class MockNode : ILazyObject
-    {
-        protected MockNode(MockNode parent)
-        {
-            Parent = parent;
-        }
-
-        public MockNode Parent { get; }
-
-        internal MockMember GetMember(string name)
-        {
-            return new MockMember(this, name);
-        }
-
-        internal string BuildString()
-        {
-            var builder = new StringBuilder();
-            builder.Insert(0, GetString());
-            var parent = Parent;
-            while (parent != null)
-            {
-                builder.Insert(0, ".");
-                builder.Insert(0, parent.GetString());
-                parent = parent.Parent;
-            }
-            builder.Insert(0, "{{");
-            builder.Append("}}");
-            return builder.ToString();
-        }
-
-        protected abstract string GetString();
-
-        bool ILazyObject.TryProperty(string propertyName, out object value)
-        {
-            value = GetMember(propertyName);
-            return true;
-        }
-    }
-
-    public sealed class MockResource : MockNode
-    {
-        internal MockResource(string resourceType)
-            : base(null)
-        {
-            ResourceType = resourceType;
-        }
-
-        public string ResourceType { get; }
-
-        protected override string GetString()
-        {
-            return "Resource";
-        }
-    }
-
-    public sealed class MockList : MockNode
-    {
-        internal MockList(string resourceId)
-            : base(null)
-        {
-            ResourceId = resourceId;
-        }
-
-        public string ResourceId { get; }
-
-        protected override string GetString()
-        {
-            return "List";
-        }
-    }
-
-    public sealed class MockMember : MockNode
-    {
-        internal MockMember(MockNode parent, string name)
-            : base(parent)
-        {
-            Name = name;
-        }
-
-        public string Name { get; }
-
-        protected override string GetString()
-        {
-            return Name;
-        }
     }
 }

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -1265,8 +1265,8 @@ namespace PSRule.Rules.Azure.Data.Template
                 return value;
 
             var result = EvaluteExpression<object>(context, value);
-            if (result is MockMember mock)
-                result = mock.BuildString();
+            if (result is IMock mock && !mock.TryGetValue(out result))
+                result = mock.ToString();
 
             return result == null ? null : JToken.FromObject(result);
         }

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -134,7 +134,7 @@ namespace PSRule.Rules.Azure
                 "boolProp", true,
                 "arrayProp", Functions.CreateArray(context, new object[] { "a", "b", "c" }),
                 "objectProp", Functions.CreateObject(context, new object[] { "key1", "value1" }),
-                "mockProp", new MockResource("Microsoft.Resources/deployments").GetMember("outputs").GetMember("aksSubnetId").GetMember("value"),
+                "mockProp", new MockResource("Microsoft.Resources/deployments").MockMember("outputs").MockMember("aksSubnetId").MockMember("value"),
             }) as JObject;
             var actual2 = Functions.CreateObject(context, new object[] { }) as JObject;
 
@@ -537,10 +537,11 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
             var parentId = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Unit.Test/type/a";
 
-            var actual1 = Functions.Reference(context, new object[] { parentId }) as MockResource;
-            Assert.NotNull(actual1);
-
-            // TODO: Improve test cases
+            var actual = Functions.Reference(context, new object[] { parentId }) as MockResource;
+            Assert.NotNull(actual);
+            Assert.Equal("{{Resource}}", actual.ToString());
+            Assert.Equal("{{Resource.value}}", actual.MockMember("value").ToString());
+            Assert.Equal("{{Resource.extra.value}}", actual.MockMember("extra").MockMember("value").ToString());
         }
 
         [Fact]

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -406,7 +406,7 @@ namespace PSRule.Rules.Azure
         {
             var resources = ProcessTemplate(GetSourcePath("Tests.Bicep.2.json"), null);
             Assert.NotNull(resources);
-            Assert.Equal(7, resources.Length);
+            Assert.Equal(10, resources.Length);
 
             var actual = resources[0];
             Assert.Equal("Microsoft.Resources/deployments", actual["type"].Value<string>());
@@ -421,22 +421,34 @@ namespace PSRule.Rules.Azure
             Assert.Equal("test", actual["tags"]["env"].Value<string>());
 
             actual = resources[3];
+            Assert.Equal("Microsoft.Network/privateEndpoints", actual["type"].Value<string>());
+            Assert.Equal("pe-sabicep001", actual["name"].Value<string>());
+
+            actual = resources[4];
             Assert.Equal("Microsoft.Resources/deployments", actual["type"].Value<string>());
             Assert.Equal("storage3", actual["name"].Value<string>());
 
-            actual = resources[4];
+            actual = resources[5];
             Assert.Equal("Microsoft.Storage/storageAccounts", actual["type"].Value<string>());
-            Assert.Equal("sabicep001a", actual["name"].Value<string>());
+            Assert.Equal("sabicep001f8cbd7940fe93", actual["name"].Value<string>());
             Assert.Equal("test", actual["tags"]["env"].Value<string>());
 
-            actual = resources[5];
+            actual = resources[6];
+            Assert.Equal("Microsoft.Network/privateEndpoints", actual["type"].Value<string>());
+            Assert.Equal("pe-sabicep001f8cbd7940fe93", actual["name"].Value<string>());
+
+            actual = resources[7];
             Assert.Equal("Microsoft.Resources/deployments", actual["type"].Value<string>());
             Assert.Equal("storage2", actual["name"].Value<string>());
 
-            actual = resources[6];
+            actual = resources[8];
             Assert.Equal("Microsoft.Storage/storageAccounts", actual["type"].Value<string>());
             Assert.Equal("sabicep002", actual["name"].Value<string>());
             Assert.Equal("test", actual["tags"]["env"].Value<string>());
+
+            actual = resources[9];
+            Assert.Equal("Microsoft.Network/privateEndpoints", actual["type"].Value<string>());
+            Assert.Equal("pe-sabicep002", actual["name"].Value<string>());
         }
 
         #region Helper methods

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.1.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.1.bicep
@@ -12,6 +12,17 @@ param tags object = {
   env: 'test'
 }
 
+@description('A reference to an example VNET.')
+resource vnet 'Microsoft.Network/virtualNetworks@2021-05-01' existing = {
+  name: 'vnet-001'
+}
+
+@description('A reference to an exampe subnet.')
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2021-05-01' existing = {
+  parent: vnet
+  name: 'subnet-001'
+}
+
 @description('An example Storage Account.')
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' = {
   name: name
@@ -33,8 +44,35 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' = {
   tags: tags
 }
 
+resource endpoint 'Microsoft.Network/privateEndpoints@2020-03-01' = {
+  location: location
+  name: 'pe-${name}'
+  properties: {
+    subnet: {
+      id: subnet.id
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'default'
+        properties: {
+          privateLinkServiceId: storageAccount.id
+          groupIds: [
+            'blob'
+          ]
+        }
+      }
+    ]
+  }
+}
+
 @description('A unique resource Id for the storage account.')
 output id string = storageAccount.id
 
 @description('Any tags set on the storage account.')
 output tags object = storageAccount.tags
+
+@description('A unique string that is generated from the blob endpoint.')
+output unique string = uniqueString(storageAccount.properties.primaryEndpoints.blob)
+
+@description('The ID of the endpoint NIC.')
+output endpointNIC string = endpoint.properties.networkInterfaces[0].id

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.2.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.2.bicep
@@ -12,7 +12,7 @@ param location string = resourceGroup().location
 module storage3 './Tests.Bicep.1.bicep' = {
   name: 'storage3'
   params: {
-    name: '${split(storage1.outputs.id, '/')[8]}a'
+    name: '${split(storage1.outputs.id, '/')[8]}${storage1.outputs.unique}'
     location: location
     tags: storage1.outputs.tags
   }

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.2.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.2.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1318.3566",
-      "templateHash": "6224506516782372373"
+      "templateHash": "13856958272754005555"
     }
   },
   "parameters": {
@@ -40,7 +40,7 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[format('{0}a', split(reference(resourceId('Microsoft.Resources/deployments', 'storage1')).outputs.id.value, '/')[8])]"
+            "value": "[format('{0}{1}', split(reference(resourceId('Microsoft.Resources/deployments', 'storage1')).outputs.id.value, '/')[8], reference(resourceId('Microsoft.Resources/deployments', 'storage1')).outputs.unique.value)]"
           },
           "location": {
             "value": "[parameters('location')]"
@@ -56,7 +56,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1318.3566",
-              "templateHash": "15881295888691004764"
+              "templateHash": "4093724470647525487"
             }
           },
           "parameters": {
@@ -107,6 +107,31 @@
               "metadata": {
                 "description": "An example Storage Account."
               }
+            },
+            {
+              "type": "Microsoft.Network/privateEndpoints",
+              "apiVersion": "2020-03-01",
+              "name": "[format('pe-{0}', parameters('name'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "subnet": {
+                  "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'vnet-001', 'subnet-001')]"
+                },
+                "privateLinkServiceConnections": [
+                  {
+                    "name": "default",
+                    "properties": {
+                      "privateLinkServiceId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]",
+                      "groupIds": [
+                        "blob"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]"
+              ]
             }
           ],
           "outputs": {
@@ -122,6 +147,20 @@
               "value": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('name')), '2021-06-01', 'full').tags]",
               "metadata": {
                 "description": "Any tags set on the storage account."
+              }
+            },
+            "unique": {
+              "type": "string",
+              "value": "[uniqueString(reference(resourceId('Microsoft.Storage/storageAccounts', parameters('name'))).primaryEndpoints.blob)]",
+              "metadata": {
+                "description": "A unique string that is generated from the blob endpoint."
+              }
+            },
+            "endpointNIC": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Network/privateEndpoints', format('pe-{0}', parameters('name')))).networkInterfaces[0].id]",
+              "metadata": {
+                "description": "The ID of the endpoint NIC."
               }
             }
           }
@@ -155,7 +194,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1318.3566",
-              "templateHash": "15881295888691004764"
+              "templateHash": "4093724470647525487"
             }
           },
           "parameters": {
@@ -206,6 +245,31 @@
               "metadata": {
                 "description": "An example Storage Account."
               }
+            },
+            {
+              "type": "Microsoft.Network/privateEndpoints",
+              "apiVersion": "2020-03-01",
+              "name": "[format('pe-{0}', parameters('name'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "subnet": {
+                  "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'vnet-001', 'subnet-001')]"
+                },
+                "privateLinkServiceConnections": [
+                  {
+                    "name": "default",
+                    "properties": {
+                      "privateLinkServiceId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]",
+                      "groupIds": [
+                        "blob"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]"
+              ]
             }
           ],
           "outputs": {
@@ -221,6 +285,20 @@
               "value": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('name')), '2021-06-01', 'full').tags]",
               "metadata": {
                 "description": "Any tags set on the storage account."
+              }
+            },
+            "unique": {
+              "type": "string",
+              "value": "[uniqueString(reference(resourceId('Microsoft.Storage/storageAccounts', parameters('name'))).primaryEndpoints.blob)]",
+              "metadata": {
+                "description": "A unique string that is generated from the blob endpoint."
+              }
+            },
+            "endpointNIC": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Network/privateEndpoints', format('pe-{0}', parameters('name')))).networkInterfaces[0].id]",
+              "metadata": {
+                "description": "The ID of the endpoint NIC."
               }
             }
           }
@@ -254,7 +332,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1318.3566",
-              "templateHash": "15881295888691004764"
+              "templateHash": "4093724470647525487"
             }
           },
           "parameters": {
@@ -305,6 +383,31 @@
               "metadata": {
                 "description": "An example Storage Account."
               }
+            },
+            {
+              "type": "Microsoft.Network/privateEndpoints",
+              "apiVersion": "2020-03-01",
+              "name": "[format('pe-{0}', parameters('name'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "subnet": {
+                  "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'vnet-001', 'subnet-001')]"
+                },
+                "privateLinkServiceConnections": [
+                  {
+                    "name": "default",
+                    "properties": {
+                      "privateLinkServiceId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]",
+                      "groupIds": [
+                        "blob"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]"
+              ]
             }
           ],
           "outputs": {
@@ -320,6 +423,20 @@
               "value": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('name')), '2021-06-01', 'full').tags]",
               "metadata": {
                 "description": "Any tags set on the storage account."
+              }
+            },
+            "unique": {
+              "type": "string",
+              "value": "[uniqueString(reference(resourceId('Microsoft.Storage/storageAccounts', parameters('name'))).primaryEndpoints.blob)]",
+              "metadata": {
+                "description": "A unique string that is generated from the blob endpoint."
+              }
+            },
+            "endpointNIC": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Network/privateEndpoints', format('pe-{0}', parameters('name')))).networkInterfaces[0].id]",
+              "metadata": {
+                "description": "The ID of the endpoint NIC."
               }
             }
           }


### PR DESCRIPTION
## PR Summary

- Fixed expand of runtime properties on reference objects.

Fixes #1324

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
