### PR TITLE
Release v1.15.2

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -19,6 +19,8 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.15.2
+
 What's changed since v1.15.1:
 
 - Bug fixes:


### PR DESCRIPTION
## PR Summary

What's changed since v1.15.1:

- Bug fixes:
  - Fixed `Azure.AppService.ManagedIdentity` does not accept both system and user assigned by @BernieWhite.
    #1415
    - This also applies to:
      - `Azure.ADX.ManagedIdentity`
      - `Azure.APIM.ManagedIdentity`
      - `Azure.EventGrid.ManagedIdentity`
      - `Azure.Automation.ManagedIdentity`
  - Fixed Web apps with .NET 6 do not meet version constraint of `Azure.AppService.NETVersion` by @BernieWhite.
    #1414
    - This also applies to `Azure.AppService.PHPVersion`.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
