### PR TITLE
Fixes app gateway TLS and WAF policy #1469 #1466

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -19,6 +19,14 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.16.0:
+
+- Bug fixes:
+  - Fixed TLS 1.3 support in `Azure.AppGw.SSLPolicy` by @BernieWhite.
+    [#1469](https://github.com/Azure/PSRule.Rules.Azure/issues/1469)
+  - Fixed Application Gateway referencing a WAF policy by @BernieWhite.
+    [#1466](https://github.com/Azure/PSRule.Rules.Azure/issues/1466)
+
 ## v1.16.0
 
 What's changed since v1.15.2:

--- a/docs/en/rules/Azure.AppGw.AvailabilityZone.md
+++ b/docs/en/rules/Azure.AppGw.AvailabilityZone.md
@@ -10,11 +10,13 @@ online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AppGw.
 
 ## SYNOPSIS
 
-Application gateways deployed with V2 SKU(Standard_v2, WAF_v2) should use availability zones in supported regions for high availability.
+Application gateways deployed with should use availability zones in supported regions for high availability.
 
 ## DESCRIPTION
 
-Application gateways using availability zones improve reliability and ensure availability during failure scenarios affecting a data center within a region. A zone redundant Application gateway or WAF deployment can spread across multiple availability zones, which ensures the application gateway will continue running even if another zone has gone down. Backend pools for applications can be similarly distributed across availability zones.
+Application gateways using availability zones improve reliability and ensure availability during failure scenarios affecting a data center within a region.
+A zone redundant Application gateway or WAF deployment can spread across multiple availability zones, which ensures the application gateway will continue running even if another zone has gone down.
+Backend pools for applications can be similarly distributed across availability zones.
 
 ## RECOMMENDATION
 

--- a/docs/examples-appgw.bicep
+++ b/docs/examples-appgw.bicep
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Bicep documentation examples
+
+@description('The name of the Application Gateway.')
+param name string
+
+@description('The location resources will be deployed.')
+param location string = resourceGroup().location
+
+resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' existing = {
+  name: 'identity-001'
+}
+
+resource wafPolicy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@2021-08-01' existing = {
+  name: 'policy-001'
+}
+
+// An example Application Gateway
+resource gateway 'Microsoft.Network/applicationGateways@2021-08-01' = {
+  name: name
+  location: location
+  zones: [
+    '1'
+    '2'
+    '3'
+  ]
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${identity.id}': {}
+    }
+  }
+  properties: {
+    enableHttp2: true
+    sslPolicy: {
+      policyType: 'Predefined'
+      policyName: 'AppGwSslPolicy20170401S'
+    }
+    firewallPolicy: {
+      id: wafPolicy.id
+    }
+  }
+}

--- a/docs/examples-appgw.json
+++ b/docs/examples-appgw.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.6.18.56646",
+      "templateHash": "11471630422390052107"
+    }
+  },
+  "parameters": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Application Gateway."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location resources will be deployed."
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/applicationGateways",
+      "apiVersion": "2021-08-01",
+      "name": "[parameters('name')]",
+      "location": "[parameters('location')]",
+      "zones": [
+        "1",
+        "2",
+        "3"
+      ],
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'id-test'))]": {}
+        }
+      },
+      "properties": {
+        "enableHttp2": true,
+        "sslPolicy": {
+          "policyType": "Predefined",
+          "policyName": "AppGwSslPolicy20170401S"
+        },
+        "firewallPolicy": {
+          "id": "[resourceId('Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies', 'wafpolicy')]"
+        }
+      }
+    }
+  ]
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.ps1
@@ -25,7 +25,7 @@ Rule 'Azure.AppGw.UseHTTPS' -Ref 'AZR-000059' -Type 'Microsoft.Network/applicati
     }
 }
 
-# Synopsis: Application gateways deployed with V2 SKU(Standard_v2, WAF_v2) should use availability zones in supported regions for high availability.
+# Synopsis: Application gateways deployed with should use availability zones in supported regions for high availability.
 Rule 'Azure.AppGw.AvailabilityZone' -Ref 'AZR-000060' -With 'Azure.IsAppGwV2Sku' -Tag @{ release = 'GA'; ruleSet = '2021_09'; } {
     $appGatewayProvider = [PSRule.Rules.Azure.Runtime.Helper]::GetResourceType('Microsoft.Network', 'applicationGateways');
 

--- a/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.yaml
@@ -88,9 +88,14 @@ spec:
   condition:
     anyOf:
     - field: Properties.sslPolicy.policyName
-      equals: AppGwSslPolicy20170401S
+      in:
+      - AppGwSslPolicy20170401S
+      - AppGwSslPolicy20220101
+      - AppGwSslPolicy20220101S
     - field: Properties.sslPolicy.minProtocolVersion
-      equals: TLSv1_2
+      in:
+      - TLSv1_2
+      - TLSv1_3
 
 ---
 # Synopsis: Internet exposed Application Gateways should use prevention mode to protect backend resources.
@@ -104,9 +109,9 @@ metadata:
     ruleSet: '2020_06'
 spec:
   with:
-  - Azure.IsAppGwPublic
+  - Azure.AppGw.WithClassicWAF
   condition:
-    field: Properties.webApplicationFirewallConfiguration.firewallMode
+    field: properties.webApplicationFirewallConfiguration.firewallMode
     equals: Prevention
 
 ---
@@ -123,8 +128,11 @@ spec:
   with:
   - Azure.IsAppGwPublic
   condition:
-    field: Properties.webApplicationFirewallConfiguration.enabled
-    equals: true
+    anyOf:
+    - field: properties.webApplicationFirewallConfiguration.enabled
+      equals: true
+    - field: properties.firewallPolicy.id
+      hasValue: true
 
 ---
 # Synopsis: Application Gateway Web Application Firewall (WAF) should use OWASP 3.x rules.
@@ -138,12 +146,12 @@ metadata:
     ruleSet: '2020_06'
 spec:
   with:
-  - Azure.IsAppGwWAF
+  - Azure.AppGw.WithClassicWAF
   condition:
     allOf:
-    - field: Properties.webApplicationFirewallConfiguration.ruleSetType
+    - field: properties.webApplicationFirewallConfiguration.ruleSetType
       equals: OWASP
-    - field: Properties.webApplicationFirewallConfiguration.ruleSetVersion
+    - field: properties.webApplicationFirewallConfiguration.ruleSetVersion
       version: '^3.0'
 
 ---
@@ -158,9 +166,9 @@ metadata:
     ruleSet: '2020_06'
 spec:
   with:
-  - Azure.IsAppGwWAF
+  - Azure.AppGw.WithClassicWAF
   condition:
-    field: Properties.webApplicationFirewallConfiguration.disabledRuleGroups
+    field: properties.webApplicationFirewallConfiguration.disabledRuleGroups
     lessOrEquals: 0
 
 #endregion Rules
@@ -172,7 +180,9 @@ spec:
 apiVersion: github.com/microsoft/PSRule/v1
 kind: Selector
 metadata:
-  name: Azure.IsAppGwWAF
+  name: Azure.AppGw.WithClassicWAF
+  annotations:
+    export: false
 spec:
   if:
     allOf:
@@ -182,7 +192,7 @@ spec:
       in:
       - 'WAF'
       - 'WAF_v2'
-    - field: Properties.webApplicationFirewallConfiguration.enabled
+    - field: properties.webApplicationFirewallConfiguration.enabled
       equals: true
 
 ---
@@ -191,12 +201,14 @@ apiVersion: github.com/microsoft/PSRule/v1
 kind: Selector
 metadata:
   name: Azure.IsAppGwPublic
+  annotations:
+    export: false
 spec:
   if:
     allOf:
     - type: '.'
       equals: Microsoft.Network/applicationGateways
-    - field: Properties.frontendIPConfigurations[?@.properties.publicIPAddress.id]
+    - field: properties.frontendIPConfigurations[?@.properties.publicIPAddress.id]
       greaterOrEquals: 1
 
 ---
@@ -205,12 +217,14 @@ apiVersion: github.com/microsoft/PSRule/v1
 kind: Selector
 metadata:
   name: Azure.IsAppGwV2Sku
+  annotations:
+    export: false
 spec:
   if:
     allOf:
     - type: '.'
       equals: Microsoft.Network/applicationGateways
-    - field: Properties.sku.tier
+    - field: properties.sku.tier
       in:
       - Standard_v2
       - WAF_v2

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppGw.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppGw.Tests.ps1
@@ -42,8 +42,8 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -BeIn 'appgw-B', 'appgw-D', 'appgw-E', 'appgw-F', 'appgw-G';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'appgw-B', 'appgw-D', 'appgw-E', 'appgw-F', 'appgw-G', 'appgw-H';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -64,8 +64,8 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-C', 'appgw-D', 'appgw-E', 'appgw-F', 'appgw-G';
+            $ruleResult.Length | Should -Be 7;
+            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-C', 'appgw-D', 'appgw-E', 'appgw-F', 'appgw-G', 'appgw-H';
         }
 
         It 'Azure.AppGw.UseWAF' {
@@ -74,14 +74,14 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -Be 'appgw-B', 'appgw-F', 'appgw-G';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'appgw-F', 'appgw-G';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-C', 'appgw-D', 'appgw-E';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'appgw-A', 'appgw-B', 'appgw-C', 'appgw-D', 'appgw-E', 'appgw-H';
         }
 
         It 'Azure.AppGw.SSLPolicy' {
@@ -96,8 +96,8 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-D', 'appgw-E', 'appgw-F', 'appgw-G';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-D', 'appgw-E', 'appgw-F', 'appgw-G', 'appgw-H';
         }
 
         It 'Azure.AppGw.Prevention' {
@@ -107,13 +107,19 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'appgw-B';
+            $ruleResult.TargetName | Should -BeIn 'appgw-C';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-C', 'appgw-D', 'appgw-E', 'appgw-F', 'appgw-G';
+            # $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'appgw-A', 'appgw-D', 'appgw-E';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            # $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'appgw-B', 'appgw-H', 'appgw-F', 'appgw-G';
         }
 
         It 'Azure.AppGw.WAFEnabled' {
@@ -128,8 +134,8 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-C', 'appgw-D', 'appgw-E', 'appgw-F', 'appgw-G';
+            $ruleResult.Length | Should -Be 7;
+            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-C', 'appgw-D', 'appgw-E', 'appgw-F', 'appgw-G',  'appgw-H';
         }
 
         It 'Azure.AppGw.OWASP' {
@@ -176,8 +182,8 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -Be 'appgw-C', 'appgw-D', 'appgw-E', 'appgw-F', 'appgw-G';
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -Be 'appgw-C', 'appgw-D', 'appgw-E', 'appgw-F', 'appgw-G', 'appgw-H';
         }
 
         It 'Azure.AppGw.AvailabilityZone' {
@@ -197,8 +203,8 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -Be 'appgw-C', 'appgw-D', 'appgw-G';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -Be 'appgw-C', 'appgw-D', 'appgw-G', 'appgw-H';
 
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
@@ -240,8 +246,8 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 4;
-            $ruleResult.TargetName | Should -BeIn 'appgw-C', 'appgw-E', 'appgw-F', 'appgw-G';
+            $ruleResult | Should -HaveCount 5;
+            $ruleResult.TargetName | Should -BeIn 'appgw-C', 'appgw-E', 'appgw-F', 'appgw-G', 'appgw-H';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "The application gateway (appgw-C) deployed to region (antarcticanorth) should use following availability zones [1, 2, 3].";
@@ -272,8 +278,8 @@ Describe 'Azure.AppGW' -Tag 'Network', 'AppGw' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult | Should -HaveCount 4;
-            $ruleResult.TargetName | Should -BeIn 'appgw-C', 'appgw-E', 'appgw-F', 'appgw-G';
+            $ruleResult | Should -HaveCount 5;
+            $ruleResult.TargetName | Should -BeIn 'appgw-C', 'appgw-E', 'appgw-F', 'appgw-G', 'appgw-H';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "The application gateway (appgw-C) deployed to region (antarcticanorth) should use following availability zones [1, 2, 3].";

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AppGw.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AppGw.json
@@ -167,7 +167,7 @@
         "Properties": {
             "sku": {
                 "name": "Standard_Small",
-                "tier": "Standard",
+                "tier": "WAF",
                 "capacity": 1
             },
             "gatewayIPConfigurations": [
@@ -521,7 +521,7 @@
             "redirectConfigurations": [],
             "webApplicationFirewallConfiguration": {
                 "enabled": true,
-                "firewallMode": "Prevention",
+                "firewallMode": "Detection",
                 "ruleSetType": "OWASP",
                 "ruleSetVersion": "3.0",
                 "disabledRuleGroups": [
@@ -1708,6 +1708,292 @@
                 "disabledRuleGroups": []
             },
             "enableHttp2": false
+        }
+    },
+    {
+        "name": "appgw-H",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H",
+        "type": "Microsoft.Network/applicationGateways",
+        "location": "antarcticasouth",
+        "zones": null,
+        "identity": {
+            "type": "userAssigned"
+        },
+        "properties": {
+            "provisioningState": "Succeeded",
+            "sku": {
+                "name": "WAF_v2",
+                "tier": "WAF_v2"
+            },
+            "operationalState": "Running",
+            "gatewayIPConfigurations": [
+                {
+                    "name": "apw-ip-configuration",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/gatewayIPConfigurations/apw-ip-configuration",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "subnet": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-spoke-BU0001A0008-00/subnets/snet-applicationgateway"
+                        }
+                    },
+                    "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"
+                }
+            ],
+            "sslCertificates": [
+                {
+                    "name": "appgw-F-ssl-certificate",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/sslCertificates/appgw-H-ssl-certificate",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "httpListeners": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/httpListeners/listener-https"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/sslCertificates"
+                }
+            ],
+            "frontendIPConfigurations": [
+                {
+                    "name": "apw-frontend-ip-configuration",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/frontendIPConfigurations/apw-frontend-ip-configuration",
+                    "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "privateIPAllocationMethod": "Dynamic",
+                        "publicIPAddress": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/publicIPAddresses/pip-BU0001A0008-00"
+                        },
+                        "httpListeners": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/httpListeners/listener-https"
+                            },
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/httpListeners/http"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "frontendPorts": [
+                {
+                    "name": "apw-frontend-ports",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/frontendPorts/apw-frontend-ports",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "port": 443,
+                        "httpListeners": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/httpListeners/listener-https"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/frontendPorts"
+                },
+                {
+                    "name": "port_80",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/frontendPorts/port_80",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "port": 80,
+                        "httpListeners": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/httpListeners/http"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/frontendPorts"
+                }
+            ],
+            "backendAddressPools": [
+                {
+                    "name": "d56ef422.aks-sb.com",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/backendAddressPools/d56ef422.aks-sb.com",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "backendAddresses": [
+                            {
+                                "fqdn": "d56ef422.aks-sb.com"
+                            }
+                        ],
+                        "requestRoutingRules": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/requestRoutingRules/apw-routing-rules"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/backendAddressPools"
+                }
+            ],
+            "backendHttpSettingsCollection": [
+                {
+                    "name": "aks-ingress-backendpool-httpsettings",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/backendHttpSettingsCollection/aks-ingress-backendpool-httpsettings",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "port": 443,
+                        "protocol": "Https",
+                        "cookieBasedAffinity": "Disabled",
+                        "pickHostNameFromBackendAddress": true,
+                        "requestTimeout": 20,
+                        "probe": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/probes/probe-d56ef422.aks-sb.com"
+                        },
+                        "requestRoutingRules": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/requestRoutingRules/apw-routing-rules"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"
+                }
+            ],
+            "httpListeners": [
+                {
+                    "name": "listener-https",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/httpListeners/listener-https",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "frontendIPConfiguration": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/frontendIPConfigurations/apw-frontend-ip-configuration"
+                        },
+                        "frontendPort": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/frontendPorts/apw-frontend-ports"
+                        },
+                        "protocol": "Https",
+                        "sslCertificate": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/sslCertificates/appgw-D-ssl-certificate"
+                        },
+                        "hostName": "d56ef422.aks-sb.com",
+                        "requireServerNameIndication": true,
+                        "requestRoutingRules": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/requestRoutingRules/apw-routing-rules"
+                            }
+                        ],
+                        "redirectConfiguration": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/redirectConfigurations/redirect-http"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/httpListeners"
+                },
+                {
+                    "name": "http",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/httpListeners/http",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "frontendIPConfiguration": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/frontendIPConfigurations/apw-frontend-ip-configuration"
+                        },
+                        "frontendPort": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/frontendPorts/port_80"
+                        },
+                        "protocol": "Http",
+                        "requireServerNameIndication": false,
+                        "requestRoutingRules": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/requestRoutingRules/redirect-http"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/httpListeners"
+                }
+            ],
+            "urlPathMaps": [],
+            "requestRoutingRules": [
+                {
+                    "name": "apw-routing-rules",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/requestRoutingRules/apw-routing-rules",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "ruleType": "Basic",
+                        "httpListener": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/httpListeners/listener-https"
+                        },
+                        "backendAddressPool": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/backendAddressPools/d56ef422.aks-sb.com"
+                        },
+                        "backendHttpSettings": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/backendHttpSettingsCollection/aks-ingress-backendpool-httpsettings"
+                        }
+                    },
+                    "type": "Microsoft.Network/applicationGateways/requestRoutingRules"
+                },
+                {
+                    "name": "redirect-http",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/requestRoutingRules/redirect-http",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "ruleType": "Basic",
+                        "httpListener": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/httpListeners/http"
+                        },
+                        "redirectConfiguration": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/redirectConfigurations/redirect-http"
+                        }
+                    },
+                    "type": "Microsoft.Network/applicationGateways/requestRoutingRules"
+                }
+            ],
+            "probes": [
+                {
+                    "name": "probe-d56ef422.aks-sb.com",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/probes/probe-d56ef422.aks-sb.com",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "protocol": "Https",
+                        "path": "/memory/healthz",
+                        "interval": 30,
+                        "timeout": 30,
+                        "unhealthyThreshold": 3,
+                        "pickHostNameFromBackendHttpSettings": true,
+                        "minServers": 0,
+                        "match": {},
+                        "backendHttpSettings": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/backendHttpSettingsCollection/aks-ingress-backendpool-httpsettings"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/probes"
+                }
+            ],
+            "redirectConfigurations": [
+                {
+                    "name": "redirect-http",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/redirectConfigurations/redirect-http",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "redirectType": "Permanent",
+                        "targetListener": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/httpListeners/listener-https"
+                        },
+                        "includePath": true,
+                        "includeQueryString": true,
+                        "requestRoutingRules": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationGateways/appgw-H/requestRoutingRules/redirect-http"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/redirectConfigurations"
+                }
+            ],
+            "sslPolicy": {
+                "policyType": "Custom",
+                "minProtocolVersion": "TLSv1_3",
+                "cipherSuites": [
+                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+                ]
+            },
+            "enableHttp2": false,
+            "firewallPolicy": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/waf001"
+            }
         }
     }
 ]


### PR DESCRIPTION
## PR Summary

- Fixed TLS 1.3 support in `Azure.AppGw.SSLPolicy`.
- Fixed Application Gateway referencing a WAF policy.

Fixes #1466
Fixes #1469

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
