### PR TITLE
Pre-release v1.21.0-B0011

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,16 +24,17 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
-- New rules:
-  - VNET:
-    - Check VNETs with a GatewaySubnet also has a AzureBastionSubnet by @bengeset96.
-      [#1761](https://github.com/Azure/PSRule.Rules.Azure/issues/1761)
+## v1.21.0-B0011 (pre-release)
 
-What's changed since pre-release v1.20.0:
+What's changed since pre-release v1.20.1:
 
 - New features:
   - Mapping of Azure Security Benchmark v3 to security rules by @jagoodwin.
     [#1610](https://github.com/Azure/PSRule.Rules.Azure/issues/1610)
+- New rules:
+  - Virtual Network:
+    - Check VNETs with a GatewaySubnet also has a AzureBastionSubnet by @bengeset96.
+      [#1761](https://github.com/Azure/PSRule.Rules.Azure/issues/1761)
 - General improvements:
   - Added built-in list of ignored policy definitions by @BernieWhite.
     [#1730](https://github.com/Azure/PSRule.Rules.Azure/issues/1730)


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.20.1:

- New features:
  - Mapping of Azure Security Benchmark v3 to security rules by @jagoodwin.
    [#1610](https://github.com/Azure/PSRule.Rules.Azure/issues/1610)
- New rules:
  - Virtual Network:
    - Check VNETs with a GatewaySubnet also has a AzureBastionSubnet by @bengeset96.
      [#1761](https://github.com/Azure/PSRule.Rules.Azure/issues/1761)
- General improvements:
  - Added built-in list of ignored policy definitions by @BernieWhite.
    [#1730](https://github.com/Azure/PSRule.Rules.Azure/issues/1730)
    - To ignore additional policy definitions, use the `AZURE_POLICY_IGNORE_LIST` configuration option.
- Engineering:
  - Bump PSRule to v2.5.1.
    [#1782](https://github.com/Azure/PSRule.Rules.Azure/pull/1782)
  - Bump Az.Resources to v6.3.0.
    [#1782](https://github.com/Azure/PSRule.Rules.Azure/pull/1782)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
