### PR TITLE
Use identity-based authentication for App Configuration

### DIFF
--- a/docs/en/rules/Azure.AppConfig.DisableLocalAuth.md
+++ b/docs/en/rules/Azure.AppConfig.DisableLocalAuth.md
@@ -1,0 +1,86 @@
+---
+reviewed: 2022-09-22
+severity: Important
+pillar: Security
+category: Authentication
+resource: resource
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AppConfig.DisableLocalAuth/
+---
+
+# Use identity-based authentication for App Configuration
+
+## SYNOPSIS
+
+Authenticate App Configuration clients with Azure AD identities.
+
+## DESCRIPTION
+
+Every request to an Azure App Configuration resource must be authenticated.
+By default, requests can be authenticated with either Azure Active Directory (Azure AD) credentials,
+or by using an access key. Of these two types of authentication schemes, Azure AD provides superior
+security and ease of use over access keys, and is recommended by Microsoft. To require clients to use
+Azure AD to authenticate requests, you can disable the usage of access keys for an Azure App Configuration
+resource.
+
+When you disable access key authentication for an Azure App Configuration resource, any existing access
+keys for that resource are deleted. Any subsequent requests to the resource using the previously existing
+access keys will be rejected. Only requests that are authenticated using Azure AD will succeed.
+
+## RECOMMENDATION
+
+Consider only using Azure AD identities to access App Configuration data.
+Then disable authentication based on access keys or SAS tokens.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy App Configuration that pass this rule:
+
+- Set the `properties.disableLocalAuth` property to `true`.
+
+For example:
+
+```json
+    {
+      "type": "Microsoft.AppConfiguration/configurationStores",
+      "apiVersion": "2022-05-01",
+      "name": "[parameters('configStoreName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('skuName')]"
+      },
+      "properties": {
+        "disableLocalAuth": true
+      }
+    }
+```
+
+### Configure with Bicep
+
+To deploy App Configuration that pass this rule:
+
+- Set the `properties.disableLocalAuth` property to `true`.
+
+For example:
+
+```bicep
+resource configStore 'Microsoft.AppConfiguration/configurationStores@2022-05-01' = {
+  name: configStoreName
+  location: location
+  sku: {
+    name: skuName
+  }
+  properties: {
+    disableLocalAuth: true
+  }
+}
+```
+
+## LINKS
+
+- [Use identity-based authentication](https://docs.microsoft.com/azure/architecture/framework/security/design-identity-authentication#use-identity-based-authentication)
+- [IM-1: Use centralized identity and authentication system](https://docs.microsoft.com/security/benchmark/azure/security-controls-v3-identity-management#im-1-use-centralized-identity-and-authentication-system)
+- [Authorize access to Azure App Configuration using Azure Active Directory](https://learn.microsoft.com/azure/azure-app-configuration/concept-enable-rbac)
+- [Disable access key authentication](https://learn.microsoft.com/azure/azure-app-configuration/howto-disable-access-key-authentication?tabs=portal)
+- [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.appconfiguration/configurationstores)

--- a/src/PSRule.Rules.Azure/rules/Azure.AppConfig.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppConfig.Rule.yaml
@@ -48,4 +48,23 @@ spec:
     - name: '.'
       match: '^[A-Za-z0-9](-|[A-Za-z0-9]){3,48}[A-Za-z0-9]$'
 
+---
+# Synopsis: Use identity-based authentication for App Configuration.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.AppConfig.DisableLocalAuth
+  ref: AZR-000291
+  tags:
+    release: 'GA'
+    ruleSet: '2022_09'
+    Azure.WAF/pillar: 'Security'
+    Azure.ASB.v3/control: 'IM-1'
+spec:
+  type:
+  - Microsoft.AppConfiguration/configurationStores
+  condition:
+    field: properties.disableLocalAuth
+    equals: true
+
 #endregion Rules

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
@@ -52,6 +52,23 @@ Describe 'Azure.AppConfig' -Tag 'AppConfig' {
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'app-config-A';
         }
+
+        It 'Azure.AppConfig.DisableLocalAuth' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppConfig.DisableLocalAuth' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'app-config-B';
+            $ruleResult.Detail.Reason.Path | Should -BeIn 'Properties.disableLocalAuth';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'app-config-A';
+        }
     }
 
     Context 'Resource name' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AppConfig.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AppConfig.json
@@ -17,7 +17,8 @@
             "encryption": {
                 "keyVaultProperties": null
             },
-            "privateEndpointConnections": null
+            "privateEndpointConnections": null,
+            "disableLocalAuth": true
         },
         "ResourceGroupName": "rg-test",
         "Type": "Microsoft.AppConfiguration/configurationStores",


### PR DESCRIPTION
## PR Summary

New rule created to disable local authN (keys, SAS tokens) to Azure App Configuration and favor Azure AD authN instead:
- `Azure.AppConfig.DisableLocalAuth.md` docs page created
- New rule added to `Azure.AppConfig.Rule.yaml`
- New test section added to `Azure.AppConfig.Tests.ps1`
- Test template `Resources.AppConfig.json` updated, so one of the configStores passes, another fails

Fixes #1691 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [ ] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
