### PR TITLE
Pre-release v1.16.0-B0041

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -19,6 +19,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.16.0-B0041 (pre-release)
+
 What's changed since pre-release v1.16.0-B0017:
 
 - Updated rules:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.16.0-B0017:

- Updated rules:
  - Public IP:
    - Updated `Azure.PublicIP.AvailabilityZone` to exclude IP addresses for Azure Bastion by @BernieWhite.
      [#1442](https://github.com/Azure/PSRule.Rules.Azure/issues/1442)
      - Public IP addresses with the `resource-usage` tag set to `azure-bastion` are excluded.
- General improvements:
  - Added support for `dateTimeFromEpoch` and `dateTimeToEpoch` ARM functions by @BernieWhite.
    [#1451](https://github.com/Azure/PSRule.Rules.Azure/issues/1451)
- Engineering:
  - Updated built documentation to include rule ref and metadata by @BernieWhite.
    [#1432](https://github.com/Azure/PSRule.Rules.Azure/issues/1432)
  - Added ref properties for several rules by @BernieWhite.
    [#1430](https://github.com/Azure/PSRule.Rules.Azure/issues/1430)
  - Updated provider data for analysis.
    [#1453](https://github.com/Azure/PSRule.Rules.Azure/pull/1453)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
