### PR TITLE
Handle key collision with duplicate definitions using same parameters

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             "name": "Debug PSRule.Rules.Azure Cmdlets",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "Build",
+            "preLaunchTask": "build",
             "program": "pwsh",
             "args": [
                 "-NoExit",

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -33,6 +33,9 @@ What's changed since pre-release v1.20.0-B0148:
     [#1636](https://github.com/Azure/PSRule.Rules.Azure/pull/1636)
   - Bump PSScriptAnalyzer to v1.21.0.
     [#1636](https://github.com/Azure/PSRule.Rules.Azure/pull/1636)
+- Bug fixes:
+  - Handle key collision with duplicate definitions using same parameters by @ArmaanMcleod.
+    [#1653](https://github.com/Azure/PSRule.Rules.Azure/issues/1653)
 
 ## v1.20.0-B0148 (pre-release)
 

--- a/src/PSRule.Rules.Azure/Common/JsonConverters.cs
+++ b/src/PSRule.Rules.Azure/Common/JsonConverters.cs
@@ -24,7 +24,7 @@ namespace PSRule.Rules.Azure
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            if (!(value is PSObject obj))
+            if (value is not PSObject obj)
                 throw new ArgumentException(message: PSRuleResources.SerializeNullPSObject, paramName: nameof(value));
 
             if (value is FileSystemInfo fileSystemInfo)

--- a/src/PSRule.Rules.Azure/Configuration/DeploymentOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/DeploymentOption.cs
@@ -19,8 +19,6 @@ namespace PSRule.Rules.Azure.Configuration
             Name = DEFAULT_NAME
         };
 
-        private string _Name;
-
         /// <summary>
         /// Creates an empty deployment option.
         /// </summary>
@@ -104,14 +102,7 @@ namespace PSRule.Rules.Azure.Configuration
         /// The name of the deployment.
         /// </summary>
         [DefaultValue(null)]
-        public string Name
-        {
-            get => _Name;
-            set
-            {
-                _Name = value;
-            }
-        }
+        public string Name { get; set; }
     }
 
     /// <summary>

--- a/src/PSRule.Rules.Azure/Data/Policy/Models.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/Models.cs
@@ -63,17 +63,20 @@ namespace PSRule.Rules.Azure.Data.Policy
     /// </summary>
     internal sealed class PolicyDefinition
     {
-        private readonly IDictionary<string, IParameterValue> _Parameters;
-
         public PolicyDefinition(string definitionId, string name, string description, JObject value)
         {
             DefinitionId = definitionId;
             Name = name;
             Description = description;
             Value = value;
-            _Parameters = new Dictionary<string, IParameterValue>(StringComparer.OrdinalIgnoreCase);
+            Parameters = new Dictionary<string, IParameterValue>(StringComparer.OrdinalIgnoreCase);
             Types = new List<string>();
         }
+
+        /// <summary>
+        /// The policy definition parameters
+        /// </summary>
+        public readonly IDictionary<string, IParameterValue> Parameters;
 
         /// <summary>
         /// The policy definition id.
@@ -122,17 +125,17 @@ namespace PSRule.Rules.Azure.Data.Policy
 
         internal void AddParameter(string name, ParameterType type, object value)
         {
-            _Parameters.Add(name, new SimpleParameterValue(name, type, value));
+            Parameters.Add(name, new SimpleParameterValue(name, type, value));
         }
 
         internal void AddParameter(IParameterValue value)
         {
-            _Parameters.Add(value.Name, value);
+            Parameters.Add(value.Name, value);
         }
 
         internal bool TryParameter(string parameterName, out IParameterValue value)
         {
-            return _Parameters.TryGetValue(parameterName, out value);
+            return Parameters.TryGetValue(parameterName, out value);
         }
     }
 

--- a/src/PSRule.Rules.Azure/Data/Policy/Models.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/Models.cs
@@ -132,11 +132,6 @@ namespace PSRule.Rules.Azure.Data.Policy
         {
             Parameters.Add(value.Name, value);
         }
-
-        internal bool TryParameter(string parameterName, out IParameterValue value)
-        {
-            return Parameters.TryGetValue(parameterName, out value);
-        }
     }
 
     internal interface ILazyValue

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
@@ -673,7 +673,10 @@ namespace PSRule.Rules.Azure.Data.Policy
             }
         }
 
-        private static bool AreParametersEqual(PolicyAssignmentContext context, IParameterValue paramA, IParameterValue paramB)
+        /// <summary>
+        /// Checks if two parameters are equal
+        /// </summary>
+        private static bool ParametersEqual(PolicyAssignmentContext context, IParameterValue paramA, IParameterValue paramB)
         {
             var typeA = paramA.Type;
             var typeB = paramB.Type;
@@ -741,7 +744,7 @@ namespace PSRule.Rules.Azure.Data.Policy
                     {
                         if (previousDefinition.TryParameter(currentParameter.Key, out var previousParameterValue))
                         {
-                            if (!AreParametersEqual(context, previousParameterValue, currentParameter.Value))
+                            if (!ParametersEqual(context, previousParameterValue, currentParameter.Value))
                             {
                                 foundDuplicateDefinition = false;
                                 break;

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
@@ -687,10 +687,16 @@ namespace PSRule.Rules.Azure.Data.Policy
                 return valueA.ToString().Equals(valueB.ToString(), StringComparison.OrdinalIgnoreCase);
 
             if (typeA == ParameterType.Integer && typeB == ParameterType.Integer)
-                return Convert.ToInt32(valueA, Thread.CurrentThread.CurrentCulture) == Convert.ToInt32(valueB, Thread.CurrentThread.CurrentCulture);
+                return Convert.ToInt64(valueA, Thread.CurrentThread.CurrentCulture) == Convert.ToInt64(valueB, Thread.CurrentThread.CurrentCulture);
 
             if (typeA == ParameterType.Boolean && typeB == ParameterType.Boolean)
                 return Convert.ToBoolean(valueA, Thread.CurrentThread.CurrentCulture) == Convert.ToBoolean(valueB, Thread.CurrentThread.CurrentCulture);
+
+            if (typeA == ParameterType.Array && typeB == ParameterType.Array)
+                return JToken.DeepEquals(JArray.FromObject(valueA), JArray.FromObject(valueB));
+
+            if (typeA == ParameterType.Object && typeB == ParameterType.Object)
+                return JToken.DeepEquals(JObject.FromObject(valueA), JObject.FromObject(valueB));
 
             // TODO: Handle more types
 

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
@@ -750,18 +750,12 @@ namespace PSRule.Rules.Azure.Data.Policy
                         }
                     }
 
-                    // Overwrite definition if we found differences
-                    if (!foundDuplicateDefinition)
-                        context.DefinitionParameterMap[policyDefinitionId] = policyDefinition.Parameters;
-
-                    // Otherwise skip adding definition
-                    else
+                    // Skip adding definition if duplicate parameters found
+                    if (foundDuplicateDefinition)
                         return false;
                 }
 
-                // Add definition for the first time
-                else
-                    context.DefinitionParameterMap.Add(policyDefinitionId, policyDefinition.Parameters);
+                context.DefinitionParameterMap[policyDefinitionId] = result.Parameters;
             }
 
             // Modify policy rule

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
@@ -248,14 +248,14 @@ namespace PSRule.Rules.Azure.Data.Template
     [DebuggerDisplay("Function: {Name}")]
     internal sealed class FunctionDescriptor : IFunctionDescriptor
     {
-        private readonly ExpressionFn Fn;
-        private readonly bool DelayBinding;
+        private readonly ExpressionFn _Fn;
+        private readonly bool _DelayBinding;
 
         public FunctionDescriptor(string name, ExpressionFn fn, bool delayBinding = false)
         {
             Name = name;
-            Fn = fn;
-            DelayBinding = delayBinding;
+            _Fn = fn;
+            _DelayBinding = delayBinding;
         }
 
         public string Name { get; }
@@ -264,9 +264,9 @@ namespace PSRule.Rules.Azure.Data.Template
         {
             var parameters = new object[args.Length];
             for (var i = 0; i < args.Length; i++)
-                parameters[i] = DelayBinding ? args[i] : args[i](context);
+                parameters[i] = _DelayBinding ? args[i] : args[i](context);
 
-            return Fn(context, parameters);
+            return _Fn(context, parameters);
         }
     }
 

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
@@ -19,7 +19,7 @@ namespace PSRule.Rules.Azure.Data.Template
         private const string TRUE = "True";
         private const string FALSE = "False";
 
-        private static readonly CultureInfo AzureCulture = new CultureInfo("en-US");
+        private static readonly CultureInfo AzureCulture = new("en-US");
 
         internal static bool TryString(object o, out string value)
         {
@@ -307,7 +307,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 value = mock.Value;
                 return true;
             }
-            value = default(long);
+            value = default;
             return false;
         }
 
@@ -322,7 +322,7 @@ namespace PSRule.Rules.Azure.Data.Template
             if (TryString(o, out var svalue) && long.TryParse(svalue, out value))
                 return true;
 
-            value = default(long);
+            value = default;
             return false;
         }
 
@@ -351,7 +351,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 value = (int)mock.Value;
                 return true;
             }
-            value = default(int);
+            value = default;
             return false;
         }
 
@@ -372,7 +372,7 @@ namespace PSRule.Rules.Azure.Data.Template
             if (TryString(o, out var s) && int.TryParse(s, out value))
                 return true;
 
-            value = default(int);
+            value = default;
             return false;
         }
 
@@ -396,7 +396,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 value = mock.Value;
                 return true;
             }
-            value = default(bool);
+            value = default;
             return false;
         }
 
@@ -419,7 +419,7 @@ namespace PSRule.Rules.Azure.Data.Template
 
         internal static bool TryArray<T>(object o, out T value) where T : class
         {
-            value = default(T);
+            value = default;
             if (o is JArray jArray)
             {
                 value = jArray as T;

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -151,7 +151,7 @@ namespace PSRule.Rules.Azure.Data.Template
             new FunctionDescriptor("uriComponentToString", UriComponentToString),
         };
 
-        private static readonly CultureInfo AzureCulture = new CultureInfo("en-US");
+        private static readonly CultureInfo AzureCulture = new("en-US");
 
         #region Array and object
 
@@ -380,9 +380,11 @@ namespace PSRule.Rules.Azure.Data.Template
                 var result = new JArray();
                 foreach (var item in jObject.Properties().OrderBy(p => p.Name))
                 {
-                    var i = new JObject();
-                    i.Add("key", item.Name);
-                    i.Add("value", item.Value);
+                    var i = new JObject
+                    {
+                        { "key", item.Name },
+                        { "value", item.Value }
+                    };
                     result.Add(i);
                 }
                 return result;

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -1653,7 +1653,7 @@ namespace PSRule.Rules.Azure.Data.Template
         protected static T EvaluateExpression<T>(ITemplateContext context, JToken value)
         {
             if (value.Type != JTokenType.String)
-                return default(T);
+                return default;
 
             var svalue = value.Value<string>();
             var lineInfo = value.TryLineInfo();
@@ -1663,7 +1663,7 @@ namespace PSRule.Rules.Azure.Data.Template
         protected static T EvaluateExpression<T>(ITemplateContext context, string value, IJsonLineInfo lineInfo)
         {
             if (string.IsNullOrEmpty(value))
-                return default(T);
+                return default;
 
             var exp = Expression<T>(context, value);
             try

--- a/src/PSRule.Rules.Azure/Pipeline/TemplatePipeline.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/TemplatePipeline.cs
@@ -19,7 +19,7 @@ namespace PSRule.Rules.Azure.Pipeline
         /// <inheritdoc/>
         public override void Process(PSObject sourceObject)
         {
-            if (sourceObject == null || !(sourceObject.BaseObject is TemplateSource source))
+            if (sourceObject == null || sourceObject.BaseObject is not TemplateSource source)
                 return;
 
             if (source.ParametersFile == null || source.ParametersFile.Length == 0)

--- a/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
@@ -714,6 +714,11 @@ Describe 'Export-AzPolicyAssignmentRuleData' -Tag 'Cmdlet', 'Export-AzPolicyAssi
             Name           = 'test10'
             Index          = 9
             AssignmentFile = (Join-Path -Path $here -ChildPath 'test10.assignment.json')
+        },
+        @{
+            Name           = 'test11'
+            Index          = 10
+            AssignmentFile = (Join-Path -Path $here -ChildPath 'test11.assignment.json')
         }
     ) {
         param($Name, $Index, $AssignmentFile)
@@ -741,7 +746,7 @@ Describe 'Get-AzPolicyAssignmentDataSource' -Tag 'Cmdlet', 'Get-AzPolicyAssignme
 
     It 'Get assignment sources from current working directory' {
         $sources = Get-AzPolicyAssignmentDataSource | Where-Object { $_.AssignmentFile -notlike "*Policy.assignment.json" } | Sort-Object { [int](Split-Path -Path $_.AssignmentFile -Leaf).Split('.')[0].TrimStart('test') }
-        $sources.Length | Should -Be 10;
+        $sources.Length | Should -Be 11;
         $sources[0].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test.assignment.json');
         $sources[1].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test2.assignment.json');
         $sources[2].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test3.assignment.json');
@@ -752,11 +757,12 @@ Describe 'Get-AzPolicyAssignmentDataSource' -Tag 'Cmdlet', 'Get-AzPolicyAssignme
         $sources[7].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test8.assignment.json');
         $sources[8].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test9.assignment.json');
         $sources[9].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test10.assignment.json');
+        $sources[10].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test11.assignment.json');
     }
 
     It 'Get assignment sources from tests folder' {
         $sources = Get-AzPolicyAssignmentDataSource -Path $here | Where-Object { $_.AssignmentFile -notlike "*Policy.assignment.json" } | Sort-Object { [int](Split-Path -Path $_.AssignmentFile -Leaf).Split('.')[0].TrimStart('test') }
-        $sources.Length | Should -Be 10;
+        $sources.Length | Should -Be 11;
         $sources[0].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test.assignment.json');
         $sources[1].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test2.assignment.json');
         $sources[2].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test3.assignment.json');
@@ -767,6 +773,7 @@ Describe 'Get-AzPolicyAssignmentDataSource' -Tag 'Cmdlet', 'Get-AzPolicyAssignme
         $sources[7].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test8.assignment.json');
         $sources[8].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test9.assignment.json');
         $sources[9].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test10.assignment.json');
+        $sources[10].AssignmentFile | Should -BeExactly (Join-Path -Path $here -ChildPath 'test11.assignment.json');
     }
 
     It 'Pipe to Export-AzPolicyAssignmentRuleData and generate JSON rules' {

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -47,7 +47,7 @@ namespace PSRule.Rules.Azure
             Assert.Empty(actual4);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Array(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Array(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Array(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Array(context, new object[] { "abcd", "efgh" }));
         }
 
@@ -69,7 +69,7 @@ namespace PSRule.Rules.Azure
             Assert.Null(actual5);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Coalesce(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Coalesce(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Coalesce(context, System.Array.Empty<object>()));
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace PSRule.Rules.Azure
             var actual2 = Functions.CreateArray(context, new object[] { "efgh" }) as JArray;
             var actual3 = Functions.CreateArray(context, new object[] { JObject.Parse("{ \"a\": \"b\", \"c\": \"d\" }"), JObject.Parse("{ \"e\": \"f\", \"g\": \"h\" }") }) as JArray;
             var actual4 = Functions.CreateArray(context, null) as JArray;
-            var actual5 = Functions.CreateArray(context, new object[] { }) as JArray;
+            var actual5 = Functions.CreateArray(context, System.Array.Empty<object>()) as JArray;
             var actual6 = Functions.CreateArray(context, new object[] {
                 "value1",
                 new MockResource("Microsoft.Resources/deployments").MockMember("outputs").MockMember("aksSubnetId").MockMember("value"),
@@ -143,7 +143,7 @@ namespace PSRule.Rules.Azure
                 "objectProp", Functions.CreateObject(context, new object[] { "key1", "value1" }),
                 "mockProp", new MockResource("Microsoft.Resources/deployments").MockMember("outputs").MockMember("aksSubnetId").MockMember("value"),
             }) as JObject;
-            var actual2 = Functions.CreateObject(context, new object[] { }) as JObject;
+            var actual2 = Functions.CreateObject(context, System.Array.Empty<object>()) as JObject;
             var actual3 = Functions.CreateObject(context, new object[] {
                 "intProp", new MockInteger(1),
                 "stringProp", new MockString("mock"),
@@ -212,7 +212,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("one", actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.First(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.First(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.First(context, System.Array.Empty<object>()));
         }
 
         [Fact]
@@ -234,7 +234,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("c", actual2["three"]);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Intersection(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Intersection(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Intersection(context, System.Array.Empty<object>()));
             Assert.Throws<ArgumentException>(() => Functions.Intersection(context, new object[] { "one", "two", "three" }));
         }
 
@@ -260,7 +260,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("b", actual1["a"]);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Json(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Json(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Json(context, System.Array.Empty<object>()));
         }
 
         [Fact]
@@ -270,7 +270,7 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             var actual1 = Functions.Null(context, null);
-            var actual2 = Functions.Null(context, new object[] { });
+            var actual2 = Functions.Null(context, System.Array.Empty<object>());
 
             Assert.Null(actual1);
             Assert.Null(actual2);
@@ -310,7 +310,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal(4, actual3);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Length(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Length(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Length(context, System.Array.Empty<object>()));
         }
 
         [Fact]
@@ -336,7 +336,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal(8, actual6);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Max(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Max(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Max(context, System.Array.Empty<object>()));
             Assert.Throws<ArgumentException>(() => Functions.Max(context, new object[] { "one", "two" }));
             Assert.Throws<ArgumentException>(() => Functions.Max(context, new object[] { 1, "0" }));
         }
@@ -364,7 +364,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal(4, actual6);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Min(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Min(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Min(context, System.Array.Empty<object>()));
             Assert.Throws<ArgumentException>(() => Functions.Min(context, new object[] { "one", "two" }));
             Assert.Throws<ArgumentException>(() => Functions.Min(context, new object[] { 1, "0" }));
         }
@@ -388,7 +388,7 @@ namespace PSRule.Rules.Azure
             Assert.Empty(actual3);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Range(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Range(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Range(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Range(context, new object[] { 1 }));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Range(context, new object[] { "one", "two" }));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Range(context, new object[] { 1, "0" }));
@@ -460,8 +460,10 @@ namespace PSRule.Rules.Azure
         public void Union()
         {
             var context = GetContext();
-            var hashtable = new Hashtable();
-            hashtable["a"] = 200;
+            var hashtable = new Hashtable
+            {
+                ["a"] = 200
+            };
 
             // Union objects
             var actual1 = Functions.Union(context, new object[] { JObject.Parse("{ \"a\": \"b\", \"c\": \"d\" }"), JObject.Parse("{ \"e\": \"f\", \"g\": \"h\" }"), JObject.Parse("{ \"i\": \"j\" }"), JObject.Parse("{ \"a\": \"100\" }") }) as JObject;
@@ -984,7 +986,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal(utc.AddYears(3), actual4);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.DateTimeAdd(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.DateTimeAdd(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.DateTimeAdd(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.DateTimeAdd(context, new object[] { 1, 2 }));
             Assert.Throws<ExpressionArgumentException>(() => Functions.DateTimeAdd(context, new object[] { utc.ToString("u"), 2 }));
         }
@@ -1004,7 +1006,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("2023-05-02T15:16:13Z", actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.DateTimeFromEpoch(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.DateTimeFromEpoch(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.DateTimeFromEpoch(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.DateTimeFromEpoch(context, new object[] { 1, 2 }));
         }
 
@@ -1023,7 +1025,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal(1683040573, actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.DateTimeToEpoch(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.DateTimeToEpoch(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.DateTimeToEpoch(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.DateTimeToEpoch(context, new object[] { 1, 2 }));
         }
 
@@ -1034,7 +1036,7 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
             var utc = DateTime.UtcNow;
 
-            var actual1 = Functions.UtcNow(context, new object[] { }) as string;
+            var actual1 = Functions.UtcNow(context, System.Array.Empty<object>()) as string;
             var actual2 = Functions.UtcNow(context, new object[] { "d" }) as string;
             var actual3 = Functions.UtcNow(context, new object[] { "M d" }) as string;
             Assert.Matches("[0-9]{8}T[0-9]{6}Z", actual1);
@@ -1088,7 +1090,7 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             var actual1 = (bool)Functions.False(context, null);
-            var actual2 = (bool)Functions.False(context, new object[] { });
+            var actual2 = (bool)Functions.False(context, System.Array.Empty<object>());
             Assert.False(actual1);
             Assert.False(actual2);
 
@@ -1146,7 +1148,7 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             var actual1 = (bool)Functions.True(context, null);
-            var actual2 = (bool)Functions.True(context, new object[] { });
+            var actual2 = (bool)Functions.True(context, System.Array.Empty<object>());
             Assert.True(actual1);
             Assert.True(actual2);
 
@@ -1240,7 +1242,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal(3.0f, actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Float(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Float(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Float(context, System.Array.Empty<object>()));
             Assert.Throws<FormatException>(() => Functions.Float(context, new object[] { "one" }));
         }
 
@@ -1259,7 +1261,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal(4, actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Int(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Int(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Int(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Int(context, new object[] { "one" }));
         }
 
@@ -1330,7 +1332,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("eydvbmUnOiAnYScsICd0d28nOiAnYid9", actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Base64(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Base64(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Base64(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Base64(context, new object[] { 1 }));
         }
 
@@ -1345,7 +1347,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("b", actual1["two"]);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Base64ToJson(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Base64ToJson(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Base64ToJson(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Base64ToJson(context, new object[] { 1 }));
         }
 
@@ -1359,7 +1361,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("one, two, three", actual1);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Base64ToString(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Base64ToString(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Base64ToString(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Base64ToString(context, new object[] { 1 }));
         }
 
@@ -1373,7 +1375,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("data:text/plain;charset=utf8;base64,SGVsbG8=", actual1);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.DataUri(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.DataUri(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.DataUri(context, System.Array.Empty<object>()));
             Assert.Throws<ArgumentException>(() => Functions.DataUri(context, new object[] { 1 }));
         }
 
@@ -1391,7 +1393,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("Hello", actual3);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.DataUriToString(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.DataUriToString(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.DataUriToString(context, System.Array.Empty<object>()));
             Assert.Throws<ArgumentException>(() => Functions.DataUriToString(context, new object[] { 1 }));
             Assert.Throws<ArgumentException>(() => Functions.DataUriToString(context, new object[] { "SGVsbG8sIFdvcmxkIQ==" }));
         }
@@ -1546,7 +1548,7 @@ namespace PSRule.Rules.Azure
         {
             var context = GetContext();
 
-            var actual1 = Functions.NewGuid(context, new object[] { }) as string;
+            var actual1 = Functions.NewGuid(context, System.Array.Empty<object>()) as string;
             Assert.Equal(36, actual1.Length);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.NewGuid(context, new object[] { "test" }));
@@ -1564,7 +1566,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("       123", actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.PadLeft(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.PadLeft(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.PadLeft(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.PadLeft(context, new object[] { "test" }));
             Assert.Throws<ExpressionArgumentException>(() => Functions.PadLeft(context, new object[] { "test", 10, "test", "test" }));
             Assert.Throws<ExpressionArgumentException>(() => Functions.PadLeft(context, new object[] { 10, "10" }));
@@ -1672,7 +1674,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("o", actual4);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.ToLower(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.ToLower(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.ToLower(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.ToLower(context, new object[] { "One", "Two", "Three" }));
             Assert.Throws<ArgumentException>(() => Functions.ToLower(context, new object[] { 2 }));
         }
@@ -1696,7 +1698,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("O", actual4);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.ToUpper(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.ToUpper(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.ToUpper(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.ToUpper(context, new object[] { "One", "Two", "Three" }));
             Assert.Throws<ArgumentException>(() => Functions.ToUpper(context, new object[] { 2 }));
         }
@@ -1713,7 +1715,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("one two three", actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Trim(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Trim(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Trim(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Trim(context, new object[] { "One", "Two", "Three" }));
             Assert.Throws<ArgumentException>(() => Functions.Trim(context, new object[] { 2 }));
         }
@@ -1730,7 +1732,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("4b9fe86f643d6", actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.UniqueString(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.UniqueString(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.UniqueString(context, System.Array.Empty<object>()));
             Assert.Throws<ArgumentException>(() => Functions.UniqueString(context, new object[] { "One", 2, "Three" }));
         }
 
@@ -1750,7 +1752,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("http://contoso.org/firstpath/azuredeploy.json/myscript.sh", actual4);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Uri(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Uri(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Uri(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Uri(context, new object[] { "http://contoso.org/firstpath", 2 }));
         }
 
@@ -1764,7 +1766,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("http%3a%2f%2fcontoso.com%2fresources%2fnested%2fazuredeploy.json", actual1);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.UriComponent(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.UriComponent(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.UriComponent(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.UriComponent(context, new object[] { 2 }));
         }
 
@@ -1778,7 +1780,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("http://contoso.com/resources/nested/azuredeploy.json", actual1);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.UriComponentToString(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.UriComponentToString(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.UriComponentToString(context, System.Array.Empty<object>()));
             Assert.Throws<ExpressionArgumentException>(() => Functions.UriComponentToString(context, new object[] { 2 }));
         }
 

--- a/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesData.jsonc
+++ b/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesData.jsonc
@@ -641,5 +641,29 @@
         ]
       }
     }
+  },
+  {
+    // Synopsis: CMA_0544 - View and configure system diagnostic data
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Rule",
+    "metadata": {
+      "name": "View and configure system diagnostic data",
+      "tags": {
+        "Azure.Policy/category": "Regulatory Compliance"
+      },
+      "annotations": {
+        "Azure.Policy/id": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
+        "Azure.Policy/version": "1.0.0"
+      }
+    },
+    "spec": {
+      "type": [
+        "Microsoft.Resources/subscriptions"
+      ],
+      "condition": {
+        "equals": "Microsoft.Resources/subscriptions",
+        "type": "."
+      }
+    }
   }
 ]

--- a/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesData.jsonc
+++ b/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesData.jsonc
@@ -643,7 +643,7 @@
     }
   },
   {
-    // Synopsis: CMA_0544 - View and configure system diagnostic data
+    // Synopsis: View and configure system diagnostic data
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "Rule",
     "metadata": {

--- a/tests/PSRule.Rules.Azure.Tests/test11.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test11.assignment.json
@@ -1,0 +1,124 @@
+[
+  {
+    "Identity": null,
+    "Location": null,
+    "Name": "000000000000000000000000",
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/000000000000000000000000",
+    "ResourceName": "000000000000000000000000",
+    "ResourceGroupName": null,
+    "ResourceType": "Microsoft.Authorization/policyAssignments",
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "Sku": null,
+    "PolicyAssignmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/000000000000000000000000",
+    "Properties": {
+      "Scope": "/subscriptions/00000000-0000-0000-0000-000000000000",
+      "NotScopes": [],
+      "DisplayName": "TestInitiative",
+      "Description": null,
+      "Metadata": {
+        "assignedBy": "Armaan McLeod",
+        "parameterScopes": {},
+        "createdBy": "e8c9aad1-7d2c-4d2a-9945-611b7379ee5d",
+        "createdOn": "2022-09-25T10:40:28.8553851Z",
+        "updatedBy": null,
+        "updatedOn": null
+      },
+      "EnforcementMode": 0,
+      "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/000000000000000000000000",
+      "Parameters": {},
+      "NonComplianceMessages": []
+    },
+    "PolicyDefinitions": [
+      {
+        "Name": "00000000-0000-0000-0000-000000000000",
+        "ResourceId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
+        "ResourceName": "00000000-0000-0000-0000-000000000000",
+        "ResourceType": "Microsoft.Authorization/policyDefinitions",
+        "SubscriptionId": null,
+        "Properties": {
+          "Description": "CMA_0544 - View and configure system diagnostic data",
+          "DisplayName": "View and configure system diagnostic data",
+          "Metadata": {
+            "version": "1.0.0",
+            "category": "Regulatory Compliance",
+            "additionalMetadataId": "/providers/Microsoft.PolicyInsights/policyMetadata/CMA_0544"
+          },
+          "Mode": "All",
+          "Parameters": {
+            "effect": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Effect",
+                "description": "Enable or disable the execution of the policy"
+              },
+              "allowedValues": [
+                "Manual",
+                "Disabled"
+              ],
+              "defaultValue": "Manual"
+            }
+          },
+          "PolicyRule": {
+            "if": {
+              "field": "type",
+              "equals": "Microsoft.Resources/subscriptions"
+            },
+            "then": {
+              "effect": "[parameters('effect')]",
+              "details": {
+                "defaultState": "NonCompliant"
+              }
+            }
+          },
+          "PolicyType": 2
+        },
+        "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+      },
+      {
+        "Name": "00000000-0000-0000-0000-000000000000",
+        "ResourceId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
+        "ResourceName": "00000000-0000-0000-0000-000000000000",
+        "ResourceType": "Microsoft.Authorization/policyDefinitions",
+        "SubscriptionId": null,
+        "Properties": {
+          "Description": "CMA_0544 - View and configure system diagnostic data",
+          "DisplayName": "View and configure system diagnostic data",
+          "Metadata": {
+            "version": "1.0.0",
+            "category": "Regulatory Compliance",
+            "additionalMetadataId": "/providers/Microsoft.PolicyInsights/policyMetadata/CMA_0544"
+          },
+          "Mode": "All",
+          "Parameters": {
+            "effect": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Effect",
+                "description": "Enable or disable the execution of the policy"
+              },
+              "allowedValues": [
+                "Manual",
+                "Disabled"
+              ],
+              "defaultValue": "Manual"
+            }
+          },
+          "PolicyRule": {
+            "if": {
+              "field": "type",
+              "equals": "Microsoft.Resources/subscriptions"
+            },
+            "then": {
+              "effect": "[parameters('effect')]",
+              "details": {
+                "defaultState": "NonCompliant"
+              }
+            }
+          },
+          "PolicyType": 2
+        },
+        "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+      }
+    ]
+  }
+]

--- a/tests/PSRule.Rules.Azure.Tests/test11.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test11.assignment.json
@@ -36,12 +36,11 @@
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": null,
         "Properties": {
-          "Description": "CMA_0544 - View and configure system diagnostic data",
+          "Description": "View and configure system diagnostic data",
           "DisplayName": "View and configure system diagnostic data",
           "Metadata": {
             "version": "1.0.0",
-            "category": "Regulatory Compliance",
-            "additionalMetadataId": "/providers/Microsoft.PolicyInsights/policyMetadata/CMA_0544"
+            "category": "Regulatory Compliance"
           },
           "Mode": "All",
           "Parameters": {
@@ -81,12 +80,11 @@
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": null,
         "Properties": {
-          "Description": "CMA_0544 - View and configure system diagnostic data",
+          "Description": "View and configure system diagnostic data",
           "DisplayName": "View and configure system diagnostic data",
           "Metadata": {
             "version": "1.0.0",
-            "category": "Regulatory Compliance",
-            "additionalMetadataId": "/providers/Microsoft.PolicyInsights/policyMetadata/CMA_0544"
+            "category": "Regulatory Compliance"
           },
           "Mode": "All",
           "Parameters": {


### PR DESCRIPTION
## PR Summary

Related to #1653.

Fixes key collisions with definitions using same parameters.
Also refactored a bit of csharp code.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [ ] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
