### PR TITLE
Bump support projects to .NET 6 #1560

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
+insert_final_newline = true
 
 # Source code
 [*.{cs,ps1,psd1,psm1}]
@@ -45,3 +46,26 @@ csharp_prefer_simple_default_expression = true:suggestion
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = true:suggestion
+
+# Define the 'private_fields' symbol group:
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+# Define the 'private_static_fields' symbol group
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+
+# Define the 'underscored' naming style
+dotnet_naming_style.underscored.capitalization = pascal_case
+dotnet_naming_style.underscored.required_prefix = _
+
+# Private instance fields must use pascal case with a leading '_'
+dotnet_naming_rule.private_fields_underscored.symbols = private_fields
+dotnet_naming_rule.private_fields_underscored.style = underscored
+dotnet_naming_rule.private_fields_underscored.severity = error
+
+# Exclude private static fields from underscored style
+dotnet_naming_rule.private_static_fields_none.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_none.style = underscored
+dotnet_naming_rule.private_static_fields_none.severity = none

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,10 @@
         "editor.formatOnSave": true,
         "editor.tabSize": 2
     },
+    "[jsonc]": {
+        "editor.formatOnSave": true,
+        "editor.tabSize": 2
+    },
     "[markdown]": {
         "editor.tabSize": 2
     },

--- a/.vscode/yaml.code-snippets
+++ b/.vscode/yaml.code-snippets
@@ -9,6 +9,7 @@
             "kind: Rule",
             "metadata:",
             "  name: ${1}",
+            "  ref: AZR-000nnn",
             "  tags:",
             "    release: 'GA'",
             "    ruleSet: '${3}'",

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -31,6 +31,8 @@ What's changed since pre-release v1.19.0-B0010:
 - Engineering:
   - Bump PSRule to v2.3.2.
     [#1574](https://github.com/Azure/PSRule.Rules.Azure/pull/1574)
+  - Bump support projects to .NET 6 by @BernieWhite.
+    [#1560](https://github.com/Azure/PSRule.Rules.Azure/issues/1560)
 
 ## v1.19.0-B0010 (pre-release)
 

--- a/docs/install-instructions.md
+++ b/docs/install-instructions.md
@@ -219,9 +219,9 @@ The following dependencies will be automatically installed if the required versi
 
 These dependencies are only required for building and running tests for PSRule for Azure.
 
-Additionally .NET Core SDK v3.1 is required.
-.NET Core will not be automatically downloaded and installed.
-To download and install the latest SDK see [Download .NET Core 3.1][dotnet].
+Additionally .NET SDK v6 is required.
+.NET will not be automatically downloaded and installed.
+To download and install the latest SDK see [Download .NET 6][dotnet].
 
 ### Limited access networks
 
@@ -256,4 +256,4 @@ After downloading the modules, copy the module directories to devices with restr
 *[CI]: continuous integration
 
 [module]: https://www.powershellgallery.com/packages/PSRule.Rules.Azure
-[dotnet]: https://dotnet.microsoft.com/download/dotnet-core/3.1
+[dotnet]: https://dotnet.microsoft.com/download/dotnet/6.0

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -442,7 +442,7 @@ task ScaffoldHelp Build, BuildRuleDocs, {
 
 task Benchmark {
     if ($Benchmark -or $BuildTask -eq 'Benchmark') {
-        dotnet run --project src/PSRule.Rules.Azure.Benchmark -f netcoreapp3.1 -c Release -- benchmark --output $PWD;
+        dotnet run --project src/PSRule.Rules.Azure.Benchmark -f net6.0 -c Release -- benchmark --output $PWD;
     }
 }
 

--- a/src/PSRule.Rules.Azure.Benchmark/PSRule.Rules.Azure.Benchmark.csproj
+++ b/src/PSRule.Rules.Azure.Benchmark/PSRule.Rules.Azure.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ProjectGuid>{9bb90abe-25f9-4110-af9f-149b0618b2a0}</ProjectGuid>
     <RepositoryUrl>https://github.com/Azure/PSRule.Rules.Azure</RepositoryUrl>
@@ -31,8 +31,8 @@
     <PackageReference Include="Microsoft.PowerShell.5.1.ReferenceAssemblies" Version="1.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.6" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PSRule.Rules.Azure.BuildTool/PSRule.Rules.Azure.BuildTool.csproj
+++ b/src/PSRule.Rules.Azure.BuildTool/PSRule.Rules.Azure.BuildTool.csproj
@@ -2,15 +2,11 @@
   <Import Project="..\PSRule.Common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ProjectGuid>{218b2d45-a2bd-4966-9b9f-4064cd68ba8a}</ProjectGuid>
     <EnableNuget>false</EnableNuget>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/PSRule.Rules.Azure/.editorconfig
+++ b/src/PSRule.Rules.Azure/.editorconfig
@@ -1,5 +1,0 @@
-﻿[*.cs]
-
-# Suppressed, issue with Azure DevOps build on MacOS, not supported
-# IDE0034: Simplify 'default' expression
-csharp_prefer_simple_default_expression = true:silent

--- a/src/PSRule.Rules.Azure/Configuration/ConfigurationOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/ConfigurationOption.cs
@@ -45,6 +45,7 @@ namespace PSRule.Rules.Azure.Configuration
             Deployment = option.Deployment;
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return obj is ConfigurationOption option && Equals(option);
@@ -61,6 +62,7 @@ namespace PSRule.Rules.Azure.Configuration
                 Deployment == other.Deployment;
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked // Overflow is fine

--- a/src/PSRule.Rules.Azure/Configuration/DeploymentOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/DeploymentOption.cs
@@ -7,6 +7,9 @@ using System.ComponentModel;
 
 namespace PSRule.Rules.Azure.Configuration
 {
+    /// <summary>
+    /// Options that affect the properties of the <c>deployment()</c> object during expansion.
+    /// </summary>
     public sealed class DeploymentOption : IEquatable<DeploymentOption>
     {
         private const string DEFAULT_NAME = "ps-rule-test-deployment";
@@ -18,6 +21,9 @@ namespace PSRule.Rules.Azure.Configuration
 
         private string _Name;
 
+        /// <summary>
+        /// Creates an empty deployment option.
+        /// </summary>
         public DeploymentOption()
         {
             Name = null;
@@ -36,6 +42,7 @@ namespace PSRule.Rules.Azure.Configuration
             Name = name ?? DEFAULT_NAME;
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return obj is DeploymentOption option && Equals(option);
@@ -63,6 +70,7 @@ namespace PSRule.Rules.Azure.Configuration
                 (!object.Equals(null, o1) && o1.Equals(o2));
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked // Overflow is fine
@@ -82,6 +90,9 @@ namespace PSRule.Rules.Azure.Configuration
             return result;
         }
 
+        /// <summary>
+        /// The name of the deployment.
+        /// </summary>
         [DefaultValue(null)]
         public string Name
         {
@@ -103,6 +114,9 @@ namespace PSRule.Rules.Azure.Configuration
             FromName = true;
         }
 
+        /// <summary>
+        /// The name of the deployment.
+        /// </summary>
         public string Name { get; set; }
 
         public bool FromName { get; private set; }

--- a/src/PSRule.Rules.Azure/Configuration/ManagementGroupOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/ManagementGroupOption.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -7,6 +7,9 @@ using YamlDotNet.Serialization;
 
 namespace PSRule.Rules.Azure.Configuration
 {
+    /// <summary>
+    /// Options that affect the properties of the <c>managementGroup()</c> object during expansion.
+    /// </summary>
     public sealed class ManagementGroupOption : IEquatable<ManagementGroupOption>
     {
         private const string DEFAULT_NAME = "psrule-test";
@@ -27,6 +30,9 @@ namespace PSRule.Rules.Azure.Configuration
 
         private string _Name;
 
+        /// <summary>
+        /// Creates an empty management group option.
+        /// </summary>
         public ManagementGroupOption()
         {
             Name = null;
@@ -64,12 +70,21 @@ namespace PSRule.Rules.Azure.Configuration
                 Details = new ManagementGroupDetails();
             }
 
+            /// <summary>
+            /// The display name of the management group.
+            /// </summary>
             [DefaultValue(null)]
             public string DisplayName { get; set; }
 
+            /// <summary>
+            /// A GUID for the tenant that the management group belongs to.
+            /// </summary>
             [YamlIgnore]
             public string TenantId { get; internal set; }
 
+            /// <summary>
+            /// Additional details of the management group.
+            /// </summary>
             public ManagementGroupDetails Details { get; internal set; }
         }
 
@@ -83,15 +98,27 @@ namespace PSRule.Rules.Azure.Configuration
                 Version = DEFAULT_VERSION;
             }
 
+            /// <summary>
+            /// Additional details about the parent of the management group.
+            /// </summary>
             [YamlIgnore]
             public ManagementGroupParent Parent { get; private set; }
 
+            /// <summary>
+            /// What identity last updated the management group.
+            /// </summary>
             [DefaultValue(null)]
             public string UpdatedBy { get; set; }
 
+            /// <summary>
+            /// When the management group was last updated.
+            /// </summary>
             [DefaultValue(null)]
             public string UpdatedTime { get; set; }
 
+            /// <summary>
+            /// The version.
+            /// </summary>
             [DefaultValue(null)]
             public string Version { get; set; }
         }
@@ -112,9 +139,15 @@ namespace PSRule.Rules.Azure.Configuration
                 DisplayName = displayName ?? DEFAULT_PARENT_DISPLAYNAME;
             }
 
+            /// <summary>
+            /// The resource identifier for the parent.
+            /// </summary>
             [YamlIgnore]
             public string Id { get; private set; }
 
+            /// <summary>
+            /// The name of the parent.
+            /// </summary>
             [DefaultValue(null)]
             public string Name
             {
@@ -126,10 +159,14 @@ namespace PSRule.Rules.Azure.Configuration
                 }
             }
 
+            /// <summary>
+            /// The display name of the parent.
+            /// </summary>
             [DefaultValue(null)]
             public string DisplayName { get; set; }
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return obj is ManagementGroupOption option && Equals(option);
@@ -158,6 +195,7 @@ namespace PSRule.Rules.Azure.Configuration
                 (!object.Equals(null, o1) && o1.Equals(o2));
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked // Overflow is fine
@@ -179,6 +217,9 @@ namespace PSRule.Rules.Azure.Configuration
             return result;
         }
 
+        /// <summary>
+        /// The Azure resource type.
+        /// </summary>
         [YamlIgnore]
         public string Type => DEFAULT_TYPE;
 
@@ -205,6 +246,9 @@ namespace PSRule.Rules.Azure.Configuration
             }
         }
 
+        /// <summary>
+        /// Additional properties of the management group.
+        /// </summary>
         public ManagementGroupProperties Properties { get; set; }
     }
 }

--- a/src/PSRule.Rules.Azure/Configuration/OutputEncoding.cs
+++ b/src/PSRule.Rules.Azure/Configuration/OutputEncoding.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using Newtonsoft.Json;
@@ -6,19 +6,40 @@ using Newtonsoft.Json.Converters;
 
 namespace PSRule.Rules.Azure.Configuration
 {
+    /// <summary>
+    /// The encoding format to convert output to.
+    /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
     public enum OutputEncoding
     {
+        /// <summary>
+        /// UTF-8 with Byte Order Mark (BOM). This is the default.
+        /// </summary>
         Default = 0,
 
+        /// <summary>
+        /// UTF-8 without Byte Order Mark (BOM).
+        /// </summary>
         UTF8 = 1,
 
+        /// <summary>
+        /// UTF-7.
+        /// </summary>
         UTF7 = 2,
 
+        /// <summary>
+        /// Unicode. Same as UTF-16.
+        /// </summary>
         Unicode = 3,
 
+        /// <summary>
+        /// UTF-32.
+        /// </summary>
         UTF32 = 4,
 
+        /// <summary>
+        /// ASCII.
+        /// </summary>
         ASCII = 5
     }
 }

--- a/src/PSRule.Rules.Azure/Configuration/OutputOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/OutputOption.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -33,6 +33,7 @@ namespace PSRule.Rules.Azure.Configuration
             Path = option.Path;
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return obj is OutputOption option && Equals(option);
@@ -45,6 +46,7 @@ namespace PSRule.Rules.Azure.Configuration
                 Path == other.Path;
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked // Overflow is fine

--- a/src/PSRule.Rules.Azure/Configuration/ParameterDefaultsOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/ParameterDefaultsOption.cs
@@ -27,6 +27,7 @@ namespace PSRule.Rules.Azure.Configuration
             _Defaults = new Dictionary<string, object>(option._Defaults, StringComparer.OrdinalIgnoreCase);
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return obj is ParameterDefaultsOption option && Equals(option);
@@ -67,6 +68,7 @@ namespace PSRule.Rules.Azure.Configuration
                 (!object.Equals(null, o1) && o1.Equals(o2));
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked // Overflow is fine

--- a/src/PSRule.Rules.Azure/Configuration/ResourceGroupOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/ResourceGroupOption.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,9 @@ using YamlDotNet.Serialization;
 
 namespace PSRule.Rules.Azure.Configuration
 {
+    /// <summary>
+    /// Options that affect the properties of the <c>resourceGroup()</c> object during expansion.
+    /// </summary>
     public sealed class ResourceGroupOption : IEquatable<ResourceGroupOption>
     {
         private const string DEFAULT_SUBSCRIPTIONID = "ffffffff-ffff-ffff-ffff-ffffffffffff";
@@ -34,6 +37,9 @@ namespace PSRule.Rules.Azure.Configuration
         private string _SubscriptionId;
         private string _Name;
 
+        /// <summary>
+        /// Creates an empty resource group option.
+        /// </summary>
         public ResourceGroupOption()
         {
             Name = null;
@@ -64,10 +70,11 @@ namespace PSRule.Rules.Azure.Configuration
             Properties = new ResourceGroupProperties(provisioningState);
         }
 
+        /// <summary>
+        /// A set of resource group properties.
+        /// </summary>
         public sealed class ResourceGroupProperties
         {
-            public readonly string ProvisioningState;
-
             public ResourceGroupProperties()
             {
                 ProvisioningState = DEFAULT_PROVISIONINGSTATE;
@@ -77,8 +84,14 @@ namespace PSRule.Rules.Azure.Configuration
             {
                 ProvisioningState = provisioningState ?? DEFAULT_PROVISIONINGSTATE;
             }
+
+            /// <summary>
+            /// The provisioning state of the resource group.
+            /// </summary>
+            public string ProvisioningState { get; }
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return obj is ResourceGroupOption option && Equals(option);
@@ -111,6 +124,7 @@ namespace PSRule.Rules.Azure.Configuration
                 (!object.Equals(null, o1) && o1.Equals(o2));
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked // Overflow is fine
@@ -180,18 +194,33 @@ namespace PSRule.Rules.Azure.Configuration
             }
         }
 
+        /// <summary>
+        /// The Azure resource type.
+        /// </summary>
         [YamlIgnore]
         public string Type => DEFAULT_TYPE;
 
+        /// <summary>
+        /// The location of the resource group.
+        /// </summary>
         [DefaultValue(null)]
         public string Location { get; set; }
 
+        /// <summary>
+        /// The value of the managed by property.
+        /// </summary>
         [DefaultValue(null)]
         public string ManagedBy { get; set; }
 
+        /// <summary>
+        /// Any tags assigned to the resource group.
+        /// </summary>
         [DefaultValue(null)]
         public Hashtable Tags { get; set; }
 
+        /// <summary>
+        /// Additional properties for the resource group.
+        /// </summary>
         [DefaultValue(null)]
         public ResourceGroupProperties Properties { get; set; }
     }

--- a/src/PSRule.Rules.Azure/Configuration/SubscriptionOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/SubscriptionOption.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,9 @@ using YamlDotNet.Serialization;
 
 namespace PSRule.Rules.Azure.Configuration
 {
+    /// <summary>
+    /// Options that affect the properties of the <c>subscription()</c> object during expansion.
+    /// </summary>
     public sealed class SubscriptionOption : IEquatable<SubscriptionOption>
     {
         private const string DEFAULT_SUBSCRIPTIONID = "ffffffff-ffff-ffff-ffff-ffffffffffff";
@@ -27,6 +30,9 @@ namespace PSRule.Rules.Azure.Configuration
 
         private string _SubscriptionId;
 
+        /// <summary>
+        /// Creates an empty subscription option.
+        /// </summary>
         public SubscriptionOption()
         {
             SubscriptionId = null;
@@ -54,6 +60,7 @@ namespace PSRule.Rules.Azure.Configuration
             State = state ?? DEFAULT_STATE;
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return obj is SubscriptionOption option && Equals(option);
@@ -84,6 +91,7 @@ namespace PSRule.Rules.Azure.Configuration
                 (!object.Equals(null, o1) && o1.Equals(o2));
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked // Overflow is fine
@@ -132,12 +140,21 @@ namespace PSRule.Rules.Azure.Configuration
             }
         }
 
+        /// <summary>
+        /// A GUID identifier for the tenant.
+        /// </summary>
         [DefaultValue(null)]
         public string TenantId { get; set; }
 
+        /// <summary>
+        /// The display name of the tenant.
+        /// </summary>
         [DefaultValue(null)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// The current state of the tenant.
+        /// </summary>
         [DefaultValue(null)]
         public string State { get; set; }
     }

--- a/src/PSRule.Rules.Azure/Configuration/TenantOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/TenantOption.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -7,6 +7,9 @@ using YamlDotNet.Serialization;
 
 namespace PSRule.Rules.Azure.Configuration
 {
+    /// <summary>
+    /// Options that affect the properties of the <c>tenant()</c> object during expansion.
+    /// </summary>
     public sealed class TenantOption : IEquatable<TenantOption>
     {
         private const string DEFAULT_COUNTRYCODE = "US";
@@ -24,6 +27,9 @@ namespace PSRule.Rules.Azure.Configuration
 
         private string _TenantId;
 
+        /// <summary>
+        /// Creates an empty tenant option.
+        /// </summary>
         public TenantOption()
         {
             CountryCode = null;
@@ -48,6 +54,7 @@ namespace PSRule.Rules.Azure.Configuration
             DisplayName = displayName ?? DEFAULT_DISPLAYNAME;
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return obj is TenantOption option && Equals(option);
@@ -77,6 +84,7 @@ namespace PSRule.Rules.Azure.Configuration
                 (!object.Equals(null, o1) && o1.Equals(o2));
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked // Overflow is fine
@@ -100,6 +108,9 @@ namespace PSRule.Rules.Azure.Configuration
             return result;
         }
 
+        /// <summary>
+        /// A country code identifier for the tenant.
+        /// </summary>
         [DefaultValue(null)]
         public string CountryCode { get; set; }
 
@@ -126,6 +137,9 @@ namespace PSRule.Rules.Azure.Configuration
             }
         }
 
+        /// <summary>
+        /// The display name of the tenant.
+        /// </summary>
         [DefaultValue(null)]
         public string DisplayName { get; set; }
     }

--- a/src/PSRule.Rules.Azure/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PipelineBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -15,44 +15,96 @@ namespace PSRule.Rules.Azure.Pipeline
     /// </summary>
     public static class PipelineBuilder
     {
+        /// <summary>
+        /// Create a builder for a template expanding pipeline.
+        /// </summary>
+        /// <param name="option">Options that configure PSRule for Azure.</param>
+        /// <returns>A builder object to configure the pipeline.</returns>
         public static ITemplatePipelineBuilder Template(PSRuleOption option)
         {
             return new TemplatePipelineBuilder(option);
         }
 
+        /// <summary>
+        /// Create a builder for a template link discovery pipeline.
+        /// </summary>
+        /// <param name="path">The base path to search from.</param>
+        /// <returns>A builder object to configure the pipeline.</returns>
         public static ITemplateLinkPipelineBuilder TemplateLink(string path)
         {
             return new TemplateLinkPipelineBuilder(path);
         }
 
+        /// <summary>
+        /// Create a builder for a policy assignment export pipeline.
+        /// </summary>
+        /// <param name="option">Options that configure PSRule for Azure.</param>
+        /// <returns>A builder object to configure the pipeline.</returns>
         public static IPolicyAssignmentPipelineBuilder Assignment(PSRuleOption option)
         {
             return new PolicyAssignmentPipelineBuilder(option);
         }
 
+        /// <summary>
+        /// Create a builder for a policy to rule generation pipeline.
+        /// </summary>
+        /// <param name="path">The base path to search from.</param>
+        /// <returns>A builder object to configure the pipeline.</returns>
         public static IPolicyAssignmentSearchPipelineBuilder AssignmentSearch(string path)
         {
             return new PolicyAssignmentSearchPipelineBuilder(path);
         }
     }
 
+    /// <summary>
+    /// A helper to build a PSRule for Azure pipeline.
+    /// </summary>
     public interface IPipelineBuilder
     {
+        /// <summary>
+        /// Configure the pipeline with cmdlet runtime information.
+        /// </summary>
         void UseCommandRuntime(PSCmdlet commandRuntime);
 
+        /// <summary>
+        /// Configure the pipeline with a PowerShell execution context.
+        /// </summary>
         void UseExecutionContext(EngineIntrinsics executionContext);
 
+        /// <summary>
+        /// Configure the pipeline with options.
+        /// </summary>
+        /// <param name="option">Options that configure PSRule for Azure.</param>
+        /// <returns></returns>
         IPipelineBuilder Configure(PSRuleOption option);
 
+        /// <summary>
+        /// Build the pipeline.
+        /// </summary>
+        /// <returns>An instance of a configured pipeline.</returns>
         IPipeline Build();
     }
 
+    /// <summary>
+    /// An instance of a PSRule for Azure pipeline.
+    /// </summary>
     public interface IPipeline
     {
+        /// <summary>
+        /// Initalize the pipeline and results. Call this method once prior to calling Process.
+        /// </summary>
         void Begin();
 
+        /// <summary>
+        /// Process an object through the pipeline.
+        /// </summary>
+        /// <param name="sourceObject">The object to process.</param>
         void Process(PSObject sourceObject);
 
+        /// <summary>
+        /// Clean up and flush pipeline results. Call this method once after processing any objects through the pipeline.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1716:Identifiers should not match keywords", Justification = "Matches PowerShell pipeline.")]
         void End();
     }
 
@@ -119,7 +171,7 @@ namespace PSRule.Rules.Azure.Pipeline
         protected readonly PipelineContext Context;
 
         // Track whether Dispose has been called.
-        private bool _Disposed = false;
+        private bool _Disposed;
 
 
         protected PipelineBase(PipelineContext context)
@@ -129,16 +181,19 @@ namespace PSRule.Rules.Azure.Pipeline
 
         #region IPipeline
 
+        /// <inheritdoc/>
         public virtual void Begin()
         {
-            //Reader.Open();
+            // Do nothing
         }
 
+        /// <inheritdoc/>
         public virtual void Process(PSObject sourceObject)
         {
             // Do nothing
         }
 
+        /// <inheritdoc/>
         public virtual void End()
         {
             Context.Writer.End();

--- a/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentPipeline.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentPipeline.cs
@@ -16,6 +16,7 @@ namespace PSRule.Rules.Azure.Pipeline
             _PolicyAssignmentHelper = new PolicyAssignmentHelper(context);
         }
 
+        /// <inheritdoc/>
         public override void Process(PSObject sourceObject)
         {
             if (sourceObject == null || !(sourceObject.BaseObject is PolicyAssignmentSource source))

--- a/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentPipelineBuilder.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentPipelineBuilder.cs
@@ -8,8 +8,15 @@ using PSRule.Rules.Azure.Pipeline.Output;
 
 namespace PSRule.Rules.Azure.Pipeline
 {
+    /// <summary>
+    /// A builder for a policy assignment export pipeline.
+    /// </summary>
     public interface IPolicyAssignmentPipelineBuilder : IPipelineBuilder
     {
+        /// <summary>
+        /// Enable pass-through of output from the pipeline.
+        /// </summary>
+        /// <param name="passThru">Enable pass-through.</param>
         void PassThru(bool passThru);
     }
 
@@ -51,6 +58,7 @@ namespace PSRule.Rules.Azure.Pipeline
             Option.Configuration.Subscription = SubscriptionOption.Combine(subscription, Option.Configuration.Subscription);
         }
 
+        /// <inheritdoc/>
         public void PassThru(bool passThru)
         {
             _PassThru = passThru;
@@ -76,6 +84,7 @@ namespace PSRule.Rules.Azure.Pipeline
             return _PassThru ? base.PrepareWriter() : new JsonOutputWriter(GetOutput(), Option);
         }
 
+        /// <inheritdoc/>
         public override IPipeline Build()
         {
             return new PolicyAssignmentPipeline(PrepareContext());

--- a/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentSearchPipeline.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentSearchPipeline.cs
@@ -16,6 +16,7 @@ namespace PSRule.Rules.Azure.Pipeline
             _PathBuilder = new PathBuilder(context.Writer, basePath, DEFAULT_ASSIGNMENTSEARCH_PATTERN);
         }
 
+        /// <inheritdoc/>
         public override void Process(PSObject sourceObject)
         {
             if (sourceObject == null | !sourceObject.GetPath(out var path))

--- a/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentSearchPipelineBuilder.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentSearchPipelineBuilder.cs
@@ -3,6 +3,9 @@
 
 namespace PSRule.Rules.Azure.Pipeline
 {
+    /// <summary>
+    /// A builder for a policy to rule generation pipeline.
+    /// </summary>
     public interface IPolicyAssignmentSearchPipelineBuilder : IPipelineBuilder
     {
 
@@ -17,6 +20,7 @@ namespace PSRule.Rules.Azure.Pipeline
             _BasePath = basePath;
         }
 
+        /// <inheritdoc/>
         public override IPipeline Build()
         {
             return new PolicyAssignmentSearchPipeline(PrepareContext(), _BasePath);

--- a/src/PSRule.Rules.Azure/Pipeline/TemplateLinkPipeline.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/TemplateLinkPipeline.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -25,6 +25,7 @@ namespace PSRule.Rules.Azure.Pipeline
             _TemplateHelper = new TemplateLinkHelper(context, _BasePath, skipUnlinked);
         }
 
+        /// <inheritdoc/>
         public override void Process(PSObject sourceObject)
         {
             if (sourceObject == null || !sourceObject.GetPath(out var path))

--- a/src/PSRule.Rules.Azure/Pipeline/TemplatePipeline.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/TemplatePipeline.cs
@@ -16,6 +16,7 @@ namespace PSRule.Rules.Azure.Pipeline
             _TemplateHelper = new TemplateHelper(context);
         }
 
+        /// <inheritdoc/>
         public override void Process(PSObject sourceObject)
         {
             if (sourceObject == null || !(sourceObject.BaseObject is TemplateSource source))

--- a/src/SDK/SDK.csproj
+++ b/src/SDK/SDK.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\PSRule.Common.props" />
   <PropertyGroup>
     <PackageId>Microsoft.PSRule.Rules.Azure</PackageId>
-    <ProjectGuid>d4302b6a-19d3-4f6a-8ef7-448d2c3e393c</ProjectGuid>
+    <ProjectGuid>{d4302b6a-19d3-4f6a-8ef7-448d2c3e393c}</ProjectGuid>
     <EnableNuget>true</EnableNuget>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ProjectGuid>{28251f7f-fc8c-495b-af73-d134f642ffb9}</ProjectGuid>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.6" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.6" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## PR Summary

- Bump support projects to .NET 6.
- Additional linting settings added for c#.
- Additional comment documentation added to classes.

Fixes #1560 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
