### PR TITLE
First cut at logs bicep doc updates

### DIFF
--- a/docs/en/rules/Azure.FrontDoor.Logs.md
+++ b/docs/en/rules/Azure.FrontDoor.Logs.md
@@ -25,6 +25,103 @@ Management operations for Front Door is captured automatically within Azure Acti
 
 Consider configuring diagnostics setting to log network activity through Front Door.
 
+## EXAMPLES
+
+<!-- 
+### Configure with Azure template
+
+To deploy Front Door that pass this rule:
+
+- Deploy a diagnostic settings sub-resource.
+- Enable logging for the `AuditEvent` category.
+
+For example:
+
+```json
+{
+    "coming soon once Bicep compiles and deploys...",
+
+}
+```
+-->
+
+---
+
+### Configure Manually
+
+To deploy Front Door that passes this rule:
+
+- Deploy a diagnostic settings sub-resource.
+- Manually go into the diagnostic settings and add these two rules:
+  - Enable logging for the `FrontdoorAccessLog` category.
+  - Enable logging for the `FrontdoorWebApplicationFirewallLog` category.
+
+---
+
+### Configure with Azure template
+
+If this setting was available in Bicep, it could be set like the following Bicep shows. 
+
+#### Bicep Template
+
+```bicep
+param frontDoorName string = 'myFrontDoor'
+param workSpaceId string = ''
+param location string = resourceGroup().location
+
+resource frontDoorResource 'Microsoft.Cdn/profiles@2021-06-01' = {
+  name: frontDoorName
+  location: 'Global'
+  sku: {
+    name: 'Standard_AzureFrontDoor'
+  }
+}
+
+resource frontDoorInsightsResource 'Microsoft.Cdn/profiles/providers/diagnosticSettings@2020-01-01-preview' = {
+  name: '${frontDoorName}/Microsoft.Insights/service'
+  dependsOn: [
+    frontDoorResource
+  ]
+  location: location
+  properties: {
+    workspaceId: workSpaceId
+    logs: [
+      {
+        category: 'FrontdoorAccessLog'
+        enabled: true
+      }
+      {
+        category: 'FrontdoorWebApplicationFirewallLog'
+        enabled: true
+      }
+    ]
+  }
+}
+```
+
+---
+
+#### Test Script
+
+Deploy Test Script: For debugging purposes, save the bicep above to sampleFrontDoor.bicep and run this command to test the deploy of this template:
+
+```ps1
+az deployment group create -n front-door-test-20220919T150200Z --resource-group rg_sandbox --template-file 'sampleFrontDoor.bicep' --parameters frontDoorName=yourFrontDoorName workSpaceId=/subscriptions/yourSubscriptionId/resourcegroups/yourResourceGroup/providers/microsoft.operationalinsights/workspaces/yourLogAnalyticsWorkspaceName
+```
+
+#### Errors
+
+However, this Bicep fails and gets the following error, so I can't figure out how to deploy this setting via ARM/Bicep.
+All the docs  say to do this manually... I can't find how to automate this setting!
+
+```bicep
+'.../resourcegroups/myResourceGroupName/providers/Microsoft.Cdn/profiles/myFrontDoorName/providers/Microsoft.Insights/diagnosticSettings/service' is not supported"
+```
+
+---
+
 ## LINKS
 
 - [Monitoring metrics and logs in Azure Front Door Service](https://docs.microsoft.com/azure/frontdoor/front-door-diagnostics#diagnostic-logging)
+- [Create a Front Door Standard/Premium using Bicep](https://learn.microsoft.com/en-us/azure/frontdoor/create-front-door-bicep?tabs=CLI)
+- [Security logs and alerts using Azure services](https://learn.microsoft.com/en-us/azure/architecture/framework/security/monitor-logs-alerts)

--- a/docs/en/rules/Azure.FrontDoor.Probe.md
+++ b/docs/en/rules/Azure.FrontDoor.Probe.md
@@ -6,7 +6,7 @@ resource: Front Door
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.FrontDoor.Probe/
 ---
 
-# Use health probes for Front Door backends
+# Use Health Probes for Front Door backends
 
 ## SYNOPSIS
 
@@ -40,6 +40,110 @@ az network front-door probe update --front-door-name '<front_door>' -n '<probe_n
 ```powershell
 $probeSetting = New-AzFrontDoorHealthProbeSettingObject -Name '<probe_name>' -EnabledState 'Enabled'
 Set-AzFrontDoor -Name '<front_door>' -ResourceGroupName '<resource_group>' -HealthProbeSetting $probeSetting
+```
+### Configure with Azure PowerShell
+
+```powershell
+$probeSetting = New-AzFrontDoorHealthProbeSettingObject -Name '<probe_name>' -Path '<path>'
+Set-AzFrontDoor -Name '<front_door>' -ResourceGroupName '<resource_group>' -HealthProbeSetting $probeSetting
+```
+
+### Configure with Azure template
+
+To deploy a Front Door resource that passes this rule:
+
+- Configure the healthProbeSettings on the OriginGroup
+
+For example:
+
+```json
+  "resources": [
+    {
+      "type": "Microsoft.Cdn/profiles",
+      "apiVersion": "2021-06-01",
+      "name": "[parameters('frontDoorName')]",
+      "location": "Global",
+      "sku": {
+        "name": "Standard_AzureFrontDoor"
+      }
+    },
+    {
+      "type": "Microsoft.Cdn/profiles/afdEndpoints",
+      "apiVersion": "2021-06-01",
+      "name": "[format('{0}/{1}', parameters('frontDoorName'), variables('frontDoorEndpointName'))]",
+      "location": "Global",
+      "properties": {
+        "enabledState": "Enabled"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Cdn/profiles', parameters('frontDoorName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Cdn/profiles/originGroups",
+      "apiVersion": "2021-06-01",
+      "name": "[format('{0}/{1}', parameters('frontDoorName'), variables('frontDoorDefaultOriginGroupName'))]",
+      "properties": {
+        "loadBalancingSettings": {
+          "sampleSize": 4,
+          "successfulSamplesRequired": 3
+        },
+        "healthProbeSettings": {
+          "probePath": "/",
+          "probeRequestType": "HEAD",
+          "probeProtocol": "Http",
+          "probeIntervalInSeconds": 100
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Cdn/profiles', parameters('frontDoorName'))]"
+      ]
+    }
+  ]
+  ```
+
+### Configure with Bicep
+
+To deploy a Front Door resource that passes this rule:
+
+- Configure the healthProbeSettings on the OriginGroup
+
+For example:
+
+```bicep
+resource frontDoorResource 'Microsoft.Cdn/profiles@2021-06-01' = {
+  name: frontDoorName
+  location: 'Global'
+  sku: {
+    name: 'Standard_AzureFrontDoor'
+  }
+}
+
+resource frontDoorEndpoint 'Microsoft.Cdn/profiles/afdendpoints@2021-06-01' = {
+  parent: frontDoorResource
+  name: frontDoorEndpointName
+  location: 'Global'
+  properties: {
+    enabledState: 'Enabled' 
+  }
+}
+
+resource frontDoorOriginGroup 'Microsoft.Cdn/profiles/origingroups@2021-06-01' = {
+  name: frontDoorDefaultOriginGroupName
+  parent: frontDoorResource
+  properties: {
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+    }
+    healthProbeSettings: {
+      probePath: '/'
+      probeRequestType: 'HEAD'
+      probeProtocol: 'Http'
+      probeIntervalInSeconds: 100
+    }
+  }
+}
 ```
 
 ## LINKS

--- a/docs/en/rules/Azure.FrontDoor.ProbeMethod.md
+++ b/docs/en/rules/Azure.FrontDoor.ProbeMethod.md
@@ -36,6 +36,110 @@ az network front-door probe update --front-door-name '<front_door>' -n '<probe_n
 $probeSetting = New-AzFrontDoorHealthProbeSettingObject -Name '<probe_name>' -HealthProbeMethod 'HEAD'
 Set-AzFrontDoor -Name '<front_door>' -ResourceGroupName '<resource_group>' -HealthProbeSetting $probeSetting
 ```
+### Configure with Azure PowerShell
+
+```powershell
+$probeSetting = New-AzFrontDoorHealthProbeSettingObject -Name '<probe_name>' -Path '<path>'
+Set-AzFrontDoor -Name '<front_door>' -ResourceGroupName '<resource_group>' -HealthProbeSetting $probeSetting
+```
+
+### Configure with Azure template
+
+To deploy a Front Door resource that passes this rule:
+
+- Configure the healthProbeSettings.probeRequestType on the OriginGroup
+
+For example:
+
+```json
+  "resources": [
+    {
+      "type": "Microsoft.Cdn/profiles",
+      "apiVersion": "2021-06-01",
+      "name": "[parameters('frontDoorName')]",
+      "location": "Global",
+      "sku": {
+        "name": "Standard_AzureFrontDoor"
+      }
+    },
+    {
+      "type": "Microsoft.Cdn/profiles/afdEndpoints",
+      "apiVersion": "2021-06-01",
+      "name": "[format('{0}/{1}', parameters('frontDoorName'), variables('frontDoorEndpointName'))]",
+      "location": "Global",
+      "properties": {
+        "enabledState": "Enabled"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Cdn/profiles', parameters('frontDoorName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Cdn/profiles/originGroups",
+      "apiVersion": "2021-06-01",
+      "name": "[format('{0}/{1}', parameters('frontDoorName'), variables('frontDoorDefaultOriginGroupName'))]",
+      "properties": {
+        "loadBalancingSettings": {
+          "sampleSize": 4,
+          "successfulSamplesRequired": 3
+        },
+        "healthProbeSettings": {
+          "probePath": "/",
+          "probeRequestType": "HEAD",
+          "probeProtocol": "Http",
+          "probeIntervalInSeconds": 100
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Cdn/profiles', parameters('frontDoorName'))]"
+      ]
+    }
+  ]
+  ```
+
+### Configure with Bicep
+
+To deploy a Front Door resource that passes this rule:
+
+- Configure the healthProbeSettings.probeRequestType on the OriginGroup
+
+For example:
+
+```bicep
+resource frontDoorResource 'Microsoft.Cdn/profiles@2021-06-01' = {
+  name: frontDoorName
+  location: 'Global'
+  sku: {
+    name: 'Standard_AzureFrontDoor'
+  }
+}
+
+resource frontDoorEndpoint 'Microsoft.Cdn/profiles/afdendpoints@2021-06-01' = {
+  parent: frontDoorResource
+  name: frontDoorEndpointName
+  location: 'Global'
+  properties: {
+    enabledState: 'Enabled' 
+  }
+}
+
+resource frontDoorOriginGroup 'Microsoft.Cdn/profiles/origingroups@2021-06-01' = {
+  name: frontDoorDefaultOriginGroupName
+  parent: frontDoorResource
+  properties: {
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+    }
+    healthProbeSettings: {
+      probePath: '/'
+      probeRequestType: 'HEAD'
+      probeProtocol: 'Http'
+      probeIntervalInSeconds: 100
+    }
+  }
+}
+```
 
 ## LINKS
 

--- a/docs/en/rules/Azure.FrontDoor.ProbePath.md
+++ b/docs/en/rules/Azure.FrontDoor.ProbePath.md
@@ -6,7 +6,7 @@ resource: Front Door
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.FrontDoor.ProbePath/
 ---
 
-# Use a dedicated health endpoint for Front Door backends
+# Use a Dedicated Health Endpoint for Front Door backends
 
 ## SYNOPSIS
 
@@ -37,6 +37,104 @@ az network front-door probe update --front-door-name '<front_door>' -n '<probe_n
 ```powershell
 $probeSetting = New-AzFrontDoorHealthProbeSettingObject -Name '<probe_name>' -Path '<path>'
 Set-AzFrontDoor -Name '<front_door>' -ResourceGroupName '<resource_group>' -HealthProbeSetting $probeSetting
+```
+
+### Configure with Azure template
+
+To deploy a Front Door resource that passes this rule:
+
+- Configure the healthProbeSettings.probePath on the OriginGroup
+
+For example:
+
+```json
+  "resources": [
+    {
+      "type": "Microsoft.Cdn/profiles",
+      "apiVersion": "2021-06-01",
+      "name": "[parameters('frontDoorName')]",
+      "location": "Global",
+      "sku": {
+        "name": "Standard_AzureFrontDoor"
+      }
+    },
+    {
+      "type": "Microsoft.Cdn/profiles/afdEndpoints",
+      "apiVersion": "2021-06-01",
+      "name": "[format('{0}/{1}', parameters('frontDoorName'), variables('frontDoorEndpointName'))]",
+      "location": "Global",
+      "properties": {
+        "enabledState": "Enabled"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Cdn/profiles', parameters('frontDoorName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Cdn/profiles/originGroups",
+      "apiVersion": "2021-06-01",
+      "name": "[format('{0}/{1}', parameters('frontDoorName'), variables('frontDoorDefaultOriginGroupName'))]",
+      "properties": {
+        "loadBalancingSettings": {
+          "sampleSize": 4,
+          "successfulSamplesRequired": 3
+        },
+        "healthProbeSettings": {
+          "probePath": "/",
+          "probeRequestType": "HEAD",
+          "probeProtocol": "Http",
+          "probeIntervalInSeconds": 100
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Cdn/profiles', parameters('frontDoorName'))]"
+      ]
+    }
+  ]
+  ```
+
+### Configure with Bicep
+
+To deploy a Front Door resource that passes this rule:
+
+- Configure the healthProbeSettings.probePath on the OriginGroup
+
+For example:
+
+```bicep
+resource frontDoorResource 'Microsoft.Cdn/profiles@2021-06-01' = {
+  name: frontDoorName
+  location: 'Global'
+  sku: {
+    name: 'Standard_AzureFrontDoor'
+  }
+}
+
+resource frontDoorEndpoint 'Microsoft.Cdn/profiles/afdendpoints@2021-06-01' = {
+  parent: frontDoorResource
+  name: frontDoorEndpointName
+  location: 'Global'
+  properties: {
+    enabledState: 'Enabled' 
+  }
+}
+
+resource frontDoorOriginGroup 'Microsoft.Cdn/profiles/origingroups@2021-06-01' = {
+  name: frontDoorDefaultOriginGroupName
+  parent: frontDoorResource
+  properties: {
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+    }
+    healthProbeSettings: {
+      probePath: '/'
+      probeRequestType: 'HEAD'
+      probeProtocol: 'Http'
+      probeIntervalInSeconds: 100
+    }
+  }
+}
 ```
 
 ## LINKS

--- a/docs/en/rules/Azure.KeyVault.Logs.md
+++ b/docs/en/rules/Azure.KeyVault.Logs.md
@@ -74,6 +74,51 @@ For example:
 }
 ```
 
+### Configure with Bicep Template
+
+To deploy key vaults that pass this rule:
+
+- Deploy a diagnostic settings sub-resource.
+- Enable logging for the `AuditEvent` category.
+
+For example:
+
+```bicep
+param vaultName string = ''
+param location string = resourceGroup().location
+param workspaceId string = ''
+
+resource keyVaultResource 'Microsoft.KeyVault/vaults@2019-09-01' = {
+  name: vaultName
+  location: location
+  properties: {
+    accessPolicies: []
+    tenantId: subscription().tenantId
+    sku: {
+      name: 'standard'
+      family: 'A'
+    }
+  }
+}
+
+resource keyVaultInsightsResource 'Microsoft.KeyVault/vaults/providers/diagnosticSettings@2016-09-01' = {
+  name: '${vaultName}/Microsoft.Insights/service'
+  dependsOn: [
+    keyVaultResource
+  ]
+  location: location
+  properties: {
+    workspaceId: workspaceId
+    logs: [
+      {
+        category: 'AuditEvent'
+        enabled: true
+      }
+    ]
+  }
+}
+```
+
 ## LINKS
 
 - [Best practices to use Key Vault](https://docs.microsoft.com/azure/key-vault/general/best-practices)

--- a/docs/en/rules/Azure.KeyVault.Logs.md
+++ b/docs/en/rules/Azure.KeyVault.Logs.md
@@ -6,7 +6,7 @@ resource: Key Vault
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.Logs/
 ---
 
-# Audit Key Vault data access
+# Audit Key Vault Data Access
 
 ## SYNOPSIS
 
@@ -74,7 +74,7 @@ For example:
 }
 ```
 
-### Configure with Bicep Template
+### Configure with Bicep
 
 To deploy key vaults that pass this rule:
 
@@ -84,13 +84,9 @@ To deploy key vaults that pass this rule:
 For example:
 
 ```bicep
-param vaultName string = ''
-param location string = resourceGroup().location
-param workspaceId string = ''
-
 resource keyVaultResource 'Microsoft.KeyVault/vaults@2019-09-01' = {
-  name: vaultName
-  location: location
+  name: parmVaultName
+  location: parmLocation
   properties: {
     accessPolicies: []
     tenantId: subscription().tenantId
@@ -102,13 +98,13 @@ resource keyVaultResource 'Microsoft.KeyVault/vaults@2019-09-01' = {
 }
 
 resource keyVaultInsightsResource 'Microsoft.KeyVault/vaults/providers/diagnosticSettings@2016-09-01' = {
-  name: '${vaultName}/Microsoft.Insights/service'
+  name: '${parmVaultName}/Microsoft.Insights/service'
   dependsOn: [
     keyVaultResource
   ]
-  location: location
+  location: parmLocation
   properties: {
-    workspaceId: workspaceId
+    workspaceId: parmWorkspaceId
     logs: [
       {
         category: 'AuditEvent'
@@ -125,3 +121,4 @@ resource keyVaultInsightsResource 'Microsoft.KeyVault/vaults/providers/diagnosti
 - [Azure Key Vault logging](https://docs.microsoft.com/azure/key-vault/general/logging)
 - [Azure Key Vault security](https://docs.microsoft.com/azure/key-vault/general/security-overview#logging-and-monitoring)
 - [Monitoring your key vault service with Azure Monitor for Key Vault](https://docs.microsoft.com/azure/azure-monitor/insights/key-vault-insights-overview)
+- [Security logs and alerts using Azure services](https://learn.microsoft.com/azure/architecture/framework/security/monitor-logs-alerts)


### PR DESCRIPTION
Updated the Azure.KeyVault.Logs.md with Bicep that mimics the ARM code in it.

Tried to do the same with Azure.FrontDoor.Logs.md, but ran into lots of issues. There was no ARM example code, so I created an template and deployed a simple Front Door. Tried to add the logging for FrontdoorAccessLog and FrontdoorWebApplicationFirewallLog settings to the ARM and Bicep, but I can't find the syntax to automate that setting. All the docs I've found just explain how to set it manually. Spent way too much time today searching for this answer...!

Is this one of those where there just isn't an ARM setting yet, so the docs should just say to do it manually...?  Any idea? or who would know where else to look...?