### PR TITLE
Pre-release v1.14.0-B2203088

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -14,6 +14,8 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.14.0-B2203088 (pre-release)
+
 What's changed since pre-release v1.14.0-B2203066:
 
 - New features:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.14.0-B2203066:

- New features:
  - Added March 2022 baselines `Azure.GA_2022_03` and `Azure.Preview_2022_03`. #1334
    - Includes rules released before or during March 2022.
    - Marked `Azure.GA_2021_12` and `Azure.Preview_2021_12` baselines as obsolete.
- Bug fixes:
  - Fixed expand of runtime properties on reference objects. #1324

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
