### PR TITLE
Fixes object parameter defaults #1355

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -14,6 +14,11 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since v1.14.0:
+
+- Bug fixes:
+  - Fixed unable to set parameter defaults option with type object. [#1355](https://github.com/Azure/PSRule.Rules.Azure/issues/1355)
+
 ## v1.14.0
 
 What's changed since v1.13.4:

--- a/src/PSRule.Rules.Azure/Common/DictionaryExtensions.cs
+++ b/src/PSRule.Rules.Azure/Common/DictionaryExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
@@ -19,6 +19,18 @@ namespace PSRule.Rules.Azure
         {
             value = default;
             if (dictionary.TryGetValue(key, out var v) && dictionary.Remove(key) && v is T result)
+            {
+                value = result;
+                return true;
+            }
+            return false;
+        }
+
+        [DebuggerStepThrough]
+        public static bool TryGetValue<T>(this IDictionary<string, object> dictionary, string key, out T value)
+        {
+            value = default;
+            if (dictionary.TryGetValue(key, out var v) && v is T result)
             {
                 value = result;
                 return true;

--- a/src/PSRule.Rules.Azure/Configuration/ParameterDefaultsOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/ParameterDefaultsOption.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace PSRule.Rules.Azure.Configuration
@@ -112,6 +113,26 @@ namespace PSRule.Rules.Azure.Configuration
                 return false;
 
             value = new JValue(result.Value);
+            return true;
+        }
+
+        internal bool TryGetObject(string parameterName, out JToken value)
+        {
+            value = default;
+            if (!_Defaults.TryGetValue<Dictionary<object, object>>(parameterName, out var result))
+                return false;
+
+            value = JObject.FromObject(result);
+            return true;
+        }
+
+        internal bool TryGetArray(string parameterName, out JToken value)
+        {
+            value = default;
+            if (!_Defaults.TryGetValue<List<object>>(parameterName, out var result))
+                return false;
+
+            value = JArray.FromObject(result);
             return true;
         }
 

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -587,10 +587,12 @@ namespace PSRule.Rules.Azure.Data.Template
                         return ParameterDefaults.TryGetLong(parameterName, out value);
 
                     case ParameterType.Array:
-                        return ParameterDefaults.TryGetString(parameterName, out value);
+                        return ParameterDefaults.TryGetArray(parameterName, out value);
 
                     case ParameterType.Object:
                     case ParameterType.SecureObject:
+                        return ParameterDefaults.TryGetObject(parameterName, out value);
+
                     default:
                         return false;
                 }

--- a/tests/PSRule.Rules.Azure.Tests/Template.Parsing.10.Parameters.json
+++ b/tests/PSRule.Rules.Azure.Tests/Template.Parsing.10.Parameters.json
@@ -7,6 +7,18 @@
     "parameters": {
         "resourceName": {
             "value": "some-resource-name"
+        },
+        "tags": {
+            "value": {
+                "env": "test",
+                "service": "test"
+            }
+        },
+        "arrayOptions": {
+            "value": [
+                "test",
+                "value"
+            ]
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Template.Parsing.10.json
+++ b/tests/PSRule.Rules.Azure.Tests/Template.Parsing.10.json
@@ -346,6 +346,12 @@
       "metadata": {
         "description": "The Log Analytics retention period"
       }
+    },
+    "tags": {
+      "type": "object"
+    },
+    "arrayOptions": {
+      "type": "array"
     }
   },
   "functions": [],
@@ -741,6 +747,7 @@
         "name": "Basic",
         "tier": "[variables('akssku')]"
       },
+      "tags": "[union(parameters('tags'), createObject(parameters('arrayOptions')[0], parameters('arrayOptions')[1]))]",
       "dependsOn": [
         "[resourceId('Microsoft.OperationalInsights/workspaces', variables('aks_law_name'))]",
         "[resourceId('Microsoft.Network/applicationGateways', variables('appgwName'))]",

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -409,6 +409,8 @@ namespace PSRule.Rules.Azure
             Assert.Equal(2, resources.Length);
 
             Assert.Equal("aks-resource123", resources[1]["name"].Value<string>());
+            Assert.Equal("dev", resources[1]["tags"]["env"].Value<string>());
+            Assert.Equal("value", resources[1]["tags"]["test"].Value<string>());
         }
 
         [Fact]

--- a/tests/PSRule.Rules.Azure.Tests/ps-rule-options.yaml
+++ b/tests/PSRule.Rules.Azure.Tests/ps-rule-options.yaml
@@ -24,6 +24,10 @@ configuration:
   AZURE_PARAMETER_DEFAULTS:
     adminPassword: $CREDENTIAL_PLACEHOLDER$
     resourceName: resource123
+    tags:
+      env: dev
+      service: test
+    arrayOptions: [ 'test', 'value' ]
   AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.22.4'
   AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST:
   - location: 'Antarctica North'


### PR DESCRIPTION
## PR Summary

- Fixed unable to set parameter defaults option with type object.

Fixes #1355 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
