### PR TITLE
Fixed MockObject with CreateObject fn #1411

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,8 @@ What's changed since v1.15.0:
 - Bug fixes:
   - Fixed exclusion of `dataCollectionRuleAssociations` from `Azure.Resource.UseTags` by @BernieWhite.
     [#1400](https://github.com/Azure/PSRule.Rules.Azure/issues/1400)
+  - Fixed could not determine JSON object type for MockObject using CreateObject by @BernieWhite.
+    [#1411](https://github.com/Azure/PSRule.Rules.Azure/issues/1411)
 
 ## v1.15.0
 

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
@@ -222,6 +223,54 @@ namespace PSRule.Rules.Azure.Data.Template
                 return true;
             }
             return false;
+        }
+
+        internal static bool IsArray(object o)
+        {
+            return o is JArray || o is Array || o is MockArray;
+        }
+
+        internal static object UnionArray(object[] o)
+        {
+            if (o == null || o.Length == 0)
+                return Array.Empty<object>();
+
+            var result = new List<object>();
+            for (var i = 0; i < o.Length; i++)
+            {
+                if (!IsArray(o[i]))
+                    continue;
+
+                if (o[i] is JArray jArray && jArray.Count > 0)
+                {
+                    for (var j = 0; j < jArray.Count; j++)
+                    {
+                        var element = jArray[j];
+                        if (!result.Contains(element))
+                            result.Add(element);
+                    }
+                }
+                else if (o[i] is MockArray mock && mock.Value != null && mock.Value.Count > 0)
+                {
+                    for (var j = 0; j < mock.Value.Count; j++)
+                    {
+                        var element = mock.Value[j];
+                        if (!result.Contains(element))
+                            result.Add(element);
+                    }
+                }
+                else if (o[i] is Array array && array.Length > 0)
+                {
+                    for (var j = 0; j < array.Length; j++)
+                    {
+                        var element = array.GetValue(j);
+                        if (!result.Contains(element))
+                            result.Add(element);
+                    }
+                }
+            }
+            return result.ToArray();
+
         }
 
         /// <summary>

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -551,21 +551,8 @@ namespace PSRule.Rules.Azure.Data.Template
                 throw ArgumentsOutOfRange(nameof(Union), args);
 
             // Array
-            if (args[0] is Array)
-            {
-                var arrays = new Array[args.Length];
-                args.CopyTo(arrays, 0);
-                return Union(arrays);
-            }
-            else if (args[0] is JArray)
-            {
-                var arrays = new JArray[args.Length];
-                for (var i = 0; i < arrays.Length; i++)
-                {
-                    arrays[i] = args[i] as JArray;
-                }
-                return Union(arrays);
-            }
+            if (ExpressionHelpers.IsArray(args[0]))
+                return ExpressionHelpers.UnionArray(args);
 
             // Object
             if (args[0] is JObject jObject1)
@@ -582,37 +569,6 @@ namespace PSRule.Rules.Azure.Data.Template
                 return result;
             }
             return null;
-        }
-
-        private static Array Union(Array[] arrays)
-        {
-            var result = new List<object>();
-            for (var i = 0; i < arrays.Length; i++)
-            {
-                for (var j = 0; arrays[i] != null && j < arrays[i].Length; j++)
-                {
-                    var value = arrays[i].GetValue(j);
-                    if (!result.Contains(value))
-                        result.Add(value);
-                }
-            }
-            return result.ToArray();
-        }
-
-        private static JArray Union(JArray[] arrays)
-        {
-            var result = new JArray();
-            for (var i = 0; i < arrays.Length; i++)
-            {
-                for (var j = 0; j < arrays[i].Count; j++)
-                {
-                    var element = arrays[i][j];
-                    if (!result.Contains(element))
-                        result.Add(element);
-                }
-
-            }
-            return result;
         }
 
         #endregion Array and object

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -606,7 +606,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 if (value is ILazyValue weakValue)
                 {
                     value = weakValue.GetValue();
-                    Variables[variableName] = value;
+                    Variables[variableName] = ConvertType(value);
                 }
                 return true;
             }
@@ -646,6 +646,28 @@ namespace PSRule.Rules.Azure.Data.Template
 
                 if (value.Type == ParameterType.String && !string.IsNullOrEmpty(value.GetValue() as string))
                     _Validator.ValidateParameter(this, parameterName, parameter, value.GetValue() as string);
+            }
+
+            private static object ConvertType(object value)
+            {
+                return value is JToken token ? ConvertJToken(token) : value;
+            }
+
+            private static object ConvertJToken(JToken token)
+            {
+                if (token == null || token.Type == JTokenType.Null)
+                    return null;
+
+                if (token.Type == JTokenType.String)
+                    return token.Value<string>();
+
+                if (token.Type == JTokenType.Integer)
+                    return token.Value<long>();
+
+                if (token.Type == JTokenType.Boolean)
+                    return token.Value<bool>();
+
+                return token;
             }
         }
 

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -143,6 +143,14 @@ namespace PSRule.Rules.Azure
                 "mockProp", new MockResource("Microsoft.Resources/deployments").MockMember("outputs").MockMember("aksSubnetId").MockMember("value"),
             }) as JObject;
             var actual2 = Functions.CreateObject(context, new object[] { }) as JObject;
+            var actual3 = Functions.CreateObject(context, new object[] {
+                "intProp", new MockInteger(1),
+                "stringProp", new MockString("mock"),
+                "boolProp", new MockBool(true),
+                "arrayProp", Functions.CreateArray(context, new object[] { "a", "b", "c" }),
+                "objectProp", Functions.CreateObject(context, new object[] { "key1", "value1" }),
+                "mockProp", new MockObject(null),
+            }) as JObject;
 
             Assert.Equal(1, actual1["intProp"]);
             Assert.Equal("abc", actual1["stringProp"]);
@@ -152,6 +160,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("{{Resource.outputs.aksSubnetId.value}}", actual1["mockProp"].Value<string>());
 
             Assert.NotNull(actual2);
+            Assert.NotNull(actual3);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.CreateObject(context, new object[] { "intProp", 1, "stringProp" }));
         }
@@ -451,6 +460,12 @@ namespace PSRule.Rules.Azure
             // Union arrays
             var actual2 = Functions.Union(context, new string[][] { new string[] { "one", "two", "three" }, new string[] { "three", "four" } }) as object[];
             Assert.Equal(4, actual2.Length);
+            actual2 = Functions.Union(context, new object[][] { new string[] { "one", "two" }, null, null }) as object[];
+            Assert.Equal(2, actual2.Length);
+            actual2 = Functions.Union(context, new object[] { new string[] { "one", "two" }, null, new string[] { "one", "three" } }) as object[];
+            Assert.Equal(3, actual2.Length);
+            actual2 = Functions.Union(context, new object[] { new string[] { "one", "two" }, new MockArray(null) }) as object[];
+            Assert.Equal(2, actual2.Length);
         }
 
         #endregion Array and object


### PR DESCRIPTION
## PR Summary

- Fixed could not determine JSON object type for MockObject using CreateObject.

Fixes #1411

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
