### PR TITLE
Release v1.15.1

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -19,6 +19,8 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.15.1
+
 What's changed since v1.15.0:
 
 - Bug fixes:


### PR DESCRIPTION
## PR Summary

What's changed since v1.15.0:

- Bug fixes:
  - Fixed exclusion of `dataCollectionRuleAssociations` from `Azure.Resource.UseTags` by @BernieWhite.
    [#1400](https://github.com/Azure/PSRule.Rules.Azure/issues/1400)
  - Fixed could not determine JSON object type for MockObject using CreateObject by @BernieWhite.
    [#1411](https://github.com/Azure/PSRule.Rules.Azure/issues/1411)
  - Fixed cannot bind argument to parameter 'Sku' because it is an empty string by @BernieWhite.
    [#1407](https://github.com/Azure/PSRule.Rules.Azure/issues/1407)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
