### PR TITLE
Pre-release v1.19.0-B0010

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -19,6 +19,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.19.0-B0010 (pre-release)
+
 What's changed since v1.18.1:
 
 - General improvements:


### PR DESCRIPTION
## PR Summary

What's changed since v1.18.1:

- General improvements:
  - Updated rule level for the following rules by @BernieWhite:
    [#1551](https://github.com/Azure/PSRule.Rules.Azure/issues/1551)
    - Set `Azure.APIM.APIDescriptors` to warning from error.
    - Set `Azure.APIM.ProductDescriptors` to warning from error.
    - Set `Azure.Template.UseLocationParameter` to warning from error.
    - Set `Azure.Template.UseComments` to information from error.
    - Set `Azure.Template.UseDescriptions` to information from error.
- Engineering:
  - Added publishing of symbols for NuGet packages by @BernieWhite.
    [#1549](https://github.com/Azure/PSRule.Rules.Azure/issues/1549)
  - Bump PSRule to v2.3.1.
    [#1561](https://github.com/Azure/PSRule.Rules.Azure/pull/1561)
  - Bump Az.Resources to v6.1.0.
    [#1557](https://github.com/Azure/PSRule.Rules.Azure/pull/1557)
  - Bump Microsoft.NET.Test.Sdk to v17.3.0.
    [#1563](https://github.com/Azure/PSRule.Rules.Azure/pull/1563)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
