### PR TITLE
Fixed Azure.SQL.TDE for IaC #1530

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -36,6 +36,9 @@ What's changed since pre-release v1.18.0-B0010:
     [#1440](https://github.com/Azure/PSRule.Rules.Azure/issues/1440)
   - Added support for `join` ARM function by @BernieWhite.
     [#1535](https://github.com/Azure/PSRule.Rules.Azure/issues/1535)
+- Bug fixes:
+  - Fixed `Azure.SQL.TDE` is not required to enable Transparent Data Encryption for IaC by @BernieWhite.
+    [#1530](https://github.com/Azure/PSRule.Rules.Azure/issues/1530)
 
 ## v1.18.0-B0010 (pre-release)
 

--- a/src/PSRule.Rules.Azure/Data/Template/RuleDataExportVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/RuleDataExportVisitor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json.Linq;
 
 namespace PSRule.Rules.Azure.Data.Template
@@ -46,10 +47,14 @@ namespace PSRule.Rules.Azure.Data.Template
         }
 
         /// <summary>
-        /// Move sub-resources based on parent resource relationship. This process nests sub-resources so that relationship can be analyzed.
+        /// Move sub-resources based on parent resource relationship.
+        /// This process nests sub-resources so that relationship can be analyzed.
         /// </summary>
         private static void MoveResource(TemplateContext context, IResourceValue resource)
         {
+            if (!ShouldMove(resource.Type))
+                return;
+
             if (resource.Value.TryGetDependencies(out _) || resource.Type.Split('/').Length > 2)
             {
                 resource.Value.Remove(PROPERTY_DEPENDSON);
@@ -66,6 +71,14 @@ namespace PSRule.Rules.Azure.Data.Template
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Determines if the specific sub-resource type should be nested.
+        /// </summary>
+        private static bool ShouldMove(string resourceType)
+        {
+            return !string.Equals(resourceType, "Microsoft.Sql/servers/databases", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.SQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.SQL.Rule.ps1
@@ -88,9 +88,15 @@ Rule 'Azure.SQL.ServerName' -Ref 'AZR-000190' -Type 'Microsoft.Sql/servers' -Tag
 #region SQL Database
 
 # Synopsis: Enable transparent data encryption
-Rule 'Azure.SQL.TDE' -Ref 'AZR-000191' -Type 'Microsoft.Sql/servers/databases' -If { !(IsMasterDatabase) } -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $configs = @(GetSubResources -ResourceType 'Microsoft.Sql/servers/databases/transparentDataEncryption');
+Rule 'Azure.SQL.TDE' -Ref 'AZR-000191' -Type 'Microsoft.Sql/servers/databases', 'Microsoft.Sql/servers/databases/transparentDataEncryption' -If { !(IsMasterDatabase) } -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
+    $configs = @($TargetObject);
+    if ($PSRule.TargetType -eq 'Microsoft.Sql/servers/databases') {
+        $configs = @(GetSubResources -ResourceType 'Microsoft.Sql/servers/databases/transparentDataEncryption');
+    }
     if ($configs.Length -eq 0) {
+        if (!(IsExport)) {
+            return $Assert.Pass();
+        }
         return $Assert.Fail($LocalizedData.SubResourceNotFound, 'Microsoft.Sql/servers/databases/transparentDataEncryption');
     }
     foreach ($config in $configs) {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.SQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.SQL.Tests.ps1
@@ -23,7 +23,7 @@ BeforeAll {
     $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-Describe 'Azure.SQL' -Tag 'SQL' {
+Describe 'Azure.SQL' -Tag 'SQL', 'SQLDB' {
     Context 'Conditions' {
         BeforeAll {
             $invokeParams = @{
@@ -332,6 +332,39 @@ Describe 'Azure.SQL' -Tag 'SQL' {
             $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.SQL.FGName';
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Outcome | Should -Be 'Fail';
+        }
+    }
+
+    Context 'With Template' {
+        BeforeAll {
+            $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.SQL.json;
+            Export-AzRuleTemplateData -TemplateFile (Join-Path -Path $here -ChildPath 'sql.tests.json') -OutputPath $outputFile;
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+            $result = Invoke-PSRule @invokeParams -InputPath $outputFile -Outcome All;
+        }
+
+        It 'Azure.SQL.TDE' {
+            $filteredResult = $result | Where-Object {
+                $_.RuleName -eq 'Azure.SQL.TDE' -and
+                ($_.TargetType -eq 'Microsoft.Sql/servers/databases' -or $_.TargetType -eq 'Microsoft.Sql/servers/databases/transparentDataEncryption')
+            };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'sql-sql-01/sqldb-sql-02', 'sql-sql-01/sqldb-sql-03', 'server01/db01/current', 'server01/db02/current';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'sql-sql-01/sqldb-sql-01';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/cognitive.tests.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/cognitive.tests.bicep
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-@description('The name of the cognitive services account.')
+@description('The name of the resource.')
 param name string = 'cognitive'
 
 @description('The location resources will be deployed.')

--- a/tests/PSRule.Rules.Azure.Tests/sql.tests.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/sql.tests.bicep
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+@description('The name of the resource.')
+param name string = 'sql'
+
+@description('The location resources will be deployed.')
+param location string = resourceGroup().location
+
+resource server01 'Microsoft.Sql/servers@2021-11-01-preview' = {
+  name: 'sql-${name}-01'
+  location: location
+}
+
+resource database01 'Microsoft.Sql/servers/databases@2021-11-01-preview' = {
+  parent: server01
+  name: 'sqldb-${name}-01'
+  location: location
+}
+
+resource database02 'Microsoft.Sql/servers/databases@2021-11-01-preview' = {
+  parent: server01
+  name: 'sqldb-${name}-02'
+  location: location
+
+  resource tde 'transparentDataEncryption@2021-11-01-preview' = {
+    name: 'current'
+    properties: {
+      state: 'Disabled'
+    }
+  }
+}
+
+resource database03 'Microsoft.Sql/servers/databases@2021-11-01-preview' = {
+  parent: server01
+  name: 'sqldb-${name}-03'
+  location: location
+}
+
+resource tde 'Microsoft.Sql/servers/databases/transparentDataEncryption@2021-11-01-preview' = {
+  parent: database03
+  name: 'current'
+  properties: {
+    state: 'Disabled'
+  }
+}
+
+resource tde2 'Microsoft.Sql/servers/databases/transparentDataEncryption@2021-11-01-preview' = {
+  name: 'server01/db01/current'
+  properties: {
+    state: 'Disabled'
+  }
+}
+
+resource tde3 'Microsoft.Sql/servers/databases/transparentDataEncryption@2014-04-01' = {
+  name: 'server01/db02/current'
+  properties: {
+    status: 'Disabled'
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/sql.tests.json
+++ b/tests/PSRule.Rules.Azure.Tests/sql.tests.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.8.9.13224",
+      "templateHash": "4205854155642746064"
+    }
+  },
+  "parameters": {
+    "name": {
+      "type": "string",
+      "defaultValue": "sql",
+      "metadata": {
+        "description": "The name of the resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location resources will be deployed."
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
+      "apiVersion": "2021-11-01-preview",
+      "name": "[format('{0}/{1}/{2}', format('sql-{0}-01', parameters('name')), format('sqldb-{0}-02', parameters('name')), 'current')]",
+      "properties": {
+        "state": "Disabled"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Sql/servers/databases', format('sql-{0}-01', parameters('name')), format('sqldb-{0}-02', parameters('name')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2021-11-01-preview",
+      "name": "[format('sql-{0}-01', parameters('name'))]",
+      "location": "[parameters('location')]"
+    },
+    {
+      "type": "Microsoft.Sql/servers/databases",
+      "apiVersion": "2021-11-01-preview",
+      "name": "[format('{0}/{1}', format('sql-{0}-01', parameters('name')), format('sqldb-{0}-01', parameters('name')))]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Sql/servers', format('sql-{0}-01', parameters('name')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Sql/servers/databases",
+      "apiVersion": "2021-11-01-preview",
+      "name": "[format('{0}/{1}', format('sql-{0}-01', parameters('name')), format('sqldb-{0}-02', parameters('name')))]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Sql/servers', format('sql-{0}-01', parameters('name')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Sql/servers/databases",
+      "apiVersion": "2021-11-01-preview",
+      "name": "[format('{0}/{1}', format('sql-{0}-01', parameters('name')), format('sqldb-{0}-03', parameters('name')))]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Sql/servers', format('sql-{0}-01', parameters('name')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
+      "apiVersion": "2021-11-01-preview",
+      "name": "[format('{0}/{1}/{2}', format('sql-{0}-01', parameters('name')), format('sqldb-{0}-03', parameters('name')), 'current')]",
+      "properties": {
+        "state": "Disabled"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Sql/servers/databases', format('sql-{0}-01', parameters('name')), format('sqldb-{0}-03', parameters('name')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
+      "apiVersion": "2021-11-01-preview",
+      "name": "server01/db01/current",
+      "properties": {
+        "state": "Disabled"
+      }
+    },
+    {
+      "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
+      "apiVersion": "2014-04-01",
+      "name": "server01/db02/current",
+      "properties": {
+        "status": "Disabled"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.SQL.TDE` is not required to enable Transparent Data Encryption for IaC.

Fixes #1530 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
