### PR TITLE
Pre-release v1.20.0-B0477

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,10 +24,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
-What's changed since pre-release v1.20.0-B0223:
+## v1.20.0-B0477 (pre-release)
 
-- New features:
-  - Added hash to `name` and `ref` properties for policy rules. [#1653]
+What's changed since pre-release v1.20.0-B0389:
+
+- General improvements:
+  - Added hash to `name` and `ref` properties for policy rules by @ArmaanMcleod.
+    [#1653](https://github.com/Azure/PSRule.Rules.Azure/issues/1653)
     - Use `AZURE_POLICY_RULE_PREFIX` or `Export-AzPolicyAssignmentRuleData -RulePrefix` to override rule prefix.
 
 ## v1.20.0-B0389 (pre-release)


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.20.0-B0389:

- General improvements:
  - Added hash to `name` and `ref` properties for policy rules by @ArmaanMcleod.
    [#1653](https://github.com/Azure/PSRule.Rules.Azure/issues/1653)
    - Use `AZURE_POLICY_RULE_PREFIX` or `Export-AzPolicyAssignmentRuleData -RulePrefix` to override rule prefix.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
