### PR TITLE
Update assembly naming for packaging #1428

### DIFF
--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure-nodeps.psd1
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure-nodeps.psd1
@@ -62,7 +62,7 @@ This project uses GitHub Issues to track bugs and feature requests. See GitHub p
 
     # Assemblies that must be loaded prior to importing this module
     RequiredAssemblies     = @(
-        'PSRule.Rules.Azure.dll'
+        'Azure.PSRule.dll'
     )
 
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.csproj
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <AssemblyName>Azure.PSRule</AssemblyName>
+    <RootNamespace>PSRule.Rules.Azure</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <OutputType>Library</OutputType>

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psd1
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psd1
@@ -57,7 +57,7 @@ This project uses GitHub Issues to track bugs and feature requests. See GitHub p
 
     # Assemblies that must be loaded prior to importing this module
     RequiredAssemblies     = @(
-        'PSRule.Rules.Azure.dll'
+        'Azure.PSRule.dll'
     )
 
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.


### PR DESCRIPTION
## PR Summary

- Update assembly naming for NuGet packaging towards #1428

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
