### PR TITLE
Fixes dateTimeAdd function #1637 (#1641)

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -23,6 +23,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.19.1:
+
+- Bug fixes:
+  - Fixed function `dateTimeAdd` errors handling `utcNow` output by @BernieWhite.
+    [#1637](https://github.com/Azure/PSRule.Rules.Azure/issues/1637)
+
 ## v1.19.1
 
 What's changed since v1.19.0:

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
@@ -620,7 +620,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 value = token.Value<DateTime>();
                 return true;
             }
-            value = default(DateTime);
+            value = default;
             return false;
         }
 
@@ -632,10 +632,9 @@ namespace PSRule.Rules.Azure.Data.Template
             if (TryDateTime(o, out value))
                 return true;
 
-            if (TryString(o, out var svalue) && DateTime.TryParse(svalue, AzureCulture, style, out value))
-                return true;
-
-            return false;
+            return TryString(o, out var svalue) &&
+                (DateTime.TryParseExact(svalue, "yyyyMMddTHHmmssZ", AzureCulture, style, out value) ||
+                DateTime.TryParse(svalue, AzureCulture, style, out value));
         }
 
         internal static bool TryJToken(object o, out JToken value)

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -1123,6 +1123,9 @@ namespace PSRule.Rules.Azure.Data.Template
         /// <summary>
         /// dateTimeAdd(base, duration, [format])
         /// </summary>
+        /// <remarks>
+        /// See <seealso href="https://docs.microsoft.com/azure/azure-resource-manager/templates/template-functions-date#datetimeadd"/>.
+        /// </remarks>
         internal static object DateTimeAdd(ITemplateContext context, object[] args)
         {
             var argCount = CountArgs(args);
@@ -1417,7 +1420,7 @@ namespace PSRule.Rules.Azure.Data.Template
         /// indexOf(stringToSearch, stringToFind)
         /// </summary>
         /// <remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/azure-resource-manager/templates/template-functions-string#indexof"/>
+        /// See <seealso href="https://docs.microsoft.com/azure/azure-resource-manager/templates/template-functions-string#indexof"/>.
         /// </remarks>
         private static object IndexOfString(string stringToSearch, string stringToFind)
         {
@@ -1433,7 +1436,7 @@ namespace PSRule.Rules.Azure.Data.Template
         /// indexOf(arrayToSearch, itemToFind)
         /// </summary>
         /// <remarks>
-        /// https://docs.microsoft.com/azure/azure-resource-manager/templates/template-functions-array#indexof
+        /// See <seealso href="https://docs.microsoft.com/azure/azure-resource-manager/templates/template-functions-array#indexof"/>.
         /// </remarks>
         private static object IndexOfArray(object o1, object o2, bool first)
         {

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -976,6 +976,7 @@ namespace PSRule.Rules.Azure
             var actual2 = DateTime.Parse(Functions.DateTimeAdd(context, new object[] { utc.ToString("u"), "-P9D" }) as string, new CultureInfo("en-US"), DateTimeStyles.AdjustToUniversal);
             var actual3 = DateTime.Parse(Functions.DateTimeAdd(context, new object[] { utc.ToString("u"), "PT1H" }) as string, new CultureInfo("en-US"), DateTimeStyles.AdjustToUniversal);
             var actual4 = DateTime.Parse(Functions.DateTimeAdd(context, new object[] { utc.ToString("u"), "P3Y", "u" }) as string, new CultureInfo("en-US"), DateTimeStyles.AdjustToUniversal);
+            var actual5 = DateTime.Parse(Functions.DateTimeAdd(context, new object[] { Functions.UtcNow(context, System.Array.Empty<object>()), "P3Y", "u" }) as string, new CultureInfo("en-US"), DateTimeStyles.AdjustToUniversal);
 
             Assert.Equal(utc.AddYears(3), actual1);
             Assert.Equal(utc.AddDays(-9), actual2);


### PR DESCRIPTION
## PR Summary

Apply fix from main on to v1.19.x for patch release.

- Fixed function `dateTimeAdd` errors handling `utcNow` output.

#1637

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
