### PR TITLE
Fix double slash in NuGet

### DIFF
--- a/src/SDK/SDK.csproj
+++ b/src/SDK/SDK.csproj
@@ -12,19 +12,19 @@
   <ItemGroup>
     <Content Include="..\PSRule.Rules.Azure\*.psd1;..\PSRule.Rules.Azure\*.psm1;">
       <PackageCopyToOutput>true</PackageCopyToOutput>
-      <PackagePath>contentFiles\any\any\Modules\PSRule.Rules.Azure\;content\Modules\PSRule.Rules.Azure\</PackagePath>
+      <PackagePath>contentFiles\any\any\Modules\PSRule.Rules.Azure;content\Modules\PSRule.Rules.Azure</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
     <Content Include="..\PSRule.Rules.Azure\rules\*">
       <PackageCopyToOutput>true</PackageCopyToOutput>
-      <PackagePath>contentFiles\any\any\Modules\PSRule.Rules.Azure\rules\;content\Modules\PSRule.Rules.Azure\rules\</PackagePath>
+      <PackagePath>contentFiles\any\any\Modules\PSRule.Rules.Azure\rules;content\Modules\PSRule.Rules.Azure\rules</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
     <Content Include="..\..\docs\en\rules\*.md">
       <PackageCopyToOutput>true</PackageCopyToOutput>
-      <PackagePath>contentFiles\any\any\Modules\PSRule.Rules.Azure\en\;content\Modules\PSRule.Rules.Azure\en\</PackagePath>
+      <PackagePath>contentFiles\any\any\Modules\PSRule.Rules.Azure\en;content\Modules\PSRule.Rules.Azure\en</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
@@ -32,13 +32,13 @@
     <Content Include="$(OutputPath)\Microsoft.PSRule.Rules.Azure.Core.dll">
       <Pack>true</Pack>
       <PackageCopyToOutput>true</PackageCopyToOutput>
-      <PackagePath>contentFiles\any\any\Modules\PSRule.Rules.Azure\;content\Modules\PSRule.Rules.Azure\</PackagePath>
+      <PackagePath>contentFiles\any\any\Modules\PSRule.Rules.Azure;content\Modules\PSRule.Rules.Azure</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
 
   <!-- <ItemGroup>
-    <PackageReference Include="Microsoft.PSRule.SDK" Version="0.0.1" />
+    <PackageReference Include="Microsoft.PSRule.SDK" Version="2.3.0-B0001" />
   </ItemGroup> -->
 </Project>


### PR DESCRIPTION
## PR Summary

- Fix double slashes in NuGet package build.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
