### PR TITLE
Pre-release v1.19.0-B0077

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -23,6 +23,15 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.19.0-B0077 (pre-release)
+
+What's changed since pre-release v1.19.0-B0077:
+
+- New rules:
+  - Azure Kubernetes Service:
+    - Check clusters use uptime SLA by @bengeset96.
+      [#1601](https://github.com/Azure/PSRule.Rules.Azure/issues/1601)
+
 ## v1.19.0-B0042 (pre-release)
 
 What's changed since pre-release v1.19.0-B0010:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.19.0-B0077:

- New rules:
  - Azure Kubernetes Service:
    - Check clusters use uptime SLA by @bengeset96.
      [#1601](https://github.com/Azure/PSRule.Rules.Azure/issues/1601)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
