### PR TITLE
Added Azure.AppConfig.PurgeProtect

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+- New rules:
+  - App Configuration:
+    - Check app configuration store has purge protection enabled by @bengeset96.
+      [#1689](https://github.com/Azure/PSRule.Rules.Azure/issues/1689)
+
 What's changed since pre-release v1.20.0-B0223:
 
 - Bug fixes:

--- a/docs/en/rules/Azure.AppConfig.PurgeProtect.md
+++ b/docs/en/rules/Azure.AppConfig.PurgeProtect.md
@@ -1,0 +1,77 @@
+---
+severity: Important
+pillar: Reliability
+category: Data management
+resource: App Configuration
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AppConfig.PurgeProtect/
+---
+
+# Purge Protect App Configuration Stores
+
+## SYNOPSIS
+
+Consider purge protection for app configuration store to ensure store cannot be purged in the retention period.
+
+## DESCRIPTION
+
+With purge protection enabled, soft deleted stores can't be purged in the retention period. If disabled, the soft deleted store can be purged before the retention period expires. Once purge protection is enabled on a store, it can't be disabled.
+
+Purge protection currently requires a **standard** SKU.
+
+## RECOMMENDATION
+
+Consider enabling purge protection for app configuration store.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy App Configuration Stores that pass this rule:
+
+- Set `properties.enablePurgeProtection` to `true`.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.AppConfiguration/configurationStores",
+  "apiVersion": "2022-05-01",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "sku": {
+    "name": "standard"
+  },
+  "properties": {
+    "disableLocalAuth": true,
+    "enablePurgeProtection": true
+  }
+}
+```
+
+### Configure with Bicep
+
+To deploy App Configuration Stores that pass this rule:
+
+- Set `properties.enablePurgeProtection` to `true`.
+
+For example:
+
+```bicep
+resource store 'Microsoft.AppConfiguration/configurationStores@2022-05-01' = {
+  name: name
+  location: location
+  sku: {
+    name: 'standard'
+  }
+  properties: {
+    disableLocalAuth: true
+    enablePurgeProtection: true
+  }
+}
+```
+
+## LINKS
+
+- [Data management for reliability](https://learn.microsoft.com/azure/architecture/framework/resiliency/data-management)
+- [Purge protection](https://learn.microsoft.com/azure/azure-app-configuration/concept-soft-delete#purge-protection)
+- [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.appconfiguration/configurationstores)

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -70,5 +70,5 @@
     ACRSoftDeletePolicy = "The container registry '{0}' should have soft delete policy enabled."
     ACRSoftDeletePolicyRetention = "The container registry '{0}' should have retention period value between one to 90 days for the soft delete policy."
     AppConfigStoresDiagnosticSetting = "Minimum one diagnostic setting should have ({0}) configured or category group ({1}) configured."
-    
+    AppConfigPurgeProtection = "The app configuration store '{0}' should have purge protection enabled." 
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.AppConfig.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppConfig.Rule.ps1
@@ -8,8 +8,7 @@
 #region Rules
 
 # Synopsis: Ensure app configuration store audit diagnostic logs are enabled.
-Rule 'Azure.AppConfig.AuditLogs' -Ref 'AZR-000311' -Type 'Microsoft.AppConfiguration/configurationStores' -Tag @{ release = 'GA'; ruleSet = '2022_09' } {
-    
+Rule 'Azure.AppConfig.AuditLogs' -Ref 'AZR-000311' -Type 'Microsoft.AppConfiguration/configurationStores' -Tag @{ release = 'GA'; ruleSet = '2022_09' } { 
     $logCategoryGroups = 'audit', 'allLogs'
     $joinedLogCategoryGroups = $logCategoryGroups -join ', '
     $diagnostics = @(GetSubResources -ResourceType 'Microsoft.Insights/diagnosticSettings' | ForEach-Object {
@@ -34,6 +33,11 @@ Rule 'Azure.AppConfig.GeoReplica' -Ref 'AZR-000312' -Type 'Microsoft.AppConfigur
         Where-Object { $_ -ne $appConfigLocation })
     
     $Assert.Greater($replicas, '.', 0).Reason($LocalizedData.ReplicaInSecondaryNotFound).PathPrefix('resources')
+}
+
+# Synopsis: Consider purge protection for app configuration store to ensure store cannot be purged in the retention period.
+Rule 'Azure.AppConfig.PurgeProtect' -Ref 'AZR-000313' -Type 'Microsoft.AppConfiguration/configurationStores' -If { IsAppConfigStandardSKU } -Tag @{ release = 'GA'; ruleSet = '2022_12' } {
+    $Assert.HasFieldValue($TargetObject, 'properties.enablePurgeProtection', $true).Reason($LocalizedData.AppConfigPurgeProtection, $TargetObject.name)
 }
 
 #endregion Rules

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
@@ -112,8 +112,8 @@ Describe 'Azure.AppConfig' -Tag 'AppConfig' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'app-config-I';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'app-config-E', 'app-config-I';
         }
 
         It 'Azure.AppConfig.PurgeProtect' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
@@ -125,10 +125,10 @@ Describe 'Azure.AppConfig' -Tag 'AppConfig' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'app-config-F', 'app-config-E', 'app-config-H', 'app-config-I';
+            $ruleResult.TargetName | Should -BeIn 'app-config-E', 'app-config-F', 'app-config-H', 'app-config-I';
 
-            $ruleResult[0].Reason | Should -BeExactly "The app configuration store 'app-config-F' should have purge protection enabled.";
-            $ruleResult[1].Reason | Should -BeExactly "The app configuration store 'app-config-E' should have purge protection enabled.";
+            $ruleResult[0].Reason | Should -BeExactly "The app configuration store 'app-config-E' should have purge protection enabled.";
+            $ruleResult[1].Reason | Should -BeExactly "The app configuration store 'app-config-F' should have purge protection enabled.";
             $ruleResult[2].Reason | Should -BeExactly "The app configuration store 'app-config-H' should have purge protection enabled.";
             $ruleResult[3].Reason | Should -BeExactly "The app configuration store 'app-config-I' should have purge protection enabled.";
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
@@ -124,12 +124,13 @@ Describe 'Azure.AppConfig' -Tag 'AppConfig' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
+            $ruleResult.Length | Should -Be 4;
             $ruleResult.TargetName | Should -BeIn 'app-config-F', 'app-config-E', 'app-config-H', 'app-config-I';
 
             $ruleResult[0].Reason | Should -BeExactly "The app configuration store 'app-config-F' should have purge protection enabled.";
-            $ruleResult[1].Reason | Should -BeExactly "The app configuration store 'app-config-H' should have purge protection enabled.";
-            $ruleResult[2].Reason | Should -BeExactly "The app configuration store 'app-config-I' should have purge protection enabled.";
+            $ruleResult[1].Reason | Should -BeExactly "The app configuration store 'app-config-E' should have purge protection enabled.";
+            $ruleResult[2].Reason | Should -BeExactly "The app configuration store 'app-config-H' should have purge protection enabled.";
+            $ruleResult[3].Reason | Should -BeExactly "The app configuration store 'app-config-I' should have purge protection enabled.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
@@ -42,15 +42,15 @@ Describe 'Azure.AppConfig' -Tag 'AppConfig' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 5;
-            $ruleResult.TargetName | Should -Be 'app-config-B', 'app-config-C', 'app-config-D', 'app-config-E', 'app-config-G';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -Be 'app-config-B', 'app-config-C', 'app-config-D', 'app-config-G';
             $ruleResult.Detail.Reason.Path | Should -BeIn 'Sku.name';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -Be 'app-config-A', 'app-config-F', 'app-config-H', 'app-config-I';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -Be 'app-config-A', 'app-config-E', 'app-config-F', 'app-config-H', 'app-config-I';
         }
 
         It 'Azure.AppConfig.DisableLocalAuth' {
@@ -124,13 +124,12 @@ Describe 'Azure.AppConfig' -Tag 'AppConfig' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'app-config-A', 'app-config-F', 'app-config-H', 'app-config-I';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'app-config-F', 'app-config-H', 'app-config-I';
 
-            $ruleResult[0].Reason | Should -BeExactly "The app configuration store 'app-config-A' should have purge protection enabled.";
-            $ruleResult[1].Reason | Should -BeExactly "The app configuration store 'app-config-F' should have purge protection enabled.";
-            $ruleResult[2].Reason | Should -BeExactly "The app configuration store 'app-config-H' should have purge protection enabled.";
-            $ruleResult[3].Reason | Should -BeExactly "The app configuration store 'app-config-I' should have purge protection enabled.";
+            $ruleResult[0].Reason | Should -BeExactly "The app configuration store 'app-config-F' should have purge protection enabled.";
+            $ruleResult[1].Reason | Should -BeExactly "The app configuration store 'app-config-H' should have purge protection enabled.";
+            $ruleResult[2].Reason | Should -BeExactly "The app configuration store 'app-config-I' should have purge protection enabled.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
@@ -125,7 +125,7 @@ Describe 'Azure.AppConfig' -Tag 'AppConfig' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'app-config-F', 'app-config-H', 'app-config-I';
+            $ruleResult.TargetName | Should -BeIn 'app-config-F', 'app-config-E', 'app-config-H', 'app-config-I';
 
             $ruleResult[0].Reason | Should -BeExactly "The app configuration store 'app-config-F' should have purge protection enabled.";
             $ruleResult[1].Reason | Should -BeExactly "The app configuration store 'app-config-H' should have purge protection enabled.";
@@ -134,8 +134,8 @@ Describe 'Azure.AppConfig' -Tag 'AppConfig' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'app-config-A', 'app-config-E';
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'app-config-A';
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppConfig.Tests.ps1
@@ -115,6 +115,29 @@ Describe 'Azure.AppConfig' -Tag 'AppConfig' {
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -BeIn 'app-config-I';
         }
+
+        It 'Azure.AppConfig.PurgeProtect' {
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.AppConfig.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppConfig.PurgeProtect' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'app-config-A', 'app-config-F', 'app-config-H', 'app-config-I';
+
+            $ruleResult[0].Reason | Should -BeExactly "The app configuration store 'app-config-A' should have purge protection enabled.";
+            $ruleResult[1].Reason | Should -BeExactly "The app configuration store 'app-config-F' should have purge protection enabled.";
+            $ruleResult[2].Reason | Should -BeExactly "The app configuration store 'app-config-H' should have purge protection enabled.";
+            $ruleResult[3].Reason | Should -BeExactly "The app configuration store 'app-config-I' should have purge protection enabled.";
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'app-config-A', 'app-config-E';
+        }
     }
 
     Context 'Resource name' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AppConfig.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AppConfig.json
@@ -18,7 +18,8 @@
         "keyVaultProperties": null
       },
       "privateEndpointConnections": null,
-      "disableLocalAuth": true
+      "disableLocalAuth": true,
+      "enablePurgeProtection": true
     },
     "ResourceGroupName": "rg-test",
     "Type": "Microsoft.AppConfiguration/configurationStores",
@@ -396,14 +397,15 @@
       "encryption": {
         "keyVaultProperties": null
       },
-      "privateEndpointConnections": null
+      "privateEndpointConnections": null,
+      "enablePurgeProtection": true
     },
     "ResourceGroupName": "rg-test",
     "Type": "Microsoft.AppConfiguration/configurationStores",
     "ResourceType": "Microsoft.AppConfiguration/configurationStores",
     "ExtensionResourceType": null,
     "Sku": {
-      "Name": "free",
+      "Name": "standard",
       "Tier": null,
       "Size": null,
       "Family": null,

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AppConfig.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AppConfig.json
@@ -398,7 +398,7 @@
         "keyVaultProperties": null
       },
       "privateEndpointConnections": null,
-      "enablePurgeProtection": true
+      "enablePurgeProtection": false
     },
     "ResourceGroupName": "rg-test",
     "Type": "Microsoft.AppConfiguration/configurationStores",


### PR DESCRIPTION
## PR Summary

Fixes #1689 

Added Azure.AppConfig.PurgeProtect rule for ensuring that app configuration stores with supporting SKU has it enabled.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
