### PR TITLE
Pre-release v1.17.0-B0035

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -19,6 +19,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.17.0-B0035 (pre-release)
+
 What's changed since pre-release v1.17.0-B0014:
 
 - New features:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.17.0-B0014:

- New features:
  - Added June 2022 baselines `Azure.GA_2022_06` and `Azure.Preview_2022_06` by @BernieWhite.
    [#1499](https://github.com/Azure/PSRule.Rules.Azure/issues/1499)
    - Includes rules released before or during June 2022.
    - Marked `Azure.GA_2022_03` and `Azure.Preview_2022_03` baselines as obsolete.
- Engineering:
  - Bump Newtonsoft.Json to v13.0.1.
    [#1494](https://github.com/Azure/PSRule.Rules.Azure/pull/1494)
  - Updated NuGet packaging metadata by @BernieWhite.
    [#1428](https://github.com/Azure/PSRule.Rules.Azure/pull/1428)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
