### PR TITLE
Fixes error expanding json single quotes #1656

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,10 +24,15 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.20.0-B0085:
+
 - New rules:
   - App Configuration:
     - Check app configuration store audit diagnostic logs are enabled by @bengeset96.
       [#1690](https://github.com/Azure/PSRule.Rules.Azure/issues/1690)
+- Bug fixes:
+  - Fixed error expanding with `json()` and single quotes by @BernieWhite.
+    [#1656](https://github.com/Azure/PSRule.Rules.Azure/issues/1656)
 
 ## v1.20.0-B0085 (pre-release)
 

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -257,10 +257,24 @@ namespace PSRule.Rules.Azure
 
             // Object
             var actual1 = Functions.Json(context, new object[] { "{ \"a\": \"b\" }" }) as JObject;
-            Assert.Equal("b", actual1["a"]);
+            Assert.Equal("b", actual1["a"].Value<string>());
+            actual1 = Functions.Json(context, new object[] { "{'a': 'b'}" }) as JObject;
+            Assert.Equal("b", actual1["a"].Value<string>());
+            actual1 = Functions.Json(context, new object[] { "{''a'': ''b''}" }) as JObject;
+            Assert.Equal("b", actual1["a"].Value<string>());
+            actual1 = Functions.Json(context, new object[] { Functions.Format(context, new object[] { "{{''a'': ''{0}''}}", "b" }) }) as JObject;
+            Assert.Equal("b", actual1["a"].Value<string>());
+            var actual2 = Functions.Json(context, new object[] { "\"\"" }) as string;
+            Assert.Equal("", actual2);
+            actual2 = Functions.Json(context, new object[] { "''" }) as string;
+            Assert.Equal("", actual2);
+            actual2 = Functions.Json(context, new object[] { "" }) as string;
+            Assert.Null(actual2);
+            var actual3 = Functions.Json(context, new object[] { "null" });
+            Assert.Null(actual3);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Json(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.Json(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.Json(context, System.Array.Empty<object>()));
         }
 
         [Fact]


### PR DESCRIPTION
## PR Summary

- Fixed error expanding with `json()` and single quotes.

Fixes #1656

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
