### PR TITLE
Exclude Bastion public IP from AZ #1442

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,7 +7,7 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 **Important notes**:
 
 - Issue #741: `Could not load file or assembly YamlDotNet`.
-See [troubleshooting guide] for a workaround to this issue.
+  See [troubleshooting guide] for a workaround to this issue.
 - The configuration option `Azure_AKSMinimumVersion` is replaced with `AZURE_AKS_CLUSTER_MINIMUM_VERSION`.
   If you have this option configured, please update it to `AZURE_AKS_CLUSTER_MINIMUM_VERSION`.
   Support for `Azure_AKSMinimumVersion` will be removed in v2.
@@ -18,6 +18,14 @@ See [troubleshooting guide] for a workaround to this issue.
   See [upgrade notes][1] for more information.
 
 ## Unreleased
+
+What's changed since pre-release v1.16.0-B0017:
+
+- Updated rules:
+  - Public IP:
+    - Updated `Azure.PublicIP.AvailabilityZone` to exclude IP addresses for Azure Bastion by @BernieWhite.
+      [#1442](https://github.com/Azure/PSRule.Rules.Azure/issues/1442)
+      - Public IP addresses with the `resource-usage` tag set to `azure-bastion` are excluded.
 
 ## v1.16.0-B0017 (pre-release)
 

--- a/docs/en/rules/Azure.PublicIP.AvailabilityZone.md
+++ b/docs/en/rules/Azure.PublicIP.AvailabilityZone.md
@@ -24,7 +24,11 @@ Consider using zone-redundant Public IP addresses deployed with Standard SKU.
 
 ## NOTES
 
-This rule applies when analyzing resources deployed to Azure using *pre-flight* and *in-flight* data.
+This rule is not applicable for public IP addresses used for Azure Bastion.
+Azure Bastion does not currently support Availability Zones.
+Public IP addresses with the following tags are automatically excluded from this rule:
+
+- `resource-usage` tag set to `azure-bastion`.
 
 This rule fails when `"zones"` is constrained to a single(zonal) zone, or set to `null`, `[]` when there are supported availability zones for the given region.
 
@@ -79,7 +83,7 @@ For example:
 To configure zone-redundancy for a Public IP address.
 
 - Set `sku.name` to `Standard`.
-- Set `zones` to `["1", "2", "3"]`.
+- Set `zones` to `['1', '2', '3']`.
 
 For example:
 

--- a/src/PSRule.Rules.Azure/rules/Azure.PublicIP.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.PublicIP.Rule.ps1
@@ -38,7 +38,7 @@ Rule 'Azure.PublicIP.DNSLabel' -Type 'Microsoft.Network/publicIPAddresses' -If {
 }
 
 # Synopsis: Public IP addresses deployed with Standard SKU should use availability zones in supported regions for high availability.
-Rule 'Azure.PublicIP.AvailabilityZone' -Type 'Microsoft.Network/publicIPAddresses' -If { IsStandardPublicIP } -Tag @{ release = 'GA'; ruleSet = '2021_12'; } {
+Rule 'Azure.PublicIP.AvailabilityZone' -With 'Azure.PublicIP.ShouldBeAvailable' -Tag @{ release = 'GA'; ruleSet = '2021_12'; } {
     $publicIpAddressProvider = [PSRule.Rules.Azure.Runtime.Helper]::GetResourceType('Microsoft.Network', 'publicIPAddresses');
 
     $configurationZoneMappings = $Configuration.AZURE_PUBLICIP_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST;
@@ -61,11 +61,6 @@ Rule 'Azure.PublicIP.AvailabilityZone' -Type 'Microsoft.Network/publicIPAddresse
     )
 
 } -Configure @{ AZURE_PUBLICIP_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST = @() }
-
-# Synopsis: Public IP addresses should be deployed with Standard SKU for production workloads.
-Rule 'Azure.PublicIP.StandardSKU' -Type 'Microsoft.Network/publicIPAddresses' -Tag @{ release = 'GA'; ruleSet = '2021_12'; } {
-    IsStandardPublicIP;
-}
 
 #region Helper functions
 

--- a/src/PSRule.Rules.Azure/rules/Azure.PublicIP.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.PublicIP.Rule.yaml
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Validation rules for public IP addresses
+#
+
+#region Rules
+
+---
+# Synopsis: Public IP addresses should be deployed with Standard SKU for production workloads.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.PublicIP.StandardSKU
+  tags:
+    release: 'GA'
+    ruleSet: '2021_12'
+spec:
+  type:
+  - Microsoft.Network/publicIPAddresses
+  condition:
+    field: sku.name
+    equals: Standard
+
+#endregion Rules
+
+#region Selectors
+
+---
+# Synopsis: Public IP addresses using the standard SKU that are not excluded.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Azure.PublicIP.ShouldBeAvailable
+  metadata:
+    export: false
+spec:
+  if:
+    allOf:
+    - type: '.'
+      equals: Microsoft.Network/publicIPAddresses
+    - field: sku.name
+      equals: Standard
+    - field: tags.'resource-usage'
+      notEquals: azure-bastion
+
+#endregion Selectors

--- a/tests/PSRule.Rules.Azure.Tests/Azure.PublicIP.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.PublicIP.Tests.ps1
@@ -25,7 +25,7 @@ BeforeAll {
     $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-Describe 'Azure.PublicIP' {
+Describe 'Azure.PublicIP' -Tag 'publicip' {
     Context 'Conditions' {
         BeforeAll {
             $invokeParams = @{
@@ -44,8 +44,8 @@ Describe 'Azure.PublicIP' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 10;
-            $ruleResult.TargetName | Should -Be 'ip-B', 'Ip-C', 'ip-D', 'ip-E', 'ip-F', 'ip-G', 'ip-H', 'ip-I', 'ip-J', 'ip-K';
+            $ruleResult.Length | Should -Be 11;
+            $ruleResult.TargetName | Should -Be 'ip-B', 'Ip-C', 'ip-D', 'ip-E', 'ip-F', 'ip-G', 'ip-H', 'ip-I', 'ip-J', 'ip-K', 'ip-L';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -64,8 +64,8 @@ Describe 'Azure.PublicIP' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 11;
-            $ruleResult.TargetName | Should -Be 'ip-A', 'ip-B', 'Ip-C', 'ip-D', 'ip-E', 'ip-F', 'ip-G', 'ip-H', 'ip-I', 'ip-J', 'ip-K';
+            $ruleResult.Length | Should -Be 12;
+            $ruleResult.TargetName | Should -Be 'ip-A', 'ip-B', 'Ip-C', 'ip-D', 'ip-E', 'ip-F', 'ip-G', 'ip-H', 'ip-I', 'ip-J', 'ip-K', 'ip-L';
         }
 
         It 'Azure.PublicIP.DNSLabel' {
@@ -78,8 +78,8 @@ Describe 'Azure.PublicIP' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 10;
-            $ruleResult.TargetName | Should -Be 'ip-B', 'Ip-C', 'ip-D', 'ip-E', 'ip-F', 'ip-G', 'ip-H', 'ip-I', 'ip-J', 'ip-K';
+            $ruleResult.Length | Should -Be 11;
+            $ruleResult.TargetName | Should -Be 'ip-B', 'Ip-C', 'ip-D', 'ip-E', 'ip-F', 'ip-G', 'ip-H', 'ip-I', 'ip-J', 'ip-K', 'ip-L';
         }
 
         It 'Azure.PublicIP.AvailabilityZone' {
@@ -107,8 +107,8 @@ Describe 'Azure.PublicIP' {
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'ip-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'ip-A', 'ip-L';
         }
 
         It 'Azure.PublicIP.StandardSKU' {
@@ -121,13 +121,13 @@ Describe 'Azure.PublicIP' {
             $ruleResult.TargetName | Should -Be 'ip-A';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[0].Reason | Should -BeExactly "The field 'sku.name' is set to 'Basic'.";
+            $ruleResult[0].Reason | Should -BeExactly "Field sku.name: Is set to 'Basic'.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 10;
-            $ruleResult.TargetName | Should -Be 'ip-B', 'ip-C', 'ip-D', 'ip-E', 'ip-F', 'ip-G', 'ip-H', 'ip-I', 'ip-J', 'ip-K';
+            $ruleResult.Length | Should -Be 11;
+            $ruleResult.TargetName | Should -BeIn 'ip-B', 'ip-C', 'ip-D', 'ip-E', 'ip-F', 'ip-G', 'ip-H', 'ip-I', 'ip-J', 'ip-K', 'ip-L';
         }
     }
 
@@ -357,13 +357,13 @@ Describe 'Azure.PublicIP' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -Be 'ip-C', 'ip-E', 'ip-I', 'ip-K';
+            $ruleResult.TargetName | Should -BeIn 'ip-C', 'ip-E', 'ip-I', 'ip-K';
 
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'ip-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'ip-A', 'ip-L';
         }
 
         It 'Azure.PublicIP.AvailabilityZone - YAML file option' {
@@ -393,13 +393,13 @@ Describe 'Azure.PublicIP' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -Be 'ip-C', 'ip-E', 'ip-I', 'ip-K';
+            $ruleResult.TargetName | Should -BeIn 'ip-C', 'ip-E', 'ip-I', 'ip-K';
 
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'ip-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'ip-A', 'ip-L';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.PublicIP.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.PublicIP.json
@@ -379,5 +379,39 @@
             "2",
             "3"
         ]
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/ip-L",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/ip-L",
+        "Location": "australiaeast",
+        "ResourceName": "ip-L",
+        "Name": "ip-L",
+        "Properties": {
+            "provisioningState": "Succeeded",
+            "ipAddress": "0.0.0.0",
+            "publicIPAddressVersion": "IPv4",
+            "publicIPAllocationMethod": "Static",
+            "idleTimeoutInMinutes": 4,
+            "ipTags": [],
+            "ipConfiguration": { },
+            "dnsSettings": {
+                "domainNameLabel": "ip-l"
+            }
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Network/publicIPAddresses",
+        "ResourceType": "Microsoft.Network/publicIPAddresses",
+        "Sku": {
+            "Name": "Standard",
+            "Tier": "Regional",
+            "Size": null,
+            "Family": null,
+            "Model": null,
+            "Capacity": null
+        },
+        "Tags": {
+            "resource-usage": "azure-bastion"
+        },
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
     }
 ]


### PR DESCRIPTION
## PR Summary

- Updated `Azure.PublicIP.AvailabilityZone` to exclude IP addresses for Azure Bastion.

Fixes #1442 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
