### PR TITLE
Fixed parameter file name link with bicep #1582

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,14 +21,17 @@
     },
     "[json]": {
         "editor.formatOnSave": true,
-        "editor.tabSize": 2
+        "editor.tabSize": 2,
+        "files.insertFinalNewline": true
     },
     "[jsonc]": {
         "editor.formatOnSave": true,
-        "editor.tabSize": 2
+        "editor.tabSize": 2,
+        "files.insertFinalNewline": true
     },
     "[markdown]": {
-        "editor.tabSize": 2
+        "editor.tabSize": 2,
+        "files.insertFinalNewline": true
     },
     "[arm-template]": {
         "editor.tabSize": 4,
@@ -101,7 +104,7 @@
     ],
     "cSpell.enabledLanguageIds": [
         "csharp",
-        "git-commit", 
+        "git-commit",
         "markdown",
         "plaintext",
         "powershell",
@@ -109,7 +112,7 @@
         "yaml",
         "yml"
     ],
-    "[csharp]": { 
+    "[csharp]": {
         "editor.formatOnSave": true
     },
     "omnisharp.enableImportCompletion": true,

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -33,6 +33,9 @@ What's changed since pre-release v1.19.0-B0010:
     [#1574](https://github.com/Azure/PSRule.Rules.Azure/pull/1574)
   - Bump support projects to .NET 6 by @BernieWhite.
     [#1560](https://github.com/Azure/PSRule.Rules.Azure/issues/1560)
+- Bug fixes:
+  - Fixed parameter files linked to bicep code via naming convention is not working by @BernieWhite.
+    [#1582](https://github.com/Azure/PSRule.Rules.Azure/issues/1582)
 
 ## v1.19.0-B0010 (pre-release)
 

--- a/docs/expanding-source-files.md
+++ b/docs/expanding-source-files.md
@@ -7,7 +7,7 @@ author: BernieWhite
 PSRule for Azure supports analyzing resources contained within Azure Infrastructure as Code.
 
 !!! Abstract
-    This topic covers what source expansion is and how to use it within PSRule for Azure.
+    This topic covers what source expansion is, why it's important, and how to use it within PSRule for Azure.
 
 ## Source expansion
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -59,6 +59,30 @@ See [Bicep compilation timeout][1] for details on how to configure this option.
 
   [1]: setup/configuring-expansion.md#bicepcompilationtimeout
 
+## My parameter file reports property metadata is not allow warning
+
+You may find while editing a `.json` parameter file the root `metadata` property is flagged with a warning.
+
+```text
+The property 'metadata' is not allowed.
+```
+
+```json
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "template": "./storage.template.json"
+    },
+    "parameters": {
+    }
+}
+```
+
+This doesn't affect the workings of the parameter file or deployment.
+The reason is that the `metadata` property has not been added to the parameter file JSON schema as it exists in template files.
+However, the top level `metadata` property is ignored by Azure Resource Manager when deploying a template.
+
 ## Could not load file or assembly YamlDotNet
 
 PSRule **>=1.3.0** uses an updated version of the YamlDotNet library.

--- a/docs/using-bicep.md
+++ b/docs/using-bicep.md
@@ -14,7 +14,9 @@ To enable this feature, you need to:
 
 !!! Abstract
     This topic covers how you can validate Azure resources within `.bicep` files.
-    To learn more about why this is important see [Expanding source files](expanding-source-files.md).
+    To learn more about why this is important see [Expanding source files][8].
+
+  [8]: expanding-source-files.md
 
 ## Enabling expansion
 
@@ -28,7 +30,7 @@ configuration:
 
 !!! Note
     If you are using JSON parameter files exclusively, you do not need to set this option.
-    Instead continue reading [Using parameter files](#usingparameterfiles).
+    Instead continue reading [using parameter files](#usingparameterfiles).
 
 ### Setup Bicep
 
@@ -45,13 +47,16 @@ PSRule will automatically detect and build `.bicep` files.
 You may choose to pre-build `.bicep` files if the Bicep CLI is not available when PSRule is run.
 
 !!! Important
-    If using this method, follow [Using templates](using-templates.md) instead.
+    If using this method, follow [using templates](using-templates.md) instead.
     Using `bicep build` transpiles Bicep code into an Azure template `.json`.
 
 ## Testing Bicep modules
 
 Bicep allows you to separate out complex details into separate files called [modules][2].
 To expand resources, any parameters must be resolved.
+
+!!! Tip
+    If you are not familar with the concept of expansion within PSRule for Azure see [Expanding source files][8].
 
 Two types of parameters exist, _required_ (also called mandatory) and _optional_.
 An optional parameter is any parameter with a default value.
@@ -175,9 +180,9 @@ You may need to [configure credentials][4] to access the private registry from a
         AZURE_TENANT_ID: $(BICEPREGISTRYTENANTID)
     ```
 
-  !!! Important
-      Variables can be configured in YAML, on the pipeline, or referenced from a defined variable group.
-      To keep `BICEPREGISTRYCLIENTSECRET` secure, use a [variable group][6] linked to an Azure Key Vault.
+    !!! Important
+        Variables can be configured in YAML, on the pipeline, or referenced from a defined variable group.
+        To keep `BICEPREGISTRYCLIENTSECRET` secure, use a [variable group][6] linked to an Azure Key Vault.
 
   [3]: https://docs.microsoft.com/azure/azure-resource-manager/bicep/bicep-config#credential-precedence
   [4]: https://docs.microsoft.com/dotnet/api/azure.identity.environmentcredential

--- a/docs/using-templates.md
+++ b/docs/using-templates.md
@@ -35,6 +35,9 @@ PSRule for Azure automatically detects parameter files and uses the following lo
     Metadata links take priority over naming convention.
     For details on both options continue reading.
 
+!!! Tip
+    Linking templates also applies to Bicep modules when you are using `.json` parameter files.
+
 ### By metadata
 
 A parameter file can be linked to an associated template or Bicep module by setting metadata.
@@ -102,16 +105,35 @@ Additional benefits you get by using metadata links include:
     Bicep modules can also be expanded from parameter files.
     Instead of specifing a template path, you can specify the path to a Bicep file.
 
+!!! Note
+    You may find while editing a `.json` parameter file the root `metadata` property is flagged with a warning.
+    For example `Property metadata is not allowed.`.
+    This doesn't affect the workings of the parameter file or deployment.
+    If you like a detailed description continue reading [Troubleshooting][9].
+
   [2]: setup/configuring-expansion.md#requiretemplatemetadatalink
+  [9]: troubleshooting.md
 
 ### By naming convention
 
-When metadata links are not set, PSRule for Azure will use a naming convention to link to template files.
-PSRule for Azure uses the parameter file prefix `<templateName>.parameters.json` to link to a template.
-When linking using naming convention, the template and the parameter file must be in the same sub-directory.
+When metadata links are not set, PSRule will fallback to use a naming convention to link to template files.
 
 !!! Example
     A parameter file named `azuredeploy.parameters.json` links to the template file named `azuredeploy.json`.
+
+PSRule for Azure supports linking by naming convention when:
+
+- Parameter files end with `.parameters.json` linking to ARM templates or Bicep modules.
+- The parameter file prefix matches the file name of the template or Bicep module.
+  For example, `azuredeploy.parameters.json` links to `azuredeploy.json` or `azuredeploy.bicep`.
+- If both an ARM template and Bicep module exist, the template (`.json`) is preferred.
+  For example, `azuredeploy.parameters.json` chooses `azuredeploy.json` over `azuredeploy.bicep` if both exist.
+- Both parameter file and template or Bicep module must be in the same directory.
+
+The following is not currently supported:
+
+- Using a different naming convention for parameter files such as `<templateName>.param.json`.
+- Template or parameter files with alternative file extensions such as `.jsonc`.
 
 *[WAF]: Well-Architected Framework
 *[ARM]: Azure Resource Manager

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Template.Tests.ps1
@@ -592,7 +592,11 @@ Describe 'Azure.Template' -Tag 'Template' {
         }
 
         It 'Azure.Template.MetadataLink' {
-            $dataPath = Join-Path -Path $here -ChildPath '*.Parameters.json';
+            $dataPath = @(
+                (Join-Path -Path $here -ChildPath '*.Parameters.json')
+                (Join-Path -Path $here -ChildPath '*.parameters.json')
+                (Join-Path -Path $here -ChildPath '*.metalink.json')
+            );
             $options = @{
                 'Configuration.AZURE_PARAMETER_FILE_METADATA_LINK' = $True
             }
@@ -602,8 +606,12 @@ Describe 'Azure.Template' -Tag 'Template' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'tests/PSRule.Rules.Azure.Tests/Resources.ServiceFabric.Parameters.json';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn @(
+                'tests/PSRule.Rules.Azure.Tests/Tests.Bicep.1.Parameters.json'
+                'tests/PSRule.Rules.Azure.Tests/Tests.Bicep.2.Parameters.json'
+                'tests/PSRule.Rules.Azure.Tests/Resources.ServiceFabric.Parameters.json'
+            );
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -130,10 +130,16 @@
     <None Update="Tests.Bicep.1.bicep">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Tests.Bicep.1.Parameters.json">
+    <None Update="Tests.Bicep.1.metalink.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests.Bicep.1.parameters.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Tests.Bicep.2.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests.Bicep.2.parameters.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Tests.Bicep.3.json">

--- a/tests/PSRule.Rules.Azure.Tests/PathBuilderTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/PathBuilderTests.cs
@@ -28,7 +28,7 @@ namespace PSRule.Rules.Azure
 
             builder.Add(GetSourcePath("*Parameters*.json"));
             var actual3 = builder.Build();
-            Assert.Equal(10, actual3.Length);
+            Assert.Equal(11, actual3.Length);
             Assert.NotNull(actual3.SingleOrDefault(f => f.FullName == GetSourcePath("Resources.Parameters.json")));
             Assert.NotNull(actual3.SingleOrDefault(f => f.FullName == GetSourcePath("Resources.Parameters2.json")));
             Assert.NotNull(actual3.SingleOrDefault(f => f.FullName == GetSourcePath("Template.StrongType.1.Parameters.json")));
@@ -40,7 +40,7 @@ namespace PSRule.Rules.Azure
 
             builder.Add(GetSourcePath("*Parameters?.json"));
             var actual4 = builder.Build();
-            Assert.Equal(10, actual4.Length);
+            Assert.Equal(11, actual4.Length);
             Assert.NotNull(actual4.SingleOrDefault(f => f.FullName == GetSourcePath("Resources.Parameters.json")));
             Assert.NotNull(actual4.SingleOrDefault(f => f.FullName == GetSourcePath("Resources.Parameters2.json")));
             Assert.NotNull(actual4.SingleOrDefault(f => f.FullName == GetSourcePath("Template.StrongType.1.Parameters.json")));

--- a/tests/PSRule.Rules.Azure.Tests/PathBuilderTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/PathBuilderTests.cs
@@ -27,6 +27,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal(GetSourcePath("Resources.Parameters.json"), actual2[0].FullName);
 
             builder.Add(GetSourcePath("*Parameters*.json"));
+            builder.Add(GetSourcePath("*parameters*.json"));
             var actual3 = builder.Build();
             Assert.Equal(11, actual3.Length);
             Assert.NotNull(actual3.SingleOrDefault(f => f.FullName == GetSourcePath("Resources.Parameters.json")));
@@ -39,6 +40,7 @@ namespace PSRule.Rules.Azure
             Assert.NotNull(actual3.SingleOrDefault(f => f.FullName == GetSourcePath("Template.Parsing.10.Parameters.json")));
 
             builder.Add(GetSourcePath("*Parameters?.json"));
+            builder.Add(GetSourcePath("*parameters?.json"));
             var actual4 = builder.Build();
             Assert.Equal(11, actual4.Length);
             Assert.NotNull(actual4.SingleOrDefault(f => f.FullName == GetSourcePath("Resources.Parameters.json")));

--- a/tests/PSRule.Rules.Azure.Tests/TemplateLinkTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateLinkTests.cs
@@ -27,10 +27,30 @@ namespace PSRule.Rules.Azure
         public void GetBicepParameters()
         {
             var helper = new TemplateLinkHelper(GetContext(), AppDomain.CurrentDomain.BaseDirectory, true);
-            var link = helper.ProcessParameterFile(GetSourcePath("Tests.Bicep.1.Parameters.json"));
+
+            // From metadata
+            var link = helper.ProcessParameterFile(GetSourcePath("Tests.Bicep.1.metalink.json"));
             Assert.NotNull(link);
             Assert.NotNull(link.TemplateFile);
+            Assert.EndsWith("Tests.Bicep.1.bicep", link.TemplateFile);
             Assert.NotNull(link.ParameterFile);
+            Assert.EndsWith("Tests.Bicep.1.metalink.json", link.ParameterFile);
+
+            // From naming convention
+            link = helper.ProcessParameterFile(GetSourcePath("Tests.Bicep.1.parameters.json"));
+            Assert.NotNull(link);
+            Assert.NotNull(link.TemplateFile);
+            Assert.EndsWith("Tests.Bicep.1.bicep", link.TemplateFile);
+            Assert.NotNull(link.ParameterFile);
+            Assert.EndsWith("Tests.Bicep.1.parameters.json", link.ParameterFile);
+
+            // From naming convention when both .bicep and .json exist
+            link = helper.ProcessParameterFile(GetSourcePath("Tests.Bicep.2.parameters.json"));
+            Assert.NotNull(link);
+            Assert.NotNull(link.TemplateFile);
+            Assert.EndsWith("Tests.Bicep.2.json", link.TemplateFile);
+            Assert.NotNull(link.ParameterFile);
+            Assert.EndsWith("Tests.Bicep.2.parameters.json", link.ParameterFile);
         }
 
         #region Helper methods

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.1.metalink.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.1.metalink.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "template": "./Tests.Bicep.1.bicep"
+  },
+  "parameters": {
+    "name": {
+      "value": "bicepstorage01"
+    }
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.1.parameters.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.1.parameters.json
@@ -1,9 +1,6 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
-    "metadata": {
-        "template": "./Tests.Bicep.1.bicep"
-    },
     "parameters": {
         "name": {
             "value": "bicepstorage01"

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.2.parameters.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.2.parameters.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "value": "eastus"
+    }
+  }
+}


### PR DESCRIPTION
## PR Summary

 Fixes parameter files linked to bicep code via naming convention is not working.

Fixes #1582

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
