### PR TITLE
Fixes union with expansion object #1515

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -19,6 +19,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.17.0:
+
+- Bug fixes:
+  - Fixed union returns null when merged with built-in expansion objects by @BernieWhite.
+    [#1515](https://github.com/Azure/PSRule.Rules.Azure/issues/1515)
+
 ## v1.17.0
 
 What's changed since v1.16.1:

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
@@ -270,7 +270,56 @@ namespace PSRule.Rules.Azure.Data.Template
                 }
             }
             return result.ToArray();
+        }
 
+        internal static bool IsObject(object o)
+        {
+            return o is JObject || o is IDictionary || o is IDictionary<string, string> || o is Dictionary<string, object>;
+        }
+
+        internal static object UnionObject(object[] o)
+        {
+            var result = new JObject();
+            if (o == null || o.Length == 0)
+                return result;
+
+            for (var i = 0; i < o.Length; i++)
+            {
+                if (o[i] is JObject jObject)
+                {
+                    foreach (var property in jObject.Properties())
+                    {
+                        if (!result.ContainsKey(property.Name))
+                            result.Add(property.Name, property.Value);
+                    }
+                }
+                else if (o[i] is IDictionary<string, string> dss)
+                {
+                    foreach (var kv in dss)
+                    {
+                        if (!result.ContainsKey(kv.Key))
+                            result.Add(kv.Key, JValue.FromObject(kv.Value));
+                    }
+                }
+                else if (o[i] is IDictionary<string, string> dso)
+                {
+                    foreach (var kv in dso)
+                    {
+                        if (!result.ContainsKey(kv.Key))
+                            result.Add(kv.Key, JToken.FromObject(kv.Value));
+                    }
+                }
+                else if (o[i] is IDictionary d)
+                {
+                    foreach (DictionaryEntry kv in d)
+                    {
+                        var key = kv.Key.ToString();
+                        if (!result.ContainsKey(key))
+                            result.Add(key, JToken.FromObject(kv.Value));
+                    }
+                }
+            }
+            return result;
         }
 
         /// <summary>

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -558,19 +558,9 @@ namespace PSRule.Rules.Azure.Data.Template
                 return ExpressionHelpers.UnionArray(args);
 
             // Object
-            if (args[0] is JObject jObject1)
-            {
-                var result = new JObject(jObject1);
-                for (var i = 1; i < args.Length && args[i] is JObject jObject2; i++)
-                {
-                    foreach (var property in jObject2.Properties())
-                    {
-                        if (!result.ContainsKey(property.Name))
-                            result.Add(property.Name, property.Value);
-                    }
-                }
-                return result;
-            }
+            if (ExpressionHelpers.IsObject(args[0]))
+                return ExpressionHelpers.UnionObject(args);
+
             return null;
         }
 

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -447,15 +448,27 @@ namespace PSRule.Rules.Azure
         public void Union()
         {
             var context = GetContext();
+            var hashtable = new Hashtable();
+            hashtable["a"] = 200;
 
             // Union objects
-            var actual1 = Functions.Union(context, new object[] { JObject.Parse("{ \"a\": \"b\", \"c\": \"d\" }"), JObject.Parse("{ \"e\": \"f\", \"g\": \"h\" }"), JObject.Parse("{ \"i\": \"j\" }") }) as JObject;
+            var actual1 = Functions.Union(context, new object[] { JObject.Parse("{ \"a\": \"b\", \"c\": \"d\" }"), JObject.Parse("{ \"e\": \"f\", \"g\": \"h\" }"), JObject.Parse("{ \"i\": \"j\" }"), JObject.Parse("{ \"a\": \"100\" }") }) as JObject;
             Assert.True(actual1.ContainsKey("a"));
             Assert.Equal("b", actual1["a"]);
             Assert.True(actual1.ContainsKey("e"));
             Assert.Equal("f", actual1["e"]);
             Assert.True(actual1.ContainsKey("i"));
             Assert.Equal("j", actual1["i"]);
+            actual1 = Functions.Union(context, new object[] { new Hashtable(), JObject.Parse("{ \"e\": \"f\", \"g\": \"h\" }"), JObject.Parse("{ \"i\": \"j\" }"), JObject.Parse("{ \"i\": \"j\" }"), JObject.Parse("{ \"a\": \"100\" }") }) as JObject;
+            Assert.True(actual1.ContainsKey("a"));
+            Assert.Equal("100", actual1["a"]);
+            Assert.True(actual1.ContainsKey("e"));
+            Assert.Equal("f", actual1["e"]);
+            actual1 = Functions.Union(context, new object[] { hashtable, JObject.Parse("{ \"e\": \"f\", \"g\": \"h\" }") }) as JObject;
+            Assert.True(actual1.ContainsKey("a"));
+            Assert.Equal(200, actual1["a"]);
+            Assert.True(actual1.ContainsKey("e"));
+            Assert.Equal("f", actual1["e"]);
 
             // Union arrays
             var actual2 = Functions.Union(context, new string[][] { new string[] { "one", "two", "three" }, new string[] { "three", "four" } }) as object[];


### PR DESCRIPTION
## PR Summary

 - Fixed union returns null when merged with built-in expansion objects.
 
Fixes #1515 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
