### PR TITLE
Added Azure.ServiceBus.MinTLS

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -28,6 +28,7 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
   - Service Bus:
     - Check service bus namespaces uses TLS 1.2 version by @bengeset96.
       [#1777](https://github.com/Azure/PSRule.Rules.Azure/issues/1777)
+
 ## v1.21.0-B0011 (pre-release)
 
 What's changed since pre-release v1.20.1:

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+- New rules:
+  - Service Bus:
+    - Check service bus namespaces uses TLS 1.2 version by @bengeset96.
+      [#1777](https://github.com/Azure/PSRule.Rules.Azure/issues/1777)
+
 What's changed since pre-release v1.20.0:
 
 - New features:

--- a/docs/en/rules/Azure.ServiceBus.MinTLS.md
+++ b/docs/en/rules/Azure.ServiceBus.MinTLS.md
@@ -1,0 +1,91 @@
+---
+severity: Important
+pillar: Security
+category: Information protection
+resource: Service Bus
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ServiceBus.MinTLS/
+---
+
+# Enforce namespaces to minimum use TLS 1.2 version
+
+## SYNOPSIS
+
+Enforce namespaces to require that clients send and receive data with TLS 1.2 version.
+
+## DESCRIPTION
+
+Communication between a client application and an Azure Service Bus namespace is encrypted using Transport Layer Security (TLS).
+
+Azure Service Bus namespaces permit clients to send and receive data with TLS 1.0 and above. To enforce stricter security measures, you can configure your Service Bus namespace to require that clients send and receive data with a newer version of TLS. If a Service Bus namespace requires a minimum version of TLS, then any requests made with an older version will fail.
+
+**Important** If you are using a service that connects to Azure Service Bus, make sure that that service is using the appropriate version of TLS to send requests to Azure Service Bus before you set the required minimum version for a Service Bus namespace.
+
+## RECOMMENDATION
+
+Consider namespaces to require that clients send and receive data with TLS 1.2 version.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy Service Bus namespaces that pass this rule:
+
+- Set `properties.minimumTlsVersion` to `1.2`.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.ServiceBus/namespaces",
+  "apiVersion": "2022-01-01-preview",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "identity": {
+    "type": "SystemAssigned"
+  },
+  "sku": {
+    "name": "Standard"
+  },
+  "properties": {
+    "disableLocalAuth": true,
+    "minimumTlsVersion": "1.2"
+  }
+}
+```
+
+### Configure with Bicep
+
+To deploy Service Bus namespaces that pass this rule:
+
+- Set `properties.minimumTlsVersion` to `1.2`.
+
+For example:
+
+```bicep
+@description('The name of the resource.')
+param name string
+
+@description('The location resources will be deployed.')
+param location string = resourceGroup().location
+
+resource ns 'Microsoft.ServiceBus/namespaces@2022-01-01-preview' = {
+  name: name
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    disableLocalAuth: true
+    minimumTlsVersion: '1.2'
+  }
+}
+```
+
+## LINKS
+
+- [Information protection and storage](https://learn.microsoft.com/azure/architecture/framework/security/storage-data-encryption)
+- [Enforce a minimum requires version of TLS](https://learn.microsoft.com/azure/service-bus-messaging/transport-layer-security-enforce-minimum-version)
+- [Azure template reference](https://learn.microsoft.com/azure/templates/microsoft.servicebus/namespaces)

--- a/docs/examples-servicebus.bicep
+++ b/docs/examples-servicebus.bicep
@@ -10,7 +10,7 @@ param name string
 param location string = resourceGroup().location
 
 // An example Service Bus namespace
-resource ns 'Microsoft.ServiceBus/namespaces@2021-11-01' = {
+resource ns 'Microsoft.ServiceBus/namespaces@2022-01-01-preview' = {
   name: name
   location: location
   identity: {
@@ -21,5 +21,6 @@ resource ns 'Microsoft.ServiceBus/namespaces@2021-11-01' = {
   }
   properties: {
     disableLocalAuth: true
+    minimumTlsVersion: '1.2'
   }
 }

--- a/docs/examples-servicebus.json
+++ b/docs/examples-servicebus.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1124.51302",
-      "templateHash": "14805995388406051764"
+      "version": "0.11.1.770",
+      "templateHash": "17235301402195616974"
     }
   },
   "parameters": {
@@ -26,7 +26,7 @@
   "resources": [
     {
       "type": "Microsoft.ServiceBus/namespaces",
-      "apiVersion": "2021-11-01",
+      "apiVersion": "2022-01-01-preview",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "identity": {
@@ -36,7 +36,8 @@
         "name": "Standard"
       },
       "properties": {
-        "disableLocalAuth": true
+        "disableLocalAuth": true,
+        "minimumTlsVersion": "1.2"
       }
     }
   ]

--- a/docs/license-contributing/hackathons.md
+++ b/docs/license-contributing/hackathons.md
@@ -11,6 +11,9 @@ link_users: true
 
 Thanks to the team who made the following contributions during the hackathon:
 
+- New features:
+  - Mapping of Azure Security Benchmark v3 to security rules by @jagoodwin.
+    [#1610](https://github.com/Azure/PSRule.Rules.Azure/issues/1610)
 - New rules:
   - Azure Cache for Redis:
     - Check the number of firewall rules for caches by @jonathanruiz.

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -72,9 +72,6 @@
     AppConfigStoresDiagnosticSetting = "Minimum one diagnostic setting should have ({0}) configured or category group ({1}) configured."
     AppConfigPurgeProtection = "The app configuration store '{0}' should have purge protection enabled." 
     LiteralSensitiveProperty = "The property '{0}' uses a deterministic literal value."
-<<<<<<< HEAD
-    ServiceBusMinTLS = "The service bus namespace '{0}' should minimum use TLS 1.2 version."
-=======
     BastionSubnetNotFound = "The virtual network '{0}' with a GatewaySubnet also should have an AzureBastionSubnet configured."
->>>>>>> main
+    ServiceBusMinTLS = "The service bus namespace '{0}' should minimum use TLS 1.2 version."
 }

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -72,4 +72,5 @@
     AppConfigStoresDiagnosticSetting = "Minimum one diagnostic setting should have ({0}) configured or category group ({1}) configured."
     AppConfigPurgeProtection = "The app configuration store '{0}' should have purge protection enabled." 
     LiteralSensitiveProperty = "The property '{0}' uses a deterministic literal value."
+    ServiceBusMinTLS = "The service bus namespace '{0}' should minimum use TLS 1.2 version."
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.ServiceBus.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.ServiceBus.Rule.ps1
@@ -13,4 +13,9 @@ Rule 'Azure.ServiceBus.Usage' -Ref 'AZR-000177' -Type 'Microsoft.ServiceBus/name
     $Assert.GreaterOrEqual($items, '.', 1);
 }
 
+# Synopsis: Enforce namespaces to require that clients send and receive data with TLS 1.2 version.
+Rule 'Azure.ServiceBus.MinTLS' -Ref 'AZR-000315' -Type 'Microsoft.ServiceBus/namespaces' -Tag @{ release = 'GA'; ruleSet = '2022_12' } {
+    $Assert.HasFieldValue($TargetObject, 'Properties.minimumTlsVersion', '1.2').Reason($LocalizedData.ServiceBusMinTLS, $PSRule.TargetName)
+}
+
 #endregion Rules

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ServiceBus.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ServiceBus.Tests.ps1
@@ -48,8 +48,8 @@ Describe 'Azure.ServiceBus' -Tag 'ServiceBus' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'servicens-B';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'servicens-B', 'servicens-C';
         }
 
         It 'Azure.ServiceBus.Usage' {
@@ -64,8 +64,8 @@ Describe 'Azure.ServiceBus' -Tag 'ServiceBus' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'servicens-B';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'servicens-B', 'servicens-C';
         }
 
         It 'Azure.ServiceBus.MinTLS' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ServiceBus.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ServiceBus.Tests.ps1
@@ -67,6 +67,27 @@ Describe 'Azure.ServiceBus' -Tag 'ServiceBus' {
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -BeIn 'servicens-B';
         }
+
+        It 'Azure.ServiceBus.MinTLS' {
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.ServiceBus.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.ServiceBus.MinTLS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'servicens-A', 'servicens-B';
+
+            $ruleResult[0].Reason | Should -BeExactly "The service bus namespace 'servicens-A' should minimum use TLS 1.2 version.";
+            $ruleResult[1].Reason | Should -BeExactly "The service bus namespace 'servicens-B' should minimum use TLS 1.2 version.";
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'servicens-C';
+        }
     }
 
     Context 'With Template' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.ServiceBus.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.ServiceBus.json
@@ -157,5 +157,130 @@
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
       }
     ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ServiceBus/namespaces/servicens-C",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ServiceBus/namespaces/servicens-C",
+    "Identity": null,
+    "Kind": null,
+    "Location": "West Europe",
+    "ManagedBy": null,
+    "ResourceName": "servicens-C",
+    "Name": "servicens-C",
+    "ExtensionResourceName": null,
+    "ParentResource": null,
+    "Plan": null,
+    "Properties": {
+      "disableLocalAuth": true,
+      "minimumTlsVersion": "1.2",
+      "zoneRedundant": false,
+      "provisioningState": "Succeeded",
+      "createdAt": "2022-06-30T13:23:58.58Z",
+      "updatedAt": "2022-08-04T10:21:56.053Z",
+      "serviceBusEndpoint": "https://servicens-C.servicebus.windows.net:443/",
+      "status": "Active"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.ServiceBus/namespaces",
+    "ResourceType": "Microsoft.ServiceBus/namespaces",
+    "ExtensionResourceType": null,
+    "Sku": {
+      "Name": "Standard",
+      "Tier": "Standard",
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": null
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ServiceBus/namespaces/servicens-C/topics/topic-A",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ServiceBus/namespaces/servicens-C/topics/topic-A",
+        "Identity": null,
+        "Kind": null,
+        "Location": "West Europe",
+        "ManagedBy": null,
+        "ResourceName": "topic-A",
+        "Name": "topic-A",
+        "ExtensionResourceName": null,
+        "Properties": {
+          "maxMessageSizeInKilobytes": 51200,
+          "defaultMessageTimeToLive": "P14D",
+          "maxSizeInMegabytes": 1024,
+          "requiresDuplicateDetection": false,
+          "duplicateDetectionHistoryTimeWindow": "PT10M",
+          "enableBatchedOperations": true,
+          "sizeInBytes": 0,
+          "status": "Active",
+          "supportOrdering": true,
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "enablePartitioning": false,
+          "enableExpress": false,
+          "createdAt": "2022-06-30T13:26:59.87Z",
+          "updatedAt": "2022-06-02T00:50:17.58Z",
+          "accessedAt": "2022-06-16T01:52:08.473Z",
+          "subscriptionCount": 0,
+          "countDetails": {
+            "activeMessageCount": 0,
+            "deadLetterMessageCount": 0,
+            "scheduledMessageCount": 0,
+            "transferMessageCount": 0,
+            "transferDeadLetterMessageCount": 0
+          }
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.ServiceBus/namespaces/topics",
+        "ResourceType": "Microsoft.ServiceBus/namespaces/topics",
+        "ExtensionResourceType": null,
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+      },
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ServiceBus/namespaces/servicens-C/topics/topic-B",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ServiceBus/namespaces/servicens-C/topics/topic-B",
+        "Identity": null,
+        "Kind": null,
+        "Location": "West Europe",
+        "ManagedBy": null,
+        "ResourceName": "topic-B",
+        "Name": "topic-B",
+        "ExtensionResourceName": null,
+        "Properties": {
+          "maxMessageSizeInKilobytes": 51200,
+          "defaultMessageTimeToLive": "P14D",
+          "maxSizeInMegabytes": 1024,
+          "requiresDuplicateDetection": false,
+          "duplicateDetectionHistoryTimeWindow": "PT10M",
+          "enableBatchedOperations": true,
+          "sizeInBytes": 0,
+          "status": "Active",
+          "supportOrdering": true,
+          "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+          "enablePartitioning": false,
+          "enableExpress": false,
+          "createdAt": "2022-04-21T11:59:31.5Z",
+          "updatedAt": "2022-04-21T11:59:31.567Z",
+          "accessedAt": "2022-05-05T12:00:49.443Z",
+          "subscriptionCount": 0,
+          "countDetails": {
+            "activeMessageCount": 0,
+            "deadLetterMessageCount": 0,
+            "scheduledMessageCount": 0,
+            "transferMessageCount": 0,
+            "transferDeadLetterMessageCount": 0
+          }
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.ServiceBus/namespaces/topics",
+        "ResourceType": "Microsoft.ServiceBus/namespaces/topics",
+        "ExtensionResourceType": null,
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and the checklist -->

Fixes #1777 

Added Azure.ServiceBus.MinTLS rule.

This rule checks for that service bus namespaces uses minimum TLS 1.2 version.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
