### PR TITLE
Fixes adminUsername with nested deployments #1762

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.20.0-B0304:
+
+- Bug fixes:
+  - Fixed `Azure.Deployment.AdminUsername` incorrectly fails with nested deployments by @BernieWhite.
+    [#1762](https://github.com/Azure/PSRule.Rules.Azure/issues/1762)
+
 ## v1.20.0-B0304 (pre-release)
 
 What's changed since pre-release v1.20.0-B0223:

--- a/src/PSRule.Rules.Azure/rules/Azure.Deployment.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Deployment.Rule.ps1
@@ -14,26 +14,45 @@ Rule 'Azure.Deployment.OutputSecretValue' -Ref 'AZR-000279' -Type 'Microsoft.Res
 
 # Synopsis: Ensure all properties named used for setting a username within a deployment are expressions (e.g. an ARM function not a string)
 Rule 'Azure.Deployment.AdminUsername' -Ref 'AZR-000284' -Type 'Microsoft.Resources/deployments' -Tag @{ release = 'GA'; ruleSet = '2022_09' } {
-    $resources = @($TargetObject.properties.template.resources);
-    if ($resources.Length -eq 0 ) {
-        return $Assert.Pass();
-    }
-    else {
+    RecurseDeploymentSensitive -Deployment $TargetObject
+}
+
+#endregion Rules
+
+#region Helpers
+
+function global:RecurseDeploymentSensitive {
+    param (
+        [Parameter(Mandatory = $True)]
+        [PSObject]$Deployment
+    )
+    process {
         $propertyNames = $Configuration.GetStringValues('AZURE_DEPLOYMENT_SENSITIVE_PROPERTY_NAMES');
+        $resources = @($Deployment.properties.template.resources);
+        if ($resources.Length -eq 0) {
+            return $Assert.Pass();
+        }
 
         foreach ($resource in $resources) {
-            foreach ($propertyName in $propertyNames) {
-                $found = $PSRule.GetPath($resource, "$..$propertyName");
-                if ($found -eq $Null -or $found.Length -eq 0) {
-                    $Assert.Pass();
-                }
-                else {
-                    Write-Debug "Found property name: $propertyName";
-                    $Assert.Create(![PSRule.Rules.Azure.Runtime.Helper]::HasLiteralValue($found), $LocalizedData.LiteralSensitiveProperty, $propertyName);
+            if ($resource.type -eq 'Microsoft.Resources/deployments') {
+                RecurseDeploymentSensitive -Deployment $resource;
+            }
+            else {
+                foreach ($propertyName in $propertyNames) {
+                    $found = $PSRule.GetPath($resource, "$..$propertyName");
+                    if ($Null -eq $found -or $found.Length -eq 0) {
+                        $Assert.Pass();
+                    }
+                    else {
+                        Write-Debug "Found property name: $propertyName";
+                        foreach ($value in $found) {
+                            $Assert.Create(![PSRule.Rules.Azure.Runtime.Helper]::HasLiteralValue($value), $LocalizedData.LiteralSensitiveProperty, $propertyName);
+                        }
+                    }
                 }
             }
         }
     }
 }
 
-#endregion Rules
+#endregion Helpers

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Deployment.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Deployment.Tests.ps1
@@ -87,4 +87,26 @@ Describe 'Azure.Deployment.AdminUsername' -Tag 'Deployment' {
              $ruleResult.TargetName | Should -BeIn 'nestedDeployment-B', 'nestedDeployment-C', 'nestedDeployment-F', 'nestedDeployment-G', 'nestedDeployment-H';
         }
     }
+
+    Context 'With Template' {
+        BeforeAll {
+            $templatePath = Join-Path -Path $here -ChildPath 'deployment.tests.json';
+            $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.Deployment.json;
+            Export-AzRuleTemplateData -TemplateFile $templatePath -OutputPath $outputFile;
+            $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
+        }
+
+        It 'Azure.Deployment.AdminUsername' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Deployment.AdminUsername' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+        }
+    }
 }

--- a/tests/PSRule.Rules.Azure.Tests/deployment-1.tests.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/deployment-1.tests.bicep
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+param name string
+
+param location string = resourceGroup().location
+
+@secure()
+param adminUsername string
+
+@secure()
+param adminPassword string
+
+resource vm 'Microsoft.Compute/virtualMachines@2022-08-01' = {
+  name: name
+  location: location
+  properties: {
+    osProfile: {
+      adminUsername: adminUsername
+      adminPassword: adminPassword
+    }
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/deployment.tests.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/deployment.tests.bicep
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+param location string = resourceGroup().location
+
+resource vault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
+  name: 'vault-001'
+}
+
+module child './deployment-1.tests.bicep' = {
+  name: 'child-deployment'
+  params: {
+    name: 'child'
+    location: location
+    adminUsername: vault.getSecret('adminUsername')
+    adminPassword: vault.getSecret('adminPassword')
+  }
+}
+
+module child1 './deployment-1.tests.bicep' = {
+  name: 'child1-deployment'
+  params: {
+    name: 'child1'
+    location: location
+    adminUsername: vault.getSecret('adminUsername')
+    adminPassword: vault.getSecret('adminPassword')
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/deployment.tests.json
+++ b/tests/PSRule.Rules.Azure.Tests/deployment.tests.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.11.1.770",
+      "templateHash": "18140130966451899933"
+    }
+  },
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "child-deployment",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "child"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "adminUsername": {
+            "reference": {
+              "keyVault": {
+                "id": "[resourceId('Microsoft.KeyVault/vaults', 'vault-001')]"
+              },
+              "secretName": "adminUsername"
+            }
+          },
+          "adminPassword": {
+            "reference": {
+              "keyVault": {
+                "id": "[resourceId('Microsoft.KeyVault/vaults', 'vault-001')]"
+              },
+              "secretName": "adminPassword"
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.11.1.770",
+              "templateHash": "12067433043052871272"
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]"
+            },
+            "adminUsername": {
+              "type": "secureString"
+            },
+            "adminPassword": {
+              "type": "secureString"
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Compute/virtualMachines",
+              "apiVersion": "2022-08-01",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "osProfile": {
+                  "adminUsername": "[parameters('adminUsername')]",
+                  "adminPassword": "[parameters('adminPassword')]"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "child1-deployment",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "child1"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "adminUsername": {
+            "reference": {
+              "keyVault": {
+                "id": "[resourceId('Microsoft.KeyVault/vaults', 'vault-001')]"
+              },
+              "secretName": "adminUsername"
+            }
+          },
+          "adminPassword": {
+            "reference": {
+              "keyVault": {
+                "id": "[resourceId('Microsoft.KeyVault/vaults', 'vault-001')]"
+              },
+              "secretName": "adminPassword"
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.11.1.770",
+              "templateHash": "12067433043052871272"
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]"
+            },
+            "adminUsername": {
+              "type": "secureString"
+            },
+            "adminPassword": {
+              "type": "secureString"
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Compute/virtualMachines",
+              "apiVersion": "2022-08-01",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "osProfile": {
+                  "adminUsername": "[parameters('adminUsername')]",
+                  "adminPassword": "[parameters('adminPassword')]"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.Deployment.AdminUsername` incorrectly fails with nested deployments.

Fixes #1762 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
