### PR TITLE
Fixes for app service and managed id #1414 #1415

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -19,6 +19,20 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since v1.15.1:
+
+- Bug fixes:
+  - Fixed `Azure.AppService.ManagedIdentity` does not accept both system and user assigned by @BernieWhite.
+    [#1415](https://github.com/Azure/PSRule.Rules.Azure/issues/1415)
+    - This also applies to:
+      - `Azure.ADX.ManagedIdentity`
+      - `Azure.APIM.ManagedIdentity`
+      - `Azure.EventGrid.ManagedIdentity`
+      - `Azure.Automation.ManagedIdentity`
+  - Fixed Web apps with .NET 6 do not meet version constraint of `Azure.AppService.NETVersion` by @BernieWhite.
+    [#1414](https://github.com/Azure/PSRule.Rules.Azure/issues/1414)
+    - This also applies to `Azure.AppService.PHPVersion`.
+
 ## v1.15.1
 
 What's changed since v1.15.0:

--- a/src/PSRule.Rules.Azure/rules/Azure.ADX.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.ADX.Rule.yaml
@@ -22,8 +22,9 @@ spec:
   condition:
     field: Identity.Type
     in:
-    - 'SystemAssigned'
-    - 'UserAssigned'
+    - SystemAssigned
+    - UserAssigned
+    - SystemAssigned, UserAssigned
 
 ---
 # Synopsis: Use disk encryption for Azure Data Explorer (ADX) clusters.

--- a/src/PSRule.Rules.Azure/rules/Azure.APIM.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.APIM.Rule.ps1
@@ -195,11 +195,6 @@ Rule 'Azure.APIM.ProductTerms' -Type 'Microsoft.ApiManagement/service', 'Microso
     }
 }
 
-# Synopsis: Consider configuring a managed identity for each API Management instance.
-Rule 'Azure.APIM.ManagedIdentity' -Type 'Microsoft.ApiManagement/service' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $Assert.In($TargetObject, 'Identity.Type', @('SystemAssigned', 'UserAssigned'));
-}
-
 # Synopsis: Renew expired certificates
 Rule 'Azure.APIM.CertificateExpiry' -Type 'Microsoft.ApiManagement/service' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $configurations = @($TargetObject.Properties.hostnameConfigurations | Where-Object {

--- a/src/PSRule.Rules.Azure/rules/Azure.APIM.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.APIM.Rule.yaml
@@ -2,24 +2,28 @@
 # Licensed under the MIT License.
 
 #
-# Validation rules for Automation Account
+# Validation rules for API Management
 #
 
+#region Rules
+
 ---
-# Synopsis: Ensure managed identity is used for authentication.
+# Synopsis: Consider configuring a managed identity for each API Management instance.
 apiVersion: github.com/microsoft/PSRule/v1
 kind: Rule
 metadata:
-  name: Azure.Automation.ManagedIdentity
+  name: Azure.APIM.ManagedIdentity
   tags:
     release: GA
-    ruleSet: 2021_12
+    ruleSet: 2020_06
 spec:
   type:
-  - Microsoft.Automation/automationAccounts
+  - Microsoft.ApiManagement/service
   condition:
     field: Identity.Type
     in:
     - SystemAssigned
     - UserAssigned
     - SystemAssigned, UserAssigned
+
+#endregion Rules

--- a/src/PSRule.Rules.Azure/rules/Azure.AppService.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppService.Rule.ps1
@@ -59,13 +59,13 @@ Rule 'Azure.AppService.NETVersion' -Type 'Microsoft.Web/sites', 'Microsoft.Web/s
     if ($siteConfigs.Length -eq 0) {
         return AnyOf {
             $Assert.HasDefaultValue($TargetObject, 'Properties.siteConfig.netFrameworkVersion', 'OFF')
-            $Assert.Version($TargetObject, 'Properties.siteConfig.netFrameworkVersion', '^4.0')
+            $Assert.Version($TargetObject, 'Properties.siteConfig.netFrameworkVersion', '>=4.0')
         }
     }
     foreach ($siteConfig in $siteConfigs) {
         AnyOf {
             $Assert.HasFieldValue($siteConfig, 'Properties.netFrameworkVersion', 'OFF')
-            $Assert.Version($siteConfig, 'Properties.netFrameworkVersion', '^4.0')
+            $Assert.Version($siteConfig, 'Properties.netFrameworkVersion', '>=4.0')
         }
     }
 }
@@ -78,13 +78,13 @@ Rule 'Azure.AppService.PHPVersion' -Type 'Microsoft.Web/sites', 'Microsoft.Web/s
     if ($siteConfigs.Length -eq 0) {
         return AnyOf {
             $Assert.HasDefaultValue($TargetObject, 'Properties.siteConfig.phpVersion', 'OFF')
-            $Assert.Version($TargetObject, 'Properties.siteConfig.phpVersion', '^7.0')
+            $Assert.Version($TargetObject, 'Properties.siteConfig.phpVersion', '>=7.0')
         }
     }
     foreach ($siteConfig in $siteConfigs) {
         AnyOf {
             $Assert.HasFieldValue($siteConfig, 'Properties.phpVersion', 'OFF')
-            $Assert.Version($siteConfig, 'Properties.phpVersion', '^7.0')
+            $Assert.Version($siteConfig, 'Properties.phpVersion', '>=7.0')
         }
     }
 }
@@ -109,11 +109,6 @@ Rule 'Azure.AppService.HTTP2' -Type 'Microsoft.Web/sites', 'Microsoft.Web/sites/
     foreach ($siteConfig in $siteConfigs) {
         $Assert.HasFieldValue($siteConfig, 'Properties.http20Enabled', $True);
     }
-}
-
-# Synopsis: Use a Managed Identities with Azure Service apps.
-Rule 'Azure.AppService.ManagedIdentity' -Type 'Microsoft.Web/sites', 'Microsoft.Web/sites/slots' -Tag @{ release = 'GA'; ruleSet = '2020_12'; } {
-    $Assert.In($TargetObject, 'Identity.Type', @('SystemAssigned', 'UserAssigned'));
 }
 
 #region Helper functions

--- a/src/PSRule.Rules.Azure/rules/Azure.AppService.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppService.Rule.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Rules for App Service
+#
+
+#region Rules
+
+---
+# Synopsis: Use a Managed Identities with Azure Service apps.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AppService.ManagedIdentity
+  tags:
+    release: 'GA'
+    ruleSet: 2020_12
+spec:
+  type:
+  - Microsoft.Web/sites
+  - Microsoft.Web/sites/slots
+  condition:
+    field: identity.type
+    in:
+    - SystemAssigned
+    - UserAssigned
+    - SystemAssigned, UserAssigned
+
+#endregion Rules

--- a/src/PSRule.Rules.Azure/rules/Azure.EventGrid.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.EventGrid.Rule.yaml
@@ -48,8 +48,9 @@ spec:
   condition:
     field: Identity.Type
     in:
-    - 'SystemAssigned'
-    - 'UserAssigned'
+    - SystemAssigned
+    - UserAssigned
+    - SystemAssigned, UserAssigned
 
 ---
 # Synopsis: Authenticate publishing clients with Azure AD identities.

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
@@ -289,8 +289,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'app-a';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c';
         }
 
         It 'Azure.AppService.RemoteDebug' {
@@ -303,8 +303,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'app-a';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c';
         }
 
         It 'Azure.AppService.NETVersion' {
@@ -317,8 +317,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'app-a';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c';
         }
 
         It 'Azure.AppService.PHPVersion' {
@@ -331,8 +331,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'app-a';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c';
         }
 
         It 'Azure.AppService.AlwaysOn' {
@@ -345,8 +345,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'app-a';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c';
         }
 
         It 'Azure.AppService.HTTP2' {
@@ -359,8 +359,23 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c';
+        }
+
+        It 'Azure.AppService.ManagedIdentity' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppService.ManagedIdentity' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -BeIn 'app-a';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'app-b', 'app-c';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.EventGrid.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.EventGrid.Tests.ps1
@@ -111,8 +111,8 @@ Describe 'Azure.EventGrid' -Tag 'EventGrid' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'topic-001';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'topic-001', 'topic-002';
         }
 
         It 'Azure.EventGrid.ManagedIdentity' {
@@ -128,8 +128,8 @@ Describe 'Azure.EventGrid' -Tag 'EventGrid' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'topic-001';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'topic-001', 'topic-002';
         }
 
         It 'Azure.EventGrid.DisableLocalAuth' {
@@ -137,13 +137,14 @@ Describe 'Azure.EventGrid' -Tag 'EventGrid' {
 
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
-            $ruleResult | Should -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'topic-001';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'topic-001';
+            $ruleResult.TargetName | Should -BeIn 'topic-002';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AppService.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AppService.Template.json
@@ -89,7 +89,9 @@
             "false": null
         },
         "planName2": "plan-b",
-        "planName3": "plan-c"
+        "planName3": "plan-c",
+        "appName2": "app-b",
+        "appName3": "app-c"
     },
     "resources": [
         {
@@ -242,6 +244,67 @@
                 "name": "EP1",
                 "tier": "ElasticPremium"
             }
+        },
+        {
+            "apiVersion": "2018-11-01",
+            "name": "[variables('appName2')]",
+            "type": "Microsoft.Web/sites",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('tags')]",
+            "dependsOn": [
+                "[concat('Microsoft.Web/serverfarms/', variables('planName2'))]"
+            ],
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "siteConfig": {
+                    "appSettings": [],
+                    "phpVersion": "OFF",
+                    "netFrameworkVersion": "OFF",
+                    "alwaysOn": "[parameters('alwaysOn')]",
+                    "minTlsVersion": "1.2",
+                    "http20Enabled": true
+                },
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms/', variables('planName2'))]",
+                "clientAffinityEnabled": false,
+                "httpsOnly": true
+            }
+        },
+        {
+            "apiVersion": "2018-11-01",
+            "name": "[variables('appName3')]",
+            "type": "Microsoft.Web/sites",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('tags')]",
+            "identity": {
+                "type": "SystemAssigned, UserAssigned",
+                "userAssignedIdentities": {
+                    "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('appName3'))]": {}
+                }
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Web/serverfarms/', variables('planName2'))]"
+            ],
+            "properties": {
+                "siteConfig": {
+                    "appSettings": [],
+                    "phpVersion": "OFF",
+                    "netFrameworkVersion": "v6.0",
+                    "alwaysOn": "[parameters('alwaysOn')]",
+                    "minTlsVersion": "1.2",
+                    "http20Enabled": true
+                },
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms/', variables('planName2'))]",
+                "clientAffinityEnabled": false,
+                "httpsOnly": true
+            }
+        },
+        {
+            "name": "[variables('appName3')]",
+            "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+            "apiVersion": "2018-11-30",
+            "location": "[parameters('location')]"
         }
     ],
     "outputs": {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.EventGrid.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.EventGrid.Template.json
@@ -98,7 +98,8 @@
         "mapping": {
             "inputSchemaMappingType": "Json",
             "properties": "[parameters('inputSchemaMapping')]"
-        }
+        },
+        "topic2": "topic-002"
     },
     "resources": [
         {
@@ -118,8 +119,7 @@
             "properties": {
                 "inputSchema": "[parameters('inputSchema')]",
                 "inputSchemaMapping": "[if(equals(parameters('inputSchema'), 'CustomEventSchema'), variables('mapping'), json('null'))]",
-                "publicNetworkAccess": "[if(parameters('publicNetworkAccess'), 'Enabled', 'Disabled')]",
-                "disableLocalAuth": true
+                "publicNetworkAccess": "[if(parameters('publicNetworkAccess'), 'Enabled', 'Disabled')]"
             }
         },
         {
@@ -148,6 +148,36 @@
                     "eventTimeToLiveInMinutes": "[if(contains(parameters('subscriptions')[copyIndex('subscriptionCopy')], 'eventTimeToLiveInMinutes'), parameters('subscriptions')[copyIndex('subscriptionCopy')].eventTimeToLiveInMinutes, 180)]"
                 },
                 "deadLetterDestination": "[if(contains(parameters('subscriptions')[copyIndex('subscriptionCopy')], 'deadLetterDestination'), parameters('subscriptions')[copyIndex('subscriptionCopy')].deadLetterDestination, json('null'))]"
+            }
+        },
+        {
+            "name": "[variables('topic2')]",
+            "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+            "apiVersion": "2018-11-30",
+            "location": "[parameters('location')]"
+        },
+        {
+            "comments": "Create or update and Event Grid Topic.",
+            "type": "Microsoft.EventGrid/topics",
+            "apiVersion": "2021-06-01-preview",
+            "name": "[variables('topic2')]",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('tags')]",
+            "sku": {
+                "name": "[parameters('sku')]"
+            },
+            "kind": "Azure",
+            "identity": {
+                "type": "SystemAssigned, UserAssigned",
+                "userAssignedIdentities": {
+                    "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('topic2'))]": {}
+                }
+            },
+            "properties": {
+                "inputSchema": "[parameters('inputSchema')]",
+                "inputSchemaMapping": "[if(equals(parameters('inputSchema'), 'CustomEventSchema'), variables('mapping'), json('null'))]",
+                "publicNetworkAccess": "[if(parameters('publicNetworkAccess'), 'Enabled', 'Disabled')]",
+                "disableLocalAuth": true
             }
         }
     ],


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.AppService.ManagedIdentity` does not accept both system and user assigned by @BernieWhite. #1415
  - This also applies to:
    - `Azure.ADX.ManagedIdentity`
    - `Azure.APIM.ManagedIdentity`
    - `Azure.EventGrid.ManagedIdentity`
    - `Azure.Automation.ManagedIdentity`
- Fixed Web apps with .NET 6 do not meet version constraint of `Azure.AppService.NETVersion` by @BernieWhite. #1414
  - This also applies to `Azure.AppService.PHPVersion`.

Fixes #1415 
Fixes #1414 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
