### PR TITLE
Limit connectivity to Redis instances with firewall rules #544

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     steps:
 
-    - uses: actions/stale@v5
+    - uses: actions/stale@v6
       with:
         stale-issue-message: >
           This issue has been automatically marked as stale because it has not had

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -31,6 +31,10 @@ What's changed since pre-release v1.20.0-B0028:
       [#1671](https://github.com/Azure/PSRule.Rules.Azure/issues/1671)
     - Check file share soft delete is enabled by @jonathanruiz.
       [#966](https://github.com/Azure/PSRule.Rules.Azure/issues/966)
+    - Limit number of firewall rules for Redis @jonathanruiz
+      [#544](https://github.com/Azure/PSRule.Rules.Azure/issues/544)
+    - Limit number of IP addresses in firewall rules for Redis @jonathanruiz
+      [#544](https://github.com/Azure/PSRule.Rules.Azure/issues/544)
   - App Configuration:
     - Use identity-based authentication for App Configuration by @pazdedav
       [#1691](https://github.com/Azure/PSRule.Rules.Azure/issues/1691)

--- a/docs/en/rules/Azure.Redis.FirewallIPRange.md
+++ b/docs/en/rules/Azure.Redis.FirewallIPRange.md
@@ -23,5 +23,5 @@ The Redis cache has greater than ten (10) public IP addresses that are permitted
 
 ## Links
 
-- [How to configure Azure Cache for Redis - Firewall](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-configure#default-redis-server-configuration#firewall)
+- [How to configure Azure Cache for Redis - Firewall](https://docs.microsoft.com/azure/azure-cache-for-redis/cache-configure#default-redis-server-configuration#firewall)
 - [Microsoft.Cache redis/firewallRules](https://docs.microsoft.com/azure/templates/microsoft.cache/2022-05-01/redis/firewallrules)

--- a/docs/en/rules/Azure.Redis.FirewallIPRange.md
+++ b/docs/en/rules/Azure.Redis.FirewallIPRange.md
@@ -1,0 +1,27 @@
+---
+reviewed: 2022-09-22
+severity: Critical
+pillar: Security
+category: Data Protection
+resource: Azure Cache for Redis
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Redis.FirewallIPRange/
+---
+
+# Limit Redis cache number of IP addresses
+
+## Synopsis
+
+Determine if there is an excessive nunber of permitted IP addresses for the Redis cache.
+
+## Description
+
+Azure Cache for Redis provides the functionality to create firewall rules, limiting the IP addresses that can access the resources. Normally, you want to limit the number of IP addresses permitted through the firewall.
+
+## Recommednation
+
+The Redis cache has greater than ten (10) public IP addresses that are permitted network access. Some rules may not be needed or can be reduced.
+
+## Links
+
+- [How to configure Azure Cache for Redis - Firewall](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-configure#default-redis-server-configuration#firewall)
+- [Microsoft.Cache redis/firewallRules](https://docs.microsoft.com/azure/templates/microsoft.cache/2022-05-01/redis/firewallrules)

--- a/docs/en/rules/Azure.Redis.FirewallRuleCount.md
+++ b/docs/en/rules/Azure.Redis.FirewallRuleCount.md
@@ -17,11 +17,54 @@ Determine if there is an excessive number of firewall rules for the Redis cache.
 
 Azure Cache for Redis provides the functionality to create firewall rules, limiting the IP addresses that can access the resources. Normally, you want to limit the number of firewall rules.
 
-## RECOMMENDATION
+## Recommendation
 
 The Redis cache has more than ten (10) firewall rules. Some rules may not be needed.
+
+## Examples
+
+### Configure with Azure template
+
+To deploy Redis Cache that pass this rule:
+
+- Set the `properties.startIP` property to the start of the IP address range.
+- Set the `properties.endIP` property to the end of the IP address range.
+
+```json
+{
+  "type": "Microsoft.Cache/redis/firewallRules",
+  "apiVersion": "2022-05-01",
+  "name": "string",
+  "properties": {
+    "startIP": "string",
+    "endIP": "string"
+  }
+}
+```
+
+### Configure with Bicep
+
+To deploy Redis Cache that pass this rule:
+
+- Set the `properties.startIP` property to the start of the IP address range.
+- Set the `properties.endIP` property to the end of the IP address range.
+
+```
+resource symbolicname 'Microsoft.Cache/redis/firewallRules@2022-05-01' = {
+  name: 'string'
+  parent: resourceSymbolicName
+  properties: {
+    startIP: 'string'
+    endIP: 'string'
+  }
+}
+```
 
 ## Links
 
 - [How to configure Azure Cache for Redis - Firewall](https://docs.microsoft.com/azure/azure-cache-for-redis/cache-configure#default-redis-server-configuration#firewall)
 - [Microsoft.Cache redis/firewallRules](https://docs.microsoft.com/azure/templates/microsoft.cache/2022-05-01/redis/firewallrules)
+
+```
+
+```

--- a/docs/en/rules/Azure.Redis.FirewallRuleCount.md
+++ b/docs/en/rules/Azure.Redis.FirewallRuleCount.md
@@ -1,0 +1,27 @@
+---
+reviewed: 2022-09-22
+severity: Awareness
+pillar: Security
+category: Network security and containment
+resource: zure Cache for Redis
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Redis.FirewallRuleCount/
+---
+
+# Cleanup Redis cache firewall rules
+
+## Synopsis
+
+Determine if there is an excessive number of firewall rules for the Redis cache.
+
+## Description
+
+Azure Cache for Redis provides the functionality to create firewall rules, limiting the IP addresses that can access the resources. Normally, you want to limit the number of firewall rules.
+
+## RECOMMENDATION
+
+The Redis cache has more than ten (10) firewall rules. Some rules may not be needed.
+
+## Links
+
+- [How to configure Azure Cache for Redis - Firewall](https://docs.microsoft.com/azure/azure-cache-for-redis/cache-configure#default-redis-server-configuration#firewall)
+- [Microsoft.Cache redis/firewallRules](https://docs.microsoft.com/azure/templates/microsoft.cache/2022-05-01/redis/firewallrules)

--- a/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.ps1
@@ -84,7 +84,7 @@ Rule 'Azure.RedisEnterprise.Zones' -Ref 'AZR-000162' -Type 'Microsoft.Cache/redi
 } -Configure @{ AZURE_REDISENTERPRISECACHE_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST = @() }
 
 # Synopsis: Determine if there is an excessive number of firewall rules for the Redis Cache
-Rule 'Azure.Redis.FirewallRuleCount' -Ref 'AZR-000293' -Type 'Microsoft.Cache/redis', 'Microsoft.Cache/redis/firewallRules' -Tag @{ release = 'GA'; ruleSet = '2022_09'; } {
+Rule 'Azure.Redis.FirewallRuleCount' -Ref 'AZR-000299' -Type 'Microsoft.Cache/redis', 'Microsoft.Cache/redis/firewallRules' -Tag @{ release = 'GA'; ruleSet = '2022_09'; } {
 
     $services = @($TargetObject);
 

--- a/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.ps1
@@ -107,7 +107,7 @@ Rule 'Azure.Redis.FirewallRuleCount' -Ref 'AZR-000299' -Type 'Microsoft.Cache/re
 }
 
 # Synopsis: Determine if there is an excessive number of permitted IP addresses for the Redis Cache
-Rule 'Azure.Redis.FirewallIPRange' -Ref 'AZR-000294' -Type 'Microsoft.Cache/redis', 'Microsoft.Cache/redis/firewallRules' -Tag @{ release = 'GA'; ruleSet = '2022_09'; } {
+Rule 'Azure.Redis.FirewallIPRange' -Ref 'AZR-000300' -Type 'Microsoft.Cache/redis', 'Microsoft.Cache/redis/firewallRules' -Tag @{ release = 'GA'; ruleSet = '2022_09'; } {
 
     $services = @($TargetObject);
 

--- a/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.ps1
@@ -83,8 +83,8 @@ Rule 'Azure.RedisEnterprise.Zones' -Ref 'AZR-000162' -Type 'Microsoft.Cache/redi
 
 } -Configure @{ AZURE_REDISENTERPRISECACHE_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST = @() }
 
-# Synopsis: Determine if there is an excessive number of permitted IP addresses for the Redis Cache
-Rule 'Azure.Redis.FirewallIPRange' -Ref 'AZR-000293' -Type 'Microsoft.Cache/redis', 'Microsoft.Cache/redis/firewallRules' -Tag @{ release = 'GA'; ruleSet = '2022_09'; } {
+# Synopsis: Determine if there is an excessive number of firewall rules for the Redis Cache
+Rule 'Azure.Redis.FirewallRuleCount' -Ref 'AZR-000293' -Type 'Microsoft.Cache/redis', 'Microsoft.Cache/redis/firewallRules' -Tag @{ release = 'GA'; ruleSet = '2022_09'; } {
 
     $services = @($TargetObject);
 
@@ -98,7 +98,30 @@ Rule 'Azure.Redis.FirewallIPRange' -Ref 'AZR-000293' -Type 'Microsoft.Cache/redi
 
     $summary = GetIPAddressSummary
     $summary.Public = [int32]$summary.Public # Had to convert $summary.Public to int32 from uint64.
+
+    $firewallRules = @(GetSubResources -ResourceType 'Microsoft.Cache/redis/firewallRules');
+    $Assert.
+        LessOrEqual($firewallRules, '.', 10).
+        WithReason(($LocalizedData.DBServerFirewallRuleCount -f $firewallRules.Length, 10), $True);
     
+}
+
+# Synopsis: Determine if there is an excessive number of permitted IP addresses for the Redis Cache
+Rule 'Azure.Redis.FirewallIPRange' -Ref 'AZR-000294' -Type 'Microsoft.Cache/redis', 'Microsoft.Cache/redis/firewallRules' -Tag @{ release = 'GA'; ruleSet = '2022_09'; } {
+
+    $services = @($TargetObject);
+
+    if ($PSRule.TargetType -eq 'Microsoft.Cache/redis') {
+        $services = @(GetSubResources -ResourceType 'Microsoft.Cache/redis/firewallRules');
+    }
+
+    if ($services.Length -eq 0) {
+        return $Assert.Fail($LocalizedData.SubResourceNotFound, 'Microsoft.Cache/redis/firewallRules');
+    }
+
+    $summary = GetIPAddressSummary
+    $summary.Public = [int32]$summary.Public # Had to convert $summary.Public to int32 from uint64.
+
     $Assert.
         LessOrEqual($summary, 'Public', 10).
         WithReason(($LocalizedData.DBServerFirewallPublicIPRange -f $summary.Public, 10), $True); 

--- a/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.ps1
@@ -87,9 +87,7 @@ Rule 'Azure.RedisEnterprise.Zones' -Ref 'AZR-000162' -Type 'Microsoft.Cache/redi
 Rule 'Azure.Redis.FirewallIPRange' -Ref 'AZR-000293' -Type 'Microsoft.Cache/Redis' -Tag @{ release = 'GA'; ruleSet = '2022_09'; } {
 
     $summary = GetIPAddressSummary
-    $Assert
-        .LessOrEqual($summary, 'Public', 10)
-        .WithReason(($LocalizedData.DBServerFirewallPublicIPRange -f $summary.Public, 10), $True);
+    $Assert.LessOrEqual($summary, 'Public', 10).WithReason(($LocalizedData.DBServerFirewallPublicIPRange -f $summary.Public, 10), $True);
     
 }
 

--- a/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.ps1
@@ -83,6 +83,16 @@ Rule 'Azure.RedisEnterprise.Zones' -Ref 'AZR-000162' -Type 'Microsoft.Cache/redi
 
 } -Configure @{ AZURE_REDISENTERPRISECACHE_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST = @() }
 
+# Synopsis: Determine if there is an excessive number of permitted IP addresses for the Redis Cache
+Rule 'Azure.Redis.FirewallIPRange' -Ref 'AZR-000293' -Type 'Microsoft.Cache/Redis' -Tag @{ release = 'GA'; ruleSet = '2022_09'; } {
+
+    $summary = GetIPAddressSummary
+    $Assert
+        .LessOrEqual($summary, 'Public', 10)
+        .WithReason(($LocalizedData.DBServerFirewallPublicIPRange -f $summary.Public, 10), $True);
+    
+}
+
 #region Helper functions
 
 function global:GetCacheMemory {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Redis.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Redis.Tests.ps1
@@ -204,6 +204,47 @@ Describe 'Azure.Redis' -Tag 'Redis' {
             $ruleResult.TargetName | Should -BeIn 'redis-K', 'redis-L', 'redis-M', 'redis-N', 'redis-O', 'redis-P';
         }
 
+        It 'Azure.Redis.FirewallRuleCount' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Redis.FirewallRuleCount' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 9;
+            $ruleResult.TargetName | Should -BeIn 'redis-C', 'redis-E', 'redis-F', 'redis-G', 'redis-H', 'redis-I', 'redis-J', 'redis-Q', 'redis-R';
+
+            $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[0].Reason | Should -BeExactly "The number of firewall rules (11) exceeded 10.";
+            $ruleResult[1].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[1].Reason | Should -BeExactly "The number of firewall rules (11) exceeded 10.";
+            $ruleResult[2].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[2].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+            $ruleResult[3].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[3].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+            $ruleResult[4].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[4].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+            $ruleResult[5].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[5].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+            $ruleResult[6].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[6].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+            $ruleResult[7].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[7].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+            $ruleResult[8].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[8].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'redis-A', 'redis-B', 'redis-D';
+
+            # None 
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'redis-K', 'redis-L', 'redis-M', 'redis-N', 'redis-O', 'redis-P';
+        }
+
         It 'Azure.Redis.FirewallIPRange' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Redis.FirewallIPRange' };
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Redis.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Redis.Tests.ps1
@@ -203,6 +203,45 @@ Describe 'Azure.Redis' -Tag 'Redis' {
             $ruleResult.Length | Should -Be 6;
             $ruleResult.TargetName | Should -BeIn 'redis-K', 'redis-L', 'redis-M', 'redis-N', 'redis-O', 'redis-P';
         }
+
+        It 'Azure.Redis.FirewallIPRange' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Redis.FirewallIPRange' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 8;
+            $ruleResult.TargetName | Should -BeIn 'redis-E', 'redis-F', 'redis-G', 'redis-H', 'redis-I', 'redis-J', 'redis-Q', 'redis-R';
+
+            $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[0].Reason | Should -BeExactly "The number of public IP addresses permitted (11) exceeded 10.";
+            $ruleResult[1].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[1].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+            $ruleResult[2].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[2].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+            $ruleResult[3].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[3].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+            $ruleResult[4].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[4].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+            $ruleResult[5].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[5].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+            $ruleResult[6].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[6].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+            $ruleResult[7].Reason | Should -Not -BeNullOrEmpty;
+            $ruleResult[7].Reason | Should -BeExactly "A sub-resource of type 'Microsoft.Cache/redis/firewallRules' has not been specified.";
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'redis-A', 'redis-B', 'redis-C', 'redis-D';
+
+            # None 
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'redis-K', 'redis-L', 'redis-M', 'redis-N', 'redis-O', 'redis-P';
+        }
     }
 
     Context 'With Configuration Option' -Tag 'Configuration' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Redis.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Redis.json
@@ -27,7 +27,21 @@
             "sslPort": 6380,
             "linkedServers": [],
             "publicNetworkAccess": "Disabled"
-        }
+        },
+        "Resources": [
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_1",
+                "ResourceName": "ClientIPAddress_1",
+                "Properties": {
+                    "startIpAddress": "10.1.1.1",
+                    "endIpAddress": "10.1.1.1"
+                }
+            }
+        ]
     },
     {
         "Name": "redis-B",
@@ -56,7 +70,129 @@
             "sslPort": 6380,
             "linkedServers": [],
             "publicNetworkAccess": "Enabled"
-        }
+        },
+        "Resources": [
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_1",
+                "ResourceName": "ClientIPAddress_1",
+                "Properties": {
+                    "startIpAddress": "10.1.1.1",
+                    "endIpAddress": "10.1.1.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_2",
+                "ResourceName": "ClientIPAddress_2",
+                "Properties": {
+                    "startIpAddress": "10.1.2.1",
+                    "endIpAddress": "10.1.2.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_3",
+                "ResourceName": "ClientIPAddress_3",
+                "Properties": {
+                    "startIpAddress": "10.1.3.1",
+                    "endIpAddress": "10.1.3.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_4",
+                "ResourceName": "ClientIPAddress_4",
+                "Properties": {
+                    "startIpAddress": "10.1.4.1",
+                    "endIpAddress": "10.1.4.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_5",
+                "ResourceName": "ClientIPAddress_5",
+                "Properties": {
+                    "startIpAddress": "10.1.5.1",
+                    "endIpAddress": "10.1.5.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_6",
+                "ResourceName": "ClientIPAddress_6",
+                "Properties": {
+                    "startIpAddress": "10.1.6.1",
+                    "endIpAddress": "10.1.6.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_7",
+                "ResourceName": "ClientIPAddress_7",
+                "Properties": {
+                    "startIpAddress": "10.1.7.1",
+                    "endIpAddress": "10.1.7.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_8",
+                "ResourceName": "ClientIPAddress_8",
+                "Properties": {
+                    "startIpAddress": "10.1.8.1",
+                    "endIpAddress": "10.1.8.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_9",
+                "ResourceName": "ClientIPAddress_9",
+                "Properties": {
+                    "startIpAddress": "10.1.9.1",
+                    "endIpAddress": "10.1.9.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_10",
+                "ResourceName": "ClientIPAddress_10",
+                "Properties": {
+                    "startIpAddress": "10.1.10.1",
+                    "endIpAddress": "10.1.10.1"
+                }
+            }
+        ]
     },
     {
         "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Cache/Redis/redis-C",
@@ -101,6 +237,140 @@
             "sslPort": 6380,
             "linkedServers": []
         },
+        "Resources": [
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_1",
+                "ResourceName": "ClientIPAddress_1",
+                "Properties": {
+                    "startIpAddress": "10.1.1.1",
+                    "endIpAddress": "10.1.1.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_2",
+                "ResourceName": "ClientIPAddress_2",
+                "Properties": {
+                    "startIpAddress": "10.1.2.1",
+                    "endIpAddress": "10.1.2.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_3",
+                "ResourceName": "ClientIPAddress_3",
+                "Properties": {
+                    "startIpAddress": "10.1.3.1",
+                    "endIpAddress": "10.1.3.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_4",
+                "ResourceName": "ClientIPAddress_4",
+                "Properties": {
+                    "startIpAddress": "10.1.4.1",
+                    "endIpAddress": "10.1.4.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_5",
+                "ResourceName": "ClientIPAddress_5",
+                "Properties": {
+                    "startIpAddress": "10.1.5.1",
+                    "endIpAddress": "10.1.5.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_6",
+                "ResourceName": "ClientIPAddress_6",
+                "Properties": {
+                    "startIpAddress": "10.1.6.1",
+                    "endIpAddress": "10.1.6.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_7",
+                "ResourceName": "ClientIPAddress_7",
+                "Properties": {
+                    "startIpAddress": "10.1.7.1",
+                    "endIpAddress": "10.1.7.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_8",
+                "ResourceName": "ClientIPAddress_8",
+                "Properties": {
+                    "startIpAddress": "10.1.8.1",
+                    "endIpAddress": "10.1.8.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_9",
+                "ResourceName": "ClientIPAddress_9",
+                "Properties": {
+                    "startIpAddress": "10.1.9.1",
+                    "endIpAddress": "10.1.9.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_10",
+                "ResourceName": "ClientIPAddress_10",
+                "Properties": {
+                    "startIpAddress": "10.1.10.1",
+                    "endIpAddress": "10.1.10.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_11",
+                "ResourceName": "ClientIPAddress_11",
+                "Properties": {
+                    "startIpAddress": "10.1.11.1",
+                    "endIpAddress": "10.1.11.1"
+                }
+            }
+        ],
         "ResourceGroupName": "test-rg",
         "Type": "Microsoft.Cache/Redis",
         "ResourceType": "Microsoft.Cache/Redis",
@@ -156,6 +426,128 @@
             "sslPort": 6380,
             "linkedServers": []
         },
+        "Resources": [
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_1",
+                "ResourceName": "ClientIPAddress_1",
+                "Properties": {
+                    "startIpAddress": "17.1.1.1",
+                    "endIpAddress": "17.1.1.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_2",
+                "ResourceName": "ClientIPAddress_2",
+                "Properties": {
+                    "startIpAddress": "17.1.2.1",
+                    "endIpAddress": "17.1.2.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_3",
+                "ResourceName": "ClientIPAddress_3",
+                "Properties": {
+                    "startIpAddress": "17.1.3.1",
+                    "endIpAddress": "17.1.3.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_4",
+                "ResourceName": "ClientIPAddress_4",
+                "Properties": {
+                    "startIpAddress": "17.1.4.1",
+                    "endIpAddress": "17.1.4.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_5",
+                "ResourceName": "ClientIPAddress_5",
+                "Properties": {
+                    "startIpAddress": "17.1.5.1",
+                    "endIpAddress": "17.1.5.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_6",
+                "ResourceName": "ClientIPAddress_6",
+                "Properties": {
+                    "startIpAddress": "17.1.6.1",
+                    "endIpAddress": "17.1.6.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_7",
+                "ResourceName": "ClientIPAddress_7",
+                "Properties": {
+                    "startIpAddress": "17.1.7.1",
+                    "endIpAddress": "17.1.7.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_8",
+                "ResourceName": "ClientIPAddress_8",
+                "Properties": {
+                    "startIpAddress": "17.1.8.1",
+                    "endIpAddress": "17.1.8.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_9",
+                "ResourceName": "ClientIPAddress_9",
+                "Properties": {
+                    "startIpAddress": "17.1.9.1",
+                    "endIpAddress": "17.1.9.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_10",
+                "ResourceName": "ClientIPAddress_10",
+                "Properties": {
+                    "startIpAddress": "17.1.10.1",
+                    "endIpAddress": "17.1.10.1"
+                }
+            }
+        ],
         "ResourceGroupName": "test-rg",
         "Type": "Microsoft.Cache/Redis",
         "ResourceType": "Microsoft.Cache/Redis",
@@ -196,6 +588,140 @@
             "linkedServers": [],
             "replicasPerMaster": 2
         },
+        "Resources": [
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_1",
+                "ResourceName": "ClientIPAddress_1",
+                "Properties": {
+                    "startIpAddress": "17.1.1.1",
+                    "endIpAddress": "17.1.1.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_2",
+                "ResourceName": "ClientIPAddress_2",
+                "Properties": {
+                    "startIpAddress": "17.1.2.1",
+                    "endIpAddress": "17.1.2.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_3",
+                "ResourceName": "ClientIPAddress_3",
+                "Properties": {
+                    "startIpAddress": "17.1.3.1",
+                    "endIpAddress": "17.1.3.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_4",
+                "ResourceName": "ClientIPAddress_4",
+                "Properties": {
+                    "startIpAddress": "17.1.4.1",
+                    "endIpAddress": "17.1.4.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_5",
+                "ResourceName": "ClientIPAddress_5",
+                "Properties": {
+                    "startIpAddress": "17.1.5.1",
+                    "endIpAddress": "17.1.5.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_6",
+                "ResourceName": "ClientIPAddress_6",
+                "Properties": {
+                    "startIpAddress": "17.1.6.1",
+                    "endIpAddress": "17.1.6.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_7",
+                "ResourceName": "ClientIPAddress_7",
+                "Properties": {
+                    "startIpAddress": "17.1.7.1",
+                    "endIpAddress": "17.1.7.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_8",
+                "ResourceName": "ClientIPAddress_8",
+                "Properties": {
+                    "startIpAddress": "17.1.8.1",
+                    "endIpAddress": "17.1.8.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_9",
+                "ResourceName": "ClientIPAddress_9",
+                "Properties": {
+                    "startIpAddress": "17.1.9.1",
+                    "endIpAddress": "17.1.9.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_10",
+                "ResourceName": "ClientIPAddress_10",
+                "Properties": {
+                    "startIpAddress": "17.1.10.1",
+                    "endIpAddress": "17.1.10.1"
+                }
+            },
+            {
+                "Type": "Microsoft.Cache/redis/firewallRules",
+                "ResourceType": "Microsoft.Cache/redis/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "ResourceGroupName": "test-rg",
+                "Name": "ClientIPAddress_11",
+                "ResourceName": "ClientIPAddress_11",
+                "Properties": {
+                    "startIpAddress": "17.1.11.1",
+                    "endIpAddress": "17.1.11.1"
+                }
+            }
+        ],
         "zones": [
             "2",
             "3",


### PR DESCRIPTION
## PR Summary

- Created Azure.Redis.FirewallRuleCount (AZR-000293) in Azure.Redis.Rule.ps1
- Created Azure.Redis.FirewallIPRule (AZR-000294) in Azure.Redis.Rule.ps1
- Created Azure.Redis.FirewallRuleCount documentation
- Created Azure.Redis.FirewallIpRule documentation.
- Created tests for both rules in Azure.Redis.Tests.ps1. 
- Updated redis-A, B, C, D, and E in Resources.Redis.json

## PR Checklist

- [X] PR has a meaningful title
- [X] Summarized changes
- [X] Change is not breaking
- [X] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [X] Unit tests created/ updated
  - [X] Rule documentation created/ updated
  - [X] Link to a filed issue
  - [X] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
