### PR TITLE
Pre-release v1.14.0-B2203117

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -14,6 +14,8 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.14.0-B2203117 (pre-release)
+
 What's changed since pre-release v1.14.0-B2203088:
 
 - New features:
@@ -22,6 +24,7 @@ What's changed since pre-release v1.14.0-B2203088:
     - `Export-AzPolicyAssignmentRuleData` - Exports JSON rules from policy assignment data. [#1278](https://github.com/Azure/PSRule.Rules.Azure/issues/1278)
     - `Get-AzPolicyAssignmentDataSource` - Discovers policy assignment data. [#1340](https://github.com/Azure/PSRule.Rules.Azure/issues/1340)
     - See cmdlet help for limitations and usage.
+    - Additional information will be posted as this feature evolves [here](https://github.com/Azure/PSRule.Rules.Azure/discussions/1345).
 - Engineering:
   - Cache Azure Policy Aliases. [#1277](https://github.com/Azure/PSRule.Rules.Azure/issues/1277)
 - Bug fixes:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.14.0-B2203088:

- New features:
  - **Experimental**: Cmdlets to validate objects with Azure policy conditions:
    - `Export-AzPolicyAssignmentData` - Exports policy assignment data. #1266
    - `Export-AzPolicyAssignmentRuleData` - Exports JSON rules from policy assignment data. #1278
    - `Get-AzPolicyAssignmentDataSource` - Discovers policy assignment data. #1340
    - See cmdlet help for limitations and usage.
- Engineering:
  - Cache Azure Policy Aliases. #1277
- Bug fixes:
  - Fixed index was out of range with split on mock properties. #1327

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
