### PR TITLE
Fix selector docs for Azure.Resource.SupportsTags

### DIFF
--- a/docs/en/selectors/Azure.Resource.SupportsTags.md
+++ b/docs/en/selectors/Azure.Resource.SupportsTags.md
@@ -12,7 +12,7 @@ Use this selector to filter rules to only run against resources that support tag
 
 ### Configure with YAML-based rules
 
-- Use the `with` property to set `Azure.Resource.SupportsTags`.
+- Use the `with` property to set `PSRule.Rules.Azure\Azure.Resource.SupportsTags`.
 
 ```yaml
 ---
@@ -23,14 +23,14 @@ metadata:
   name: Local.MyRule
 spec:
   with:
-  - Azure.Resource.SupportsTags
+  - PSRule.Rules.Azure\Azure.Resource.SupportsTags
   condition:
     # Rule logic goes here
 ```
 
 ### Configure with JSON-based rules
 
-- Use the `with` property to set `Azure.Resource.SupportsTags`.
+- Use the `with` property to set `PSRule.Rules.Azure\Azure.Resource.SupportsTags`.
 
 ```json
 {
@@ -42,7 +42,7 @@ spec:
     },
     "spec": {
         "with": [
-            "Azure.Resource.SupportsTags"
+            "PSRule.Rules.Azure\\Azure.Resource.SupportsTags"
         ],
         "condition": {
             // Rule logic goes here
@@ -53,11 +53,11 @@ spec:
 
 ### Configure with PowerShell-based rules
 
-- Use the `-With` parameter to set `Azure.Resource.SupportsTags`.
+- Use the `-With` parameter to set `PSRule.Rules.Azure\Azure.Resource.SupportsTags`.
 
 ```powershell
 # Synopsis: An example rule.
-Rule 'Local.MyRule' -With 'Azure.Resource.SupportsTags' {
+Rule 'Local.MyRule' -With 'PSRule.Rules.Azure\Azure.Resource.SupportsTags' {
   # Rule logic goes here
 }
 ```


### PR DESCRIPTION
## PR Summary

- Fix reference to `Azure.Resource.SupportsTags` which should be fully qualifies in docs.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
