### PR TITLE
Added policy definition ignore list #1730

### DIFF
--- a/data/policy-ignore.json
+++ b/data/policy-ignore.json
@@ -1,0 +1,22 @@
+[
+  // Azure.SQL.AAD
+  "/providers/Microsoft.Authorization/policyDefinitions/1f314764-cb73-4fc9-b863-8eca98ac36e9",
+  // Azure.ServiceFabric.AAD
+  "/providers/Microsoft.Authorization/policyDefinitions/b54ed75b-3e1a-44ac-a333-05ba39b99ff0",
+  // Azure.Redis.NonSslPort
+  "/providers/Microsoft.Authorization/policyDefinitions/22bee202-a82f-4305-9a2a-6d7f44d4dedb",
+  // Azure.Automation.EncryptVariables
+  "/providers/Microsoft.Authorization/policyDefinitions/3657f5a0-770e-44a3-b44e-9431ba1e9735",
+  // Azure.AKS.UseRBAC
+  "/providers/Microsoft.Authorization/policyDefinitions/ac4a19c2-fa67-49b4-8ae5-0b2e78c49457",
+  // Azure.AKS.AzurePolicyAddOn
+  "/providers/Microsoft.Authorization/policyDefinitions/0a15ec92-a229-4763-bb14-0ea34a568f8d",
+  // Azure.Storage.BlobPublicAccess
+  "/providers/Microsoft.Authorization/policyDefinitions/4fa4b6c0-31ca-4c0d-b10d-24b96f62a751",
+  // Azure.PostgreSQL.UseSSL
+  "/providers/Microsoft.Authorization/policyDefinitions/d158790f-bfb0-486c-8631-2dc6b4e8e6af",
+  // Azure.MySQL.UseSSL
+  "/providers/Microsoft.Authorization/policyDefinitions/e802a67a-daf5-4436-9ea6-f6d821dd0c5d",
+  // Azure.KeyVault.SoftDelete
+  "/providers/Microsoft.Authorization/policyDefinitions/0b60c0b2-2dc2-4e1c-b5c9-abbed971de53"
+]

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -26,6 +26,10 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v1.20.0:
 
+- General improvements:
+  - Added built-in list of ignored policy definitions by @BernieWhite.
+    [#1730](https://github.com/Azure/PSRule.Rules.Azure/issues/1730)
+    - To ignore additional policy definitions, use the `AZURE_POLICY_IGNORE_LIST` configuration option.
 - Engineering:
   - Bump PSRule to v2.5.0.
     [#1769](https://github.com/Azure/PSRule.Rules.Azure/pull/1769)

--- a/docs/concepts/about_PSRule_Azure_Configuration.md
+++ b/docs/concepts/about_PSRule_Azure_Configuration.md
@@ -25,6 +25,7 @@ The following configurations options are available for use:
 - [AZURE_POLICY_WAIVER_MAX_EXPIRY](#azure_policy_waiver_max_expiry)
 - [AZURE_RESOURCE_GROUP](#azure_resource_group)
 - [AZURE_SUBSCRIPTION](#azure_subscription)
+- [AZURE_POLICY_IGNORE_LIST](#azure_policy_ignore_list)
 - [AZURE_POLICY_RULE_PREFIX](#azure_policy_rule_prefix)
 
   [1]: https://aka.ms/ps-rule/options
@@ -284,6 +285,41 @@ Example:
 # YAML: Override the display name of the subscription object
   AZURE_SUBSCRIPTION:
     displayName: 'My test subscription'
+```
+
+### AZURE_POLICY_IGNORE_LIST
+
+This configuration option configures a custom list policy definitions to ignore when exporting policy to rules.
+In addition to the custom list, a built-in list of policies are ignored.
+The built-in list can be found [here](https://github.com/Azure/PSRule.Rules.Azure/blob/main/data/policy-ignore.json).
+
+Configure this option to ignore policy definitions that:
+
+- Already have a rule defined.
+- Are not relevant to testing Infrastructure as Code.
+
+Syntax:
+
+```yaml
+configuration:
+  AZURE_POLICY_IGNORE_LIST: array
+```
+
+Default:
+
+```yaml
+# YAML: The default AZURE_POLICY_IGNORE_LIST configuration option
+configuration:
+  AZURE_POLICY_IGNORE_LIST: []
+```
+
+Example:
+
+```yaml
+# YAML: Add a custom policy definition to ignore
+  AZURE_POLICY_IGNORE_LIST:
+  - '/providers/Microsoft.Authorization/policyDefinitions/1f314764-cb73-4fc9-b863-8eca98ac36e9'
+  - '/providers/Microsoft.Authorization/policyDefinitions/b54ed75b-3e1a-44ac-a333-05ba39b99ff0'
 ```
 
 ### AZURE_POLICY_RULE_PREFIX

--- a/src/PSRule.Rules.Azure.BuildTool/ProviderResource.cs
+++ b/src/PSRule.Rules.Azure.BuildTool/ProviderResource.cs
@@ -34,6 +34,7 @@ namespace PSRule.Rules.Azure.BuildTool
             BuildIndex(options);
             MinifyTypes(options);
             MinifyEnvironments(options);
+            MinifyPolicyIgnore(options);
         }
 
         private static void MinifyEnvironments(ProviderResourceOption options)
@@ -41,6 +42,13 @@ namespace PSRule.Rules.Azure.BuildTool
             Console.WriteLine("BuildTool -- Minify environments");
             var environments = ReadFile<JObject>(GetSourcePath("./data/environments.json"));
             WriteFile(GetSourcePath("./data/environments.min.json"), environments);
+        }
+
+        private static void MinifyPolicyIgnore(ProviderResourceOption options)
+        {
+            Console.WriteLine("BuildTool -- Minify policy-ignore");
+            var policyIgnore = ReadFile<string[]>(GetSourcePath("./data/policy-ignore.json"));
+            WriteFile(GetSourcePath("./data/policy-ignore.min.json"), policyIgnore);
         }
 
         private static void MinifyTypes(ProviderResourceOption options)

--- a/src/PSRule.Rules.Azure/Configuration/ConfigurationOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/ConfigurationOption.cs
@@ -12,6 +12,8 @@ namespace PSRule.Rules.Azure.Configuration
     /// </summary>
     public sealed class ConfigurationOption : IEquatable<ConfigurationOption>
     {
+        private const string DEFAULT_POLICYRULEPREFIX = "Azure";
+
         internal static readonly ConfigurationOption Default = new()
         {
             Subscription = SubscriptionOption.Default,
@@ -20,7 +22,7 @@ namespace PSRule.Rules.Azure.Configuration
             ManagementGroup = ManagementGroupOption.Default,
             ParameterDefaults = ParameterDefaultsOption.Default,
             Deployment = DeploymentOption.Default,
-            PolicyRulePrefix = "Azure"
+            PolicyRulePrefix = DEFAULT_POLICYRULEPREFIX,
         };
 
         /// <summary>
@@ -34,6 +36,7 @@ namespace PSRule.Rules.Azure.Configuration
             ManagementGroup = null;
             ParameterDefaults = null;
             Deployment = null;
+            PolicyIgnoreList = null;
             PolicyRulePrefix = null;
         }
 
@@ -48,6 +51,7 @@ namespace PSRule.Rules.Azure.Configuration
             ManagementGroup = option.ManagementGroup;
             ParameterDefaults = option.ParameterDefaults;
             Deployment = option.Deployment;
+            PolicyIgnoreList = option.PolicyIgnoreList;
             PolicyRulePrefix = option.PolicyRulePrefix;
         }
 
@@ -67,6 +71,7 @@ namespace PSRule.Rules.Azure.Configuration
                 ManagementGroup == other.ManagementGroup &&
                 ParameterDefaults == other.ParameterDefaults &&
                 Deployment == other.Deployment &&
+                PolicyIgnoreList == other.PolicyIgnoreList &&
                 PolicyRulePrefix == other.PolicyRulePrefix;
         }
 
@@ -82,6 +87,7 @@ namespace PSRule.Rules.Azure.Configuration
                 hash = hash * 23 + (ManagementGroup != null ? ManagementGroup.GetHashCode() : 0);
                 hash = hash * 23 + (ParameterDefaults != null ? ParameterDefaults.GetHashCode() : 0);
                 hash = hash * 23 + (Deployment != null ? Deployment.GetHashCode() : 0);
+                hash = hash * 23 + (PolicyIgnoreList != null ? PolicyIgnoreList.GetHashCode() : 0);
                 hash = hash * 23 + (PolicyRulePrefix != null ? PolicyRulePrefix.GetHashCode() : 0);
                 return hash;
             }
@@ -97,6 +103,7 @@ namespace PSRule.Rules.Azure.Configuration
                 ManagementGroup = ManagementGroupOption.Combine(o1?.ManagementGroup, o2?.ManagementGroup),
                 ParameterDefaults = ParameterDefaultsOption.Combine(o1?.ParameterDefaults, o2?.ParameterDefaults),
                 Deployment = DeploymentOption.Combine(o1?.Deployment, o2?.Deployment),
+                PolicyIgnoreList = o1?.PolicyIgnoreList ?? o2?.PolicyIgnoreList,
                 PolicyRulePrefix = o1?.PolicyRulePrefix ?? o2?.PolicyRulePrefix
             };
             return result;
@@ -151,5 +158,12 @@ namespace PSRule.Rules.Azure.Configuration
         [DefaultValue(null)]
         [YamlMember(Alias = "AZURE_POLICY_RULE_PREFIX", ApplyNamingConventions = false)]
         public string PolicyRulePrefix { get; set; }
+
+        /// <summary>
+        /// Configures a list of policy definitions to ignore.
+        /// </summary>
+        [DefaultValue(null)]
+        [YamlMember(Alias = "AZURE_POLICY_IGNORE_LIST", ApplyNamingConventions = false)]
+        public string[] PolicyIgnoreList { get; set; }
     }
 }

--- a/src/PSRule.Rules.Azure/Data/CloudEnvironment.cs
+++ b/src/PSRule.Rules.Azure/Data/CloudEnvironment.cs
@@ -2,23 +2,44 @@
 // Licensed under the MIT License.
 
 using Newtonsoft.Json;
+using static System.Net.WebRequestMethods;
 
 namespace PSRule.Rules.Azure.Data
 {
+    /// <summary>
+    /// Properties of an Azure Cloud Environment.
+    /// This object is exposed by the ARM <c>environment()</c> function.
+    /// See <seealso href="https://learn.microsoft.com/azure/azure-resource-manager/templates/template-functions-deployment#environment">docs</seealso>.
+    /// </summary>
     public sealed class CloudEnvironment
     {
+        /// <summary>
+        /// The name of the cloud environment.
+        /// </summary>
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
+        /// <summary>
+        /// The gallery endpoint.
+        /// </summary>
         [JsonProperty(PropertyName = "gallery")]
         public string Gallery { get; set; }
 
+        /// <summary>
+        /// The Microsoft Graph endpoint.
+        /// </summary>
         [JsonProperty(PropertyName = "graph")]
         public string Graph { get; set; }
 
+        /// <summary>
+        /// The Azure Portal endpoint.
+        /// </summary>
         [JsonProperty(PropertyName = "portal")]
         public string Portal { get; set; }
 
+        /// <summary>
+        /// The audience for Microsoft Graph.
+        /// </summary>
         [JsonProperty(PropertyName = "graphAudience")]
         public string GraphAudience { get; set; }
 

--- a/src/PSRule.Rules.Azure/Data/EnvironmentData.cs
+++ b/src/PSRule.Rules.Azure/Data/EnvironmentData.cs
@@ -18,7 +18,7 @@ namespace PSRule.Rules.Azure.Data
         /// <summary>
         /// Settings for JSON deserialization.
         /// </summary>
-        private static readonly JsonSerializerSettings _Settings = new JsonSerializerSettings
+        private static readonly JsonSerializerSettings _Settings = new()
         {
             Converters = new List<JsonConverter>
             {

--- a/src/PSRule.Rules.Azure/Data/PolicyIgnoreData.cs
+++ b/src/PSRule.Rules.Azure/Data/PolicyIgnoreData.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using PSRule.Rules.Azure.Resources;
+
+namespace PSRule.Rules.Azure.Data
+{
+    internal sealed class PolicyIgnoreData : ResourceLoader
+    {
+        private const string RESOURCE_PATH = "policy-ignore.min.json.deflated";
+
+        /// <summary>
+        /// Settings for JSON deserialization.
+        /// </summary>
+        private static readonly JsonSerializerSettings _Settings = new()
+        {
+            Converters = new List<JsonConverter>
+            {
+                new HashSetConverter(StringComparer.OrdinalIgnoreCase),
+            }
+        };
+        private HashSet<string> _Index;
+
+        internal HashSet<string> GetIndex()
+        {
+            _Index ??= ReadIndex(GetContent(RESOURCE_PATH));
+            return _Index;
+        }
+
+        private static HashSet<string> ReadIndex(string content)
+        {
+            return JsonConvert.DeserializeObject<HashSet<string>>(content, _Settings) ?? throw new JsonException(PSRuleResources.PolicyIgnoreInvalid);
+        }
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/ProviderData.cs
+++ b/src/PSRule.Rules.Azure/Data/ProviderData.cs
@@ -20,7 +20,7 @@ namespace PSRule.Rules.Azure.Data
         /// <summary>
         /// Settings for JSON deserialization.
         /// </summary>
-        private static readonly JsonSerializerSettings _Settings = new JsonSerializerSettings
+        private static readonly JsonSerializerSettings _Settings = new()
         {
             Converters = new List<JsonConverter>
             {

--- a/src/PSRule.Rules.Azure/Data/TypeIndex.cs
+++ b/src/PSRule.Rules.Azure/Data/TypeIndex.cs
@@ -135,4 +135,29 @@ namespace PSRule.Rules.Azure.Data
             throw new NotImplementedException();
         }
     }
+
+    internal sealed class HashSetConverter : JsonConverter<HashSet<string>>
+    {
+        private readonly IEqualityComparer<string> _Comparer;
+
+        public HashSetConverter(IEqualityComparer<string> comparer)
+        {
+            _Comparer = comparer;
+        }
+
+        public override HashSet<string> ReadJson(JsonReader reader, Type objectType, HashSet<string> existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader == null || serializer == null || reader.TokenType != JsonToken.StartArray)
+                return null;
+
+            var d = new HashSet<string>(_Comparer);
+            serializer.Populate(reader, d);
+            return d;
+        }
+
+        public override void WriteJson(JsonWriter writer, HashSet<string> value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
 }

--- a/src/PSRule.Rules.Azure/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PipelineBuilder.cs
@@ -123,18 +123,21 @@ namespace PSRule.Rules.Azure.Pipeline
             _Output = new PSPipelineWriter(Option);
         }
 
+        /// <inheritdoc/>
         public virtual void UseCommandRuntime(PSCmdlet commandRuntime)
         {
             CmdletContext = commandRuntime;
             _Output.UseCommandRuntime(commandRuntime);
         }
 
+        /// <inheritdoc/>
         public void UseExecutionContext(EngineIntrinsics executionContext)
         {
             ExecutionContext = executionContext;
             _Output.UseExecutionContext(executionContext);
         }
 
+        /// <inheritdoc/>
         public virtual IPipelineBuilder Configure(PSRuleOption option)
         {
             if (option == null)
@@ -145,6 +148,7 @@ namespace PSRule.Rules.Azure.Pipeline
             return this;
         }
 
+        /// <inheritdoc/>
         public abstract IPipeline Build();
 
         protected PipelineContext PrepareContext()

--- a/src/PSRule.Rules.Azure/Pipeline/TemplateLinkPipelineBuilder.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/TemplateLinkPipelineBuilder.cs
@@ -3,8 +3,14 @@
 
 namespace PSRule.Rules.Azure.Pipeline
 {
+    /// <summary>
+    /// A helper to build a template link pipeline.
+    /// </summary>
     public interface ITemplateLinkPipelineBuilder : IPipelineBuilder
     {
+        /// <summary>
+        /// Determines if unlinked parameter files are skipped or error.
+        /// </summary>
         void SkipUnlinked(bool skipUnlinked);
     }
 
@@ -19,11 +25,13 @@ namespace PSRule.Rules.Azure.Pipeline
             _BasePath = basePath;
         }
 
+        /// <inheritdoc/>
         public void SkipUnlinked(bool skipUnlinked)
         {
             _SkipUnlinked = skipUnlinked;
         }
 
+        /// <inheritdoc/>
         public override IPipeline Build()
         {
             return new TemplateLinkPipeline(PrepareContext(), _BasePath, _SkipUnlinked);

--- a/src/PSRule.Rules.Azure/Pipeline/TemplatePipelineBuilder.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/TemplatePipelineBuilder.cs
@@ -7,14 +7,29 @@ using PSRule.Rules.Azure.Pipeline.Output;
 
 namespace PSRule.Rules.Azure.Pipeline
 {
+    /// <summary>
+    /// A helper for building a template expansion pipeline.
+    /// </summary>
     public interface ITemplatePipelineBuilder : IPipelineBuilder
     {
+        /// <summary>
+        /// Configures the name of the deployment.
+        /// </summary>
         void Deployment(string deploymentName);
 
+        /// <summary>
+        /// Configures properties of the resource group.
+        /// </summary>
         void ResourceGroup(ResourceGroupOption resourceGroup);
 
+        /// <summary>
+        /// Configures properties of the subscription.
+        /// </summary>
         void Subscription(SubscriptionOption subscription);
 
+        /// <summary>
+        /// Determines if expanded resources are passed through to the pipeline.
+        /// </summary>
         void PassThru(bool passThru);
     }
 
@@ -34,6 +49,7 @@ namespace PSRule.Rules.Azure.Pipeline
             Configure(option);
         }
 
+        /// <inheritdoc/>
         public void Deployment(string deploymentName)
         {
             if (string.IsNullOrEmpty(deploymentName))
@@ -43,6 +59,7 @@ namespace PSRule.Rules.Azure.Pipeline
             _DeploymentName = deploymentName;
         }
 
+        /// <inheritdoc/>
         public void ResourceGroup(ResourceGroupOption resourceGroup)
         {
             if (resourceGroup == null)
@@ -51,6 +68,7 @@ namespace PSRule.Rules.Azure.Pipeline
             Option.Configuration.ResourceGroup = ResourceGroupOption.Combine(resourceGroup, Option.Configuration.ResourceGroup);
         }
 
+        /// <inheritdoc/>
         public void Subscription(SubscriptionOption subscription)
         {
             if (subscription == null)
@@ -59,11 +77,13 @@ namespace PSRule.Rules.Azure.Pipeline
             Option.Configuration.Subscription = SubscriptionOption.Combine(subscription, Option.Configuration.Subscription);
         }
 
+        /// <inheritdoc/>
         public void PassThru(bool passThru)
         {
             _PassThru = passThru;
         }
 
+        /// <inheritdoc/>
         protected override PipelineWriter GetOutput()
         {
             // Redirect to file instead
@@ -79,11 +99,13 @@ namespace PSRule.Rules.Azure.Pipeline
                 : base.GetOutput();
         }
 
+        /// <inheritdoc/>
         protected override PipelineWriter PrepareWriter()
         {
             return _PassThru ? base.PrepareWriter() : new JsonOutputWriter(GetOutput(), Option);
         }
 
+        /// <inheritdoc/>
         public override IPipeline Build()
         {
             return new TemplatePipeline(PrepareContext());

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
@@ -313,6 +313,15 @@ namespace PSRule.Rules.Azure.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to the policy ignore content..
+        /// </summary>
+        internal static string PolicyIgnoreInvalid {
+            get {
+                return ResourceManager.GetString("PolicyIgnoreInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The language expression property &apos;{0}&apos; doesn&apos;t exist..
         /// </summary>
         internal static string PropertyNotFound {

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
@@ -208,6 +208,9 @@
     <value>The template file '{0}' must be within the current working directory.</value>
     <comment>Occurs when the template file is outside of the current working path.</comment>
   </data>
+  <data name="PolicyIgnoreInvalid" xml:space="preserve">
+    <value>Failed to the policy ignore content.</value>
+  </data>
   <data name="PropertyNotFound" xml:space="preserve">
     <value>The language expression property '{0}' doesn't exist.</value>
     <comment>Occurs when a property that don't exist is referenced.</comment>


### PR DESCRIPTION
## PR Summary

- Added built-in list of ignored policy definitions.
- To ignore additional policy definitions, use the `AZURE_POLICY_IGNORE_LIST` configuration option.

Fixes #1730 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
