### PR TITLE
Added Azure.VM.MigrateAMA and Azure.VMSS.MigrateAMA

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,14 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+- New rules:
+  - Virtual Machine:
+    - Check virtual machines uses Azure Monitor Agent instead of old legacy Log Analytics Agent by @bengeset96.
+      [#1792](https://github.com/Azure/PSRule.Rules.Azure/issues/1792)
+  - Virtual Machine Scale Sets:
+    - Check virtual machine scale sets uses Azure Monitor Agent instead of old legacy Log Analytics Agent by @bengeset96.
+      [#1792](https://github.com/Azure/PSRule.Rules.Azure/issues/1792)
+
 What's changed since pre-release v1.21.0-B0027:
 
 - Engineering:

--- a/docs/en/rules/Azure.VM.MigrateAMA.md
+++ b/docs/en/rules/Azure.VM.MigrateAMA.md
@@ -1,0 +1,129 @@
+---
+severity: Important
+pillar: Operational Excellence
+category: Monitoring
+resource: Virtual Machine
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VM.MigrateAMA/
+---
+
+# Migrate to Azure Monitor Agent
+
+## SYNOPSIS
+
+Use Azure Monitor Agent as replacement for Log Analytics Agent.
+
+## DESCRIPTION
+
+The legacy Log Analytics agent will be retired on August 31, 2024. Before that date, you'll need to start using the Azure Monitor agent to monitor your VMs and servers in Azure. The Azure Monitor agent provdes the following benefits over legacy agents:
+
+- Security and performance
+  - Enhanced security through Managed Identity and Azure Active Directory (Azure AD) tokens (for clients).
+  - A higher events-per-second (EPS) upload rate.
+- Cost savings by using data collection rules. Using DCRs is one of the most useful advantages of using Azure Monitor Agent:
+  - DCRs let you configure data collection for specific machines connected to a workspace as compared to the "all or nothing" approach of legacy agents.
+  - With DCRs, you can define which data to ingest and which data to filter out to reduce workspace clutter and save on costs.
+- Simpler management of data collection, including ease of troubleshooting:
+  - Easy multihoming on Windows and Linux.
+  - Centralized, "in the cloud" agent configuration makes every action simpler and more easily scalable throughout the data collection lifecycle, from onboarding to deployment to updates and changes over time.
+  - Greater transparency and control of more capabilities and services, such as Microsoft Sentinel, Defender for Cloud, and VM Insights.
+- A single agent that consolidates all features necessary to address all telemetry data collection needs across servers and client devices running Windows 10 or 11. A single agent is the goal, although Azure Monitor Agent currently converges with the Log Analytics agents.
+
+## RECOMMENDATION
+
+Virtual Machines should migrate to Azure Monitor Agent.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy virtual machines that pass this rule:
+
+- Deploy a extension sub-resource (extension resource).
+- Set `properties.publisher` to `'Microsoft.Azure.Monitor'`.
+- Set `properties.type` to `'AzureMonitorWindowsAgent'` (Windows) or `'AzureMonitorLinuxAgent'` (Linux).
+
+For example:
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vmName": {
+      "type": "string"
+    },
+    "location": {
+      "type": "string"
+    },
+    "userAssignedManagedIdentity": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "apiVersion": "2022-08-01",
+      "name": "[format('{0}/AzureMonitorWindowsAgent', parameters('vmName'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "publisher": "Microsoft.Azure.Monitor",
+        "type": "AzureMonitorWindowsAgent",
+        "typeHandlerVersion": "1.0",
+        "settings": {
+          "authentication": {
+            "managedIdentity": {
+              "identifier-name": "mi_res_id",
+              "identifier-value": "[parameters('userAssignedManagedIdentity')]"
+            }
+          }
+        },
+        "autoUpgradeMinorVersion": true,
+        "enableAutomaticUpgrade": true
+      }
+    }
+  ]
+}
+```
+
+### Configure with Bicep
+
+To deploy virtual machines that pass this rule:
+
+- Deploy a extension sub-resource (extension resource).
+- Set `properties.publisher` to `'Microsoft.Azure.Monitor'`.
+- Set `properties.type` to `'AzureMonitorWindowsAgent'` (Windows) or `'AzureMonitorLinuxAgent'` (Linux).
+
+For example:
+
+```bicep
+param vmName string
+param location string
+param userAssignedManagedIdentity string
+
+resource windowsAgent 'Microsoft.Compute/virtualMachines/extensions@2022-08-01' = {
+  name: '${vmName}/AzureMonitorWindowsAgent'
+  location: location
+  properties: {
+    publisher: 'Microsoft.Azure.Monitor'
+    type: 'AzureMonitorWindowsAgent'
+    typeHandlerVersion: '1.0'
+    autoUpgradeMinorVersion: true
+    enableAutomaticUpgrade: true
+    settings: {
+      authentication: {
+        managedIdentity: {
+          identifier-name: 'mi_res_id'
+          identifier-value: userAssignedManagedIdentity
+        }
+      }
+    }
+  }
+}
+```
+
+## LINKS
+
+- [Monitoring](https://learn.microsoft.com/azure/architecture/framework/devops/checklist)
+- [Log Analytics agent retiring](https://azure.microsoft.com/updates/were-retiring-the-log-analytics-agent-in-azure-monitor-on-31-august-2024)
+- [Migrate to Azure Monitor Agent from Log Analytics Agent](https://learn.microsoft.com/azure/azure-monitor/agents/azure-monitor-agent-migration)
+- [Azure template reference](https://learn.microsoft.com/azure/templates/microsoft.compute/virtualmachines/extensions)

--- a/docs/en/rules/Azure.VMSS.MigrateAMA.md
+++ b/docs/en/rules/Azure.VMSS.MigrateAMA.md
@@ -1,0 +1,354 @@
+---
+severity: Important
+pillar: Operational Excellence
+category: Monitoring
+resource: Virtual Machine Scale Sets
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VMSS.MigrateAMA/
+---
+
+# Migrate to Azure Monitor Agent
+
+## SYNOPSIS
+
+Use Azure Monitor Agent as replacement for Log Analytics Agent.
+
+## DESCRIPTION
+
+The legacy Log Analytics agent will be retired on August 31, 2024. Before that date, you'll need to start using the Azure Monitor agent to monitor your virtual machine scale sets. The Azure Monitor agent provdes the following benefits over legacy agents:
+
+- Security and performance
+  - Enhanced security through Managed Identity and Azure Active Directory (Azure AD) tokens (for clients).
+  - A higher events-per-second (EPS) upload rate.
+- Cost savings by using data collection rules. Using DCRs is one of the most useful advantages of using Azure Monitor Agent:
+  - DCRs let you configure data collection for specific machines connected to a workspace as compared to the "all or nothing" approach of legacy agents.
+  - With DCRs, you can define which data to ingest and which data to filter out to reduce workspace clutter and save on costs.
+- Simpler management of data collection, including ease of troubleshooting:
+  - Easy multihoming on Windows and Linux.
+  - Centralized, "in the cloud" agent configuration makes every action simpler and more easily scalable throughout the data collection lifecycle, from onboarding to deployment to updates and changes over time.
+  - Greater transparency and control of more capabilities and services, such as Microsoft Sentinel, Defender for Cloud, and VM Insights.
+- A single agent that consolidates all features necessary to address all telemetry data collection needs across servers and client devices running Windows 10 or 11. A single agent is the goal, although Azure Monitor Agent currently converges with the Log Analytics agents.
+
+## RECOMMENDATION
+
+Virtual Machine Scale Sets should migrate to Azure Monitor Agent.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy virtual machine scale sets that pass this rule:
+
+- Set `properties.virtualMachineProfile.extensionProfile.extensions.properties.publisher` to `'Microsoft.Azure.Monitor'`.
+- Set `properties.virtualMachineProfile.extensionProfile.extensions.properties.type` to `'AzureMonitorWindowsAgent'` (Windows) or `'AzureMonitorLinuxAgent'` (Linux).
+
+For example:
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vmssName": {
+      "type": "string",
+      "defaultValue": "vmss-01"
+    },
+    "location": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Compute/virtualMachineScaleSets",
+      "apiVersion": "2022-08-01",
+      "name": "[parameters('vmssName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "b2ms",
+        "tier": "Standard",
+        "capacity": 1
+      },
+      "properties": {
+        "overprovision": true,
+        "upgradePolicy": {
+          "mode": "Automatic"
+        },
+        "singlePlacementGroup": true,
+        "platformFaultDomainCount": 3,
+        "virtualMachineProfile": {
+          "extensionProfile": {
+            "extensions": [
+              {
+                "name": "[format('{0}/AzureMonitorLinuxAgent', parameters('vmssName'))]",
+                "properties": {
+                  "autoUpgradeMinorVersion": true,
+                  "enableAutomaticUpgrade": true,
+                  "publisher": "Microsoft.Azure.Monitor",
+                  "type": "AzureMonitorLinuxAgent",
+                  "typeHandlerVersion": "1.21"
+                }
+              }
+            ]
+          },
+          "storageProfile": {
+            "osDisk": {
+              "caching": "ReadWrite",
+              "createOption": "FromImage"
+            },
+            "imageReference": {
+              "publisher": "microsoft-aks",
+              "offer": "aks",
+              "sku": "aks-ubuntu-1804-202208",
+              "version": "2022.08.29"
+            }
+          },
+          "osProfile": {
+            "adminUsername": "azureuser",
+            "computerNamePrefix": "vmss-01",
+            "linuxConfiguration": {
+              "disablePasswordAuthentication": true
+            },
+            "provisionVMAgent": true,
+            "ssh": {
+              "publicKeys": [
+                {
+                  "path": "/home/azureuser/.ssh/authorized_keys"
+                }
+              ]
+            }
+          },
+          "networkProfile": {
+            "networkInterfaceConfigurations": [
+              {
+                "name": "vmss-001",
+                "properties": {
+                  "primary": true,
+                  "enableAcceleratedNetworking": true,
+                  "networkSecurityGroup": {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-001"
+                  },
+                  "ipConfigurations": [
+                    {
+                      "name": "ipconfig1",
+                      "properties": {
+                        "primary": true,
+                        "subnet": {
+                          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                        },
+                        "privateIPAddressVersion": "IPv4",
+                        "loadBalancerBackendAddressPools": [
+                          {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+To deploy virtual machine scale sets with a extension sub resource that pass this rule:
+
+- Deploy a extension sub-resource (extension resource).
+- Set `properties.publisher` to `'Microsoft.Azure.Monitor'`.
+- Set `properties.type` to `'AzureMonitorWindowsAgent'` (Windows) or `'AzureMonitorLinuxAgent'` (Linux).
+
+For example:
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vmssName": {
+      "type": "string"
+    },
+    "location": {
+      "type": "string"
+    },
+    "userAssignedManagedIdentity": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
+      "apiVersion": "2022-08-01",
+      "name": "[format('{0}/AzureMonitorLinuxAgent', parameters('vmssName'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "publisher": "Microsoft.Azure.Monitor",
+        "type": "AzureMonitorLinuxAgent",
+        "typeHandlerVersion": "1.21",
+          "settings": {
+          "authentication": {
+            "managedIdentity": {
+              "identifier-name": "mi_res_id",
+              "identifier-value": "[parameters('userAssignedManagedIdentity')]"
+            }
+          }
+        },
+        "autoUpgradeMinorVersion": true,
+        "enableAutomaticUpgrade": true
+      }
+    }
+  ]
+}
+```
+
+### Configure with Bicep
+
+To deploy virtual machines that pass this rule:
+
+- Deploy a extension sub-resource (extension resource).
+- Set `properties.publisher` to `'Microsoft.Azure.Monitor'`.
+- Set `properties.type` to `'AzureMonitorWindowsAgent'` (Windows) or `'AzureMonitorLinuxAgent'` (Linux).
+
+For example:
+
+```bicep
+param vmssName string = 'vmss-01'
+param location string
+
+resource vmScaleSet 'Microsoft.Compute/virtualMachineScaleSets@2022-08-01' = {
+  name: vmssName
+  location: location
+  sku: {
+    name: 'b2ms'
+    tier: 'Standard'
+    capacity: 1
+  }
+  properties: {
+    overprovision: true
+    upgradePolicy: {
+      mode: 'Automatic'
+    }
+    singlePlacementGroup: true
+    platformFaultDomainCount: 3
+    virtualMachineProfile: {
+      extensionProfile: {
+        extensions: [
+          {
+            name: '${vmssName}/AzureMonitorLinuxAgent'
+
+            properties: {
+              autoUpgradeMinorVersion: true
+              enableAutomaticUpgrade: true
+              publisher: 'Microsoft.Azure.Monitor'
+              type: 'AzureMonitorLinuxAgent'
+              typeHandlerVersion: '1.21'
+            }
+          }
+        ]
+      }
+      storageProfile: {
+        osDisk: {
+          caching: 'ReadWrite'
+          createOption: 'FromImage'
+        }
+        imageReference: {
+          publisher: 'microsoft-aks'
+          offer: 'aks'
+          sku: 'aks-ubuntu-1804-202208'
+          version: '2022.08.29'
+        }
+      }
+      osProfile: {
+        adminUsername: 'azureuser'
+        computerNamePrefix: 'vmss-01'
+        linuxConfiguration: {
+          disablePasswordAuthentication: true
+        }
+        provisionVMAgent: true
+        ssh: {
+          publicKeys: [
+            {
+              path: '/home/azureuser/.ssh/authorized_keys'
+            }
+          ]
+        }
+      }
+      networkProfile: {
+        networkInterfaceConfigurations: [
+          {
+            name: 'vmss-001'
+            properties: {
+              primary: true
+              enableAcceleratedNetworking: true
+              networkSecurityGroup: {
+                id: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-001'
+              }
+              ipConfigurations: [
+                {
+                  name: 'ipconfig1'
+                  properties: {
+                    primary: true
+                    subnet: {
+                      id: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001'
+                    }
+                    privateIPAddressVersion: 'IPv4'
+                    loadBalancerBackendAddressPools: [
+                      {
+                        id: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes'
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+To deploy virtual machine scale sets with a extension sub resource that pass this rule:
+
+- Deploy a extension sub-resource (extension resource).
+- Set `properties.publisher` to `'Microsoft.Azure.Monitor'`.
+- Set `properties.type` to `'AzureMonitorWindowsAgent'` (Windows) or `'AzureMonitorLinuxAgent'` (Linux).
+
+For example:
+
+```bicep
+param vmssName string
+param location string
+param userAssignedManagedIdentity string
+
+resource linuxAgent 'Microsoft.Compute/virtualMachineScaleSets/extensions@2022-08-01' = {
+  name: '${vmssName}/AzureMonitorLinuxAgent'
+  location: location
+  properties: {
+    publisher: 'Microsoft.Azure.Monitor'
+    type: 'AzureMonitorLinuxAgent'
+    typeHandlerVersion: '1.21'
+    autoUpgradeMinorVersion: true
+    enableAutomaticUpgrade: true
+    settings: {
+      authentication: {
+        managedIdentity: {
+          identifier-name: 'mi_res_id'
+          identifier-value: userAssignedManagedIdentity
+        }
+      }
+    }
+  }
+}
+```
+
+## LINKS
+
+- [Monitoring](https://learn.microsoft.com/azure/architecture/framework/devops/checklist)
+- [Log Analytics agent retiring](https://azure.microsoft.com/updates/were-retiring-the-log-analytics-agent-in-azure-monitor-on-31-august-2024)
+- [Migrate to Azure Monitor Agent from Log Analytics Agent](https://learn.microsoft.com/azure/azure-monitor/agents/azure-monitor-agent-migration)
+- [Azure template reference](https://learn.microsoft.com/azure/templates/microsoft.compute/virtualmachinescalesets)
+- [Azure template reference](https://learn.microsoft.com/azure/templates/microsoft.compute/virtualmachinescalesets/extensions)

--- a/docs/en/rules/Azure.VMSS.MigrateAMA.md
+++ b/docs/en/rules/Azure.VMSS.MigrateAMA.md
@@ -205,11 +205,10 @@ For example:
 
 ### Configure with Bicep
 
-To deploy virtual machines that pass this rule:
+To deploy virtual machine scale sets that pass this rule:
 
-- Deploy a extension sub-resource (extension resource).
-- Set `properties.publisher` to `'Microsoft.Azure.Monitor'`.
-- Set `properties.type` to `'AzureMonitorWindowsAgent'` (Windows) or `'AzureMonitorLinuxAgent'` (Linux).
+- Set `properties.virtualMachineProfile.extensionProfile.extensions.properties.publisher` to `'Microsoft.Azure.Monitor'`.
+- Set `properties.virtualMachineProfile.extensionProfile.extensions.properties.type` to `'AzureMonitorWindowsAgent'` (Windows) or `'AzureMonitorLinuxAgent'` (Linux).
 
 For example:
 

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -75,5 +75,5 @@
     SecureParameterRequired = "The property '{0}' must use a secure parameter but does not."
     BastionSubnetNotFound = "The virtual network '{0}' with a GatewaySubnet also should have an AzureBastionSubnet configured."
     ServiceBusMinTLS = "The service bus namespace '{0}' should minimum use TLS 1.2 version."
-    LogAnalyticsAgentDeprecated = "The Log Analytics is deprecated and will be retired on August 31, 2024. Migrate to the Azure Monitor Agent."
+    LogAnalyticsAgentDeprecated = "The legacy Log Analytics Agent is deprecated and will be retired on August 31, 2024. Migrate to the Azure Monitor Agent."
 }

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -75,4 +75,5 @@
     SecureParameterRequired = "The property '{0}' must use a secure parameter but does not."
     BastionSubnetNotFound = "The virtual network '{0}' with a GatewaySubnet also should have an AzureBastionSubnet configured."
     ServiceBusMinTLS = "The service bus namespace '{0}' should minimum use TLS 1.2 version."
+    LogAnalyticsAgentDeprecated = "The Log Analytics is deprecated and will be retired on August 31, 2024. Migrate to the Azure Monitor Agent."
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -205,7 +205,7 @@ function global:IsLinuxOffering {
 
         return $False
     }
- }
+}
  
 function global:VMHasLinuxOS {
     [CmdletBinding()]
@@ -217,7 +217,7 @@ function global:VMHasLinuxOS {
         }
 
         return $TargetObject.Properties.storageProfile.osDisk.osType -eq 'Linux' -or
-            $Assert.HasField($TargetObject, 'properties.osProfile.linuxConfiguration').Result -or
+        $Assert.HasField($TargetObject, 'properties.osProfile.linuxConfiguration').Result -or
             (IsLinuxOffering($TargetObject.Properties.storageProfile.imageReference))
     }
 }
@@ -232,7 +232,7 @@ function global:VMSSHasLinuxOS {
         }
 
         return $TargetObject.Properties.virtualMachineProfile.storageProfile.osDisk.osType -eq 'Linux' -or
-            $Assert.HasField($TargetObject, 'properties.virtualMachineProfile.osProfile.linuxConfiguration').Result -or
+        $Assert.HasField($TargetObject, 'properties.virtualMachineProfile.osProfile.linuxConfiguration').Result -or
             (IsLinuxOffering($TargetObject.Properties.virtualMachineProfile.storageProfile.imageReference))
     }
 }
@@ -395,7 +395,7 @@ function global:GetIPAddressSummary {
     param ()
     process {
         $firewallRules = @($TargetObject.resources | Where-Object -FilterScript {
-                $_.Type -like "*/firewallRules"
+                $_.Type -like '*/firewallRules'
             } | ForEach-Object -Process {
                 if (!($_.ResourceName -eq 'AllowAllWindowsAzureIps' -or ($_.properties.startIpAddress -eq '0.0.0.0' -and $_.properties.endIpAddress -eq '0.0.0.0'))) {
                     $_;
@@ -406,7 +406,7 @@ function global:GetIPAddressSummary {
         $public = 0;
 
         foreach ($fwRule in $firewallRules) {
-            if ($fwRule.Properties.startIpAddress -like "10.*" -or $fwRule.Properties.startIpAddress -like "172.*" -or $fwRule.Properties.startIpAddress -like "192.168.*") {
+            if ($fwRule.Properties.startIpAddress -like '10.*' -or $fwRule.Properties.startIpAddress -like '172.*' -or $fwRule.Properties.startIpAddress -like '192.168.*') {
                 $private += GetIPAddressCount -Start $fwRule.Properties.startIpAddress -End $fwRule.Properties.endIpAddress;
             }
             else {
@@ -519,4 +519,14 @@ function global:PrependConfigurationZoneWithProviderZone {
         
         return $ProviderZone;
     }
+}
+
+function global:HasLogAnalyticsAgent {
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param ()
+    process {
+        @(GetSubResources -ResourceType 'Microsoft.Compute/virtualMachines/extensions', 'Microsoft.Compute/virtualMachineScaleSets/extensions' |
+            Where-Object { $_.Properties.publisher -eq 'Microsoft.EnterpriseCloud.Monitoring' })    
+    } 
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -521,12 +521,25 @@ function global:PrependConfigurationZoneWithProviderZone {
     }
 }
 
-function global:HasLogAnalyticsAgent {
+function global:HasOMSOrAMAExtension {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param ()
     process {
-        @(GetSubResources -ResourceType 'Microsoft.Compute/virtualMachines/extensions', 'Microsoft.Compute/virtualMachineScaleSets/extensions' |
-            Where-Object { $_.Properties.publisher -eq 'Microsoft.EnterpriseCloud.Monitoring' })    
-    } 
+        if ($PSRule.TargetType -eq 'Microsoft.Compute/virtualMachines') {
+            $extensions = @(GetSubResources -ResourceType 'Microsoft.Compute/virtualMachines/extensions' |
+                Where-Object { ($_.Properties.publisher -eq 'Microsoft.EnterpriseCloud.Monitoring') -or ($_.Properties.publisher -eq 'Microsoft.Azure.Monitor') })
+            
+            $Assert.Greater($extensions, '.', 0).Result
+        }
+        elseif ($PSRule.TargetType -eq 'Microsoft.Compute/virtualMachineScaleSets') {
+            $property = $TargetObject.Properties.virtualMachineProfile.extensionProfile.extensions.properties |
+                Where-Object { ($_.publisher -eq 'Microsoft.EnterpriseCloud.Monitoring') -or ($_.publisher -eq 'Microsoft.Azure.Monitor') }
+                    $subresource = @(GetSubResources -ResourceType 'Microsoft.Compute/virtualMachineScaleSets/extensions' |
+                        Where-Object { ($_.Properties.publisher -eq 'Microsoft.EnterpriseCloud.Monitoring') -or ($_.Properties.publisher -eq 'Microsoft.Azure.Monitor') })
+                      
+            $extensions = @($property; $subresource)
+            $Assert.Greater($extensions, '.', 0).Result
+        }
+    }
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.VM.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VM.Rule.ps1
@@ -11,14 +11,14 @@
 Rule 'Azure.VM.UseManagedDisks' -Ref 'AZR-000238' -Type 'Microsoft.Compute/virtualMachines' -Tag @{ release = 'GA'; ruleSet = '2020_06'; 'Azure.WAF/pillar' = 'Security'; } -Labels @{ 'Azure.ASB.v3/control' = 'DP-4' } {
     # Check OS disk
     $Assert.
-        NullOrEmpty($TargetObject, 'properties.storageProfile.osDisk.vhd.uri').
-        WithReason(($LocalizedData.UnmanagedDisk -f $TargetObject.properties.storageProfile.osDisk.name), $True);
+    NullOrEmpty($TargetObject, 'properties.storageProfile.osDisk.vhd.uri').
+    WithReason(($LocalizedData.UnmanagedDisk -f $TargetObject.properties.storageProfile.osDisk.name), $True);
 
     # Check data disks
     foreach ($dataDisk in $TargetObject.properties.storageProfile.dataDisks) {
         $Assert.
-            NullOrEmpty($dataDisk, 'vhd.uri').
-            WithReason(($LocalizedData.UnmanagedDisk -f $dataDisk.name), $True);
+        NullOrEmpty($dataDisk, 'vhd.uri').
+        WithReason(($LocalizedData.UnmanagedDisk -f $dataDisk.name), $True);
     }
 }
 
@@ -29,8 +29,8 @@ Rule 'Azure.VM.DiskCaching' -Ref 'AZR-000242' -Type 'Microsoft.Compute/virtualMa
 
     # Check data disks
     $dataDisks = @($TargetObject.properties.storageProfile.dataDisks | Where-Object {
-        $Null -ne $_
-    })
+            $Null -ne $_
+        })
     if ($dataDisks.Length -gt 0) {
         foreach ($disk in $dataDisks) {
             if ($disk.managedDisk.storageAccountType -eq 'Premium_LRS') {
@@ -229,3 +229,12 @@ Rule 'Azure.VM.PPGName' -Ref 'AZR-000260' -Type 'Microsoft.Compute/proximityPlac
 }
 
 #endregion Proximity Placement Groups
+
+#region Azure Monitor Agent
+
+# Synopsis: Use Azure Monitor Agent as replacement for Log Analytics Agent.
+Rule 'Azure.VM.AMA' -Ref 'AZR-000317' -Type 'Microsoft.Compute/virtualMachines' -If { HasLogAnalyticsAgent } -Tag @{ release = 'GA'; ruleSet = '2022_12' } {
+    $Assert.Fail($LocalizedData.LogAnalyticsAgentDeprecated)
+}
+
+#endregion Azure Monitor Agent

--- a/src/PSRule.Rules.Azure/rules/Azure.VMSS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VMSS.Rule.ps1
@@ -60,7 +60,7 @@ Rule 'Azure.VMSS.MigrateAMA' -Ref 'AZR-000318' -Type 'Microsoft.Compute/virtualM
                         (($_.Properties.publisher -eq 'Microsoft.EnterpriseCloud.Monitoring') -and ($_.Properties.type -eq 'OmsAgentForLinux')) })
     
     $extensions = @($property; $subresource)
-    $Assert.Less($extensions, '.', 1).Reason($LocalizedData.LogAnalyticsAgentDeprecated).PathPrefix('resources')
+    $Assert.Less($extensions, '.', 1).Reason($LocalizedData.LogAnalyticsAgentDeprecated)
 }
 
 #endregion Virtual machine scale set

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VM.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VM.Tests.ps1
@@ -513,6 +513,27 @@ Describe 'Azure.VM' -Tag 'VM' {
             $ruleResult.Length | Should -Be 4;
             $ruleResult.TargetName | Should -BeIn 'ReplicaVM_DataDisk_0-ASRReplica', 'disk-A', 'disk-B', 'disk-C';
         }
+
+        It 'Azure.VM.MigrateAMA' {
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.VirtualMachine.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VM.MigrateAMA' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'vm-B', 'vm-D';
+
+            $ruleResult[0].Reason | Should -BeExactly "The legacy Log Analytics Agent is deprecated and will be retired on August 31, 2024. Migrate to the Azure Monitor Agent.";
+            $ruleResult[1].Reason | Should -BeExactly "The legacy Log Analytics Agent is deprecated and will be retired on August 31, 2024. Migrate to the Azure Monitor Agent.";
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'vm-A', 'vm-C';
+        }
     }
 
     Context 'Resource name - Azure.VM.Name' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VMSS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VMSS.Tests.ps1
@@ -48,8 +48,8 @@ Describe 'Azure.VMSS' -Tag 'VMSS' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'vmss-001', 'vmss-002', 'vmss-003';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'vmss-001', 'vmss-002', 'vmss-003', 'vmss-004', 'vmss-005';
         }
 
         It 'Azure.VMSS.ComputerName' {
@@ -62,8 +62,8 @@ Describe 'Azure.VMSS' -Tag 'VMSS' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'vmss-001', 'vmss-002', 'vmss-003';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'vmss-001', 'vmss-002', 'vmss-003', 'vmss-004', 'vmss-005';
         }
     }
 
@@ -251,8 +251,8 @@ Describe 'Azure.VMSS' -Tag 'VMSS' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'vmss-001';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'vmss-001', 'vmss-005';
         }
 
         It 'Azure.VMSS.MigrateAMA' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VMSS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VMSS.Tests.ps1
@@ -254,5 +254,27 @@ Describe 'Azure.VMSS' -Tag 'VMSS' {
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -BeIn 'vmss-001';
         }
+
+        It 'Azure.VMSS.MigrateAMA' {
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.VMSS.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VMSS.MigrateAMA' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'vmss-002', 'vmss-004', 'vmss-005';
+
+            $ruleResult[0].Reason | Should -BeExactly "The legacy Log Analytics Agent is deprecated and will be retired on August 31, 2024. Migrate to the Azure Monitor Agent.";
+            $ruleResult[1].Reason | Should -BeExactly "The legacy Log Analytics Agent is deprecated and will be retired on August 31, 2024. Migrate to the Azure Monitor Agent.";
+            $ruleResult[2].Reason | Should -BeExactly "The legacy Log Analytics Agent is deprecated and will be retired on August 31, 2024. Migrate to the Azure Monitor Agent.";
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'vmss-001', 'vmss-003';
+        }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VMSS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VMSS.json
@@ -1,448 +1,807 @@
 [
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-001",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-001",
-        "Identity": null,
-        "Kind": null,
-        "Location": "region",
-        "ManagedBy": null,
-        "ResourceName": "vmss-001",
-        "Name": "vmss-001",
-        "ExtensionResourceName": null,
-        "ParentResource": null,
-        "Plan": null,
-        "Properties": {
-            "singlePlacementGroup": true,
-            "upgradePolicy": {
-                "mode": "Manual"
-            },
-            "virtualMachineProfile": {
-                "osProfile": {
-                    "computerNamePrefix": "vmss-001",
-                    "adminUsername": "azureuser",
-                    "linuxConfiguration": {
-                        "disablePasswordAuthentication": true,
-                        "ssh": {
-                            "publicKeys": [
-                                {
-                                    "path": "/home/azureuser/.ssh/authorized_keys"
-                                }
-                            ]
-                        },
-                        "provisionVMAgent": true
-                    },
-                    "secrets": [],
-                    "allowExtensionOperations": true,
-                    "requireGuestProvisionSignal": true
-                },
-                "storageProfile": {
-                    "osDisk": {
-                        "createOption": "FromImage",
-                        "caching": "ReadWrite",
-                        "managedDisk": {
-                            "storageAccountType": "Premium_LRS"
-                        },
-                        "diskSizeGB": 100
-                    },
-                    "imageReference": {
-                        "publisher": "microsoft-aks",
-                        "offer": "aks",
-                        "sku": "aks-ubuntu-1604-202003",
-                        "version": "2020.03.05"
-                    }
-                },
-                "networkProfile": {
-                    "networkInterfaceConfigurations": [
-                        {
-                            "name": "vmss-001",
-                            "properties": {
-                                "primary": true,
-                                "enableAcceleratedNetworking": false,
-                                "networkSecurityGroup": {
-                                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-001"
-                                },
-                                "dnsSettings": {
-                                    "dnsServers": []
-                                },
-                                "enableIPForwarding": false,
-                                "ipConfigurations": [
-                                    {
-                                        "name": "ipconfig1",
-                                        "properties": {
-                                            "primary": true,
-                                            "subnet": {
-                                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
-                                            },
-                                            "privateIPAddressVersion": "IPv4",
-                                            "loadBalancerBackendAddressPools": [
-                                                {
-                                                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "name": "ipconfig2",
-                                        "properties": {
-                                            "subnet": {
-                                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
-                                            },
-                                            "privateIPAddressVersion": "IPv4"
-                                        }
-                                    },
-                                    {
-                                        "name": "ipconfig3",
-                                        "properties": {
-                                            "subnet": {
-                                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
-                                            },
-                                            "privateIPAddressVersion": "IPv4"
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                },
-                "extensionProfile": {
-                    "extensions": [
-                        {
-                            "name": "vmssCSE",
-                            "properties": {
-                                "autoUpgradeMinorVersion": true,
-                                "publisher": "Microsoft.Azure.Extensions",
-                                "type": "CustomScript",
-                                "typeHandlerVersion": "2.0",
-                                "settings": {}
-                            }
-                        },
-                        {
-                            "name": "vmss-001-AKSLinuxBilling",
-                            "properties": {
-                                "autoUpgradeMinorVersion": true,
-                                "publisher": "Microsoft.AKS",
-                                "type": "Compute.AKS.Linux.Billing",
-                                "typeHandlerVersion": "1.0",
-                                "settings": {}
-                            }
-                        }
-                    ]
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-001",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-001",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "vmss-001",
+    "Name": "vmss-001",
+    "ExtensionResourceName": null,
+    "ParentResource": null,
+    "Plan": null,
+    "Properties": {
+      "singlePlacementGroup": true,
+      "upgradePolicy": {
+        "mode": "Manual"
+      },
+      "virtualMachineProfile": {
+        "osProfile": {
+          "computerNamePrefix": "vmss-001",
+          "adminUsername": "azureuser",
+          "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
+            "ssh": {
+              "publicKeys": [
+                {
+                  "path": "/home/azureuser/.ssh/authorized_keys"
                 }
+              ]
             },
-            "provisioningState": "Succeeded",
-            "overprovision": false,
-            "doNotRunExtensionsOnOverprovisionedVMs": false
+            "provisionVMAgent": true
+          },
+          "secrets": [],
+          "allowExtensionOperations": true,
+          "requireGuestProvisionSignal": true
         },
-        "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Compute/virtualMachineScaleSets",
-        "ResourceType": "Microsoft.Compute/virtualMachineScaleSets",
-        "ExtensionResourceType": null,
-        "Sku": {
-            "Name": "Standard_B2ms",
-            "Tier": "Standard",
-            "Size": null,
-            "Family": null,
-            "Model": null,
-            "Capacity": 1
+        "storageProfile": {
+          "osDisk": {
+            "createOption": "FromImage",
+            "caching": "ReadWrite",
+            "managedDisk": {
+              "storageAccountType": "Premium_LRS"
+            },
+            "diskSizeGB": 100
+          },
+          "imageReference": {
+            "publisher": "microsoft-aks",
+            "offer": "aks",
+            "sku": "aks-ubuntu-1604-202003",
+            "version": "2020.03.05"
+          }
         },
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+        "networkProfile": {
+          "networkInterfaceConfigurations": [
+            {
+              "name": "vmss-001",
+              "properties": {
+                "primary": true,
+                "enableAcceleratedNetworking": false,
+                "networkSecurityGroup": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-001"
+                },
+                "dnsSettings": {
+                  "dnsServers": []
+                },
+                "enableIPForwarding": false,
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "primary": true,
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                      },
+                      "privateIPAddressVersion": "IPv4",
+                      "loadBalancerBackendAddressPools": [
+                        {
+                          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "ipconfig2",
+                    "properties": {
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                      },
+                      "privateIPAddressVersion": "IPv4"
+                    }
+                  },
+                  {
+                    "name": "ipconfig3",
+                    "properties": {
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                      },
+                      "privateIPAddressVersion": "IPv4"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "extensionProfile": {
+          "extensions": [
+            {
+              "name": "vmssCSE",
+              "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.0",
+                "settings": {}
+              }
+            },
+            {
+              "name": "vmss-001-AKSLinuxBilling",
+              "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.AKS",
+                "type": "Compute.AKS.Linux.Billing",
+                "typeHandlerVersion": "1.0",
+                "settings": {}
+              }
+            }
+          ]
+        }
+      },
+      "provisioningState": "Succeeded",
+      "overprovision": false,
+      "doNotRunExtensionsOnOverprovisionedVMs": false
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-002",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-002",
-        "Identity": null,
-        "Kind": null,
-        "Location": "region",
-        "ManagedBy": null,
-        "ResourceName": "vmss-002",
-        "Name": "vmss-002",
-        "ExtensionResourceName": null,
-        "ParentResource": null,
-        "Plan": null,
-        "Properties": {
-            "singlePlacementGroup": true,
-            "upgradePolicy": {
-                "mode": "Manual"
-            },
-            "virtualMachineProfile": {
-                "osProfile": {
-                    "computerNamePrefix": "vmss-002",
-                    "adminUsername": "azureuser",
-                    "linuxConfiguration": {
-                        "disablePasswordAuthentication": false,
-                        "ssh": {
-                            "publicKeys": [
-                                {
-                                    "path": "/home/azureuser/.ssh/authorized_keys"
-                                }
-                            ]
-                        },
-                        "provisionVMAgent": true
-                    },
-                    "secrets": [],
-                    "allowExtensionOperations": true,
-                    "requireGuestProvisionSignal": true
-                },
-                "storageProfile": {
-                    "osDisk": {
-                        "createOption": "FromImage",
-                        "caching": "ReadWrite",
-                        "managedDisk": {
-                            "storageAccountType": "Premium_LRS"
-                        },
-                        "diskSizeGB": 100
-                    },
-                    "imageReference": {
-                        "publisher": "microsoft-aks",
-                        "offer": "aks",
-                        "sku": "aks-ubuntu-1604-202003",
-                        "version": "2020.03.05"
-                    }
-                },
-                "networkProfile": {
-                    "networkInterfaceConfigurations": [
-                        {
-                            "name": "vmss-002",
-                            "properties": {
-                                "primary": true,
-                                "enableAcceleratedNetworking": false,
-                                "networkSecurityGroup": {
-                                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-002"
-                                },
-                                "dnsSettings": {
-                                    "dnsServers": []
-                                },
-                                "enableIPForwarding": false,
-                                "ipConfigurations": [
-                                    {
-                                        "name": "ipconfig1",
-                                        "properties": {
-                                            "primary": true,
-                                            "subnet": {
-                                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-002/subnets/subnet-002"
-                                            },
-                                            "privateIPAddressVersion": "IPv4",
-                                            "loadBalancerBackendAddressPools": [
-                                                {
-                                                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "name": "ipconfig2",
-                                        "properties": {
-                                            "subnet": {
-                                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-002/subnets/subnet-002"
-                                            },
-                                            "privateIPAddressVersion": "IPv4"
-                                        }
-                                    },
-                                    {
-                                        "name": "ipconfig3",
-                                        "properties": {
-                                            "subnet": {
-                                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-002/subnets/subnet-002"
-                                            },
-                                            "privateIPAddressVersion": "IPv4"
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                },
-                "extensionProfile": {
-                    "extensions": [
-                        {
-                            "name": "vmssCSE",
-                            "properties": {
-                                "autoUpgradeMinorVersion": true,
-                                "publisher": "Microsoft.Azure.Extensions",
-                                "type": "CustomScript",
-                                "typeHandlerVersion": "2.0",
-                                "settings": {}
-                            }
-                        },
-                        {
-                            "name": "vmss-002-AKSLinuxBilling",
-                            "properties": {
-                                "autoUpgradeMinorVersion": true,
-                                "publisher": "Microsoft.AKS",
-                                "type": "Compute.AKS.Linux.Billing",
-                                "typeHandlerVersion": "1.0",
-                                "settings": {}
-                            }
-                        }
-                    ]
-                }
-            },
-            "provisioningState": "Succeeded",
-            "overprovision": false,
-            "doNotRunExtensionsOnOverprovisionedVMs": false
-        },
-        "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Compute/virtualMachineScaleSets",
-        "ResourceType": "Microsoft.Compute/virtualMachineScaleSets",
-        "ExtensionResourceType": null,
-        "Sku": {
-            "Name": "Standard_B2ms",
-            "Tier": "Standard",
-            "Size": null,
-            "Family": null,
-            "Model": null,
-            "Capacity": 1
-        },
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/virtualMachineScaleSets",
+    "ResourceType": "Microsoft.Compute/virtualMachineScaleSets",
+    "ExtensionResourceType": null,
+    "Sku": {
+      "Name": "Standard_B2ms",
+      "Tier": "Standard",
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": 1
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-003",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-003",
-        "Identity": null,
-        "Kind": null,
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-001/extensions/AzureMonitorLinuxAgent",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-001/extensions/AzureMonitorLinuxAgent",
         "Location": "region",
-        "ManagedBy": null,
-        "ResourceName": "vmss-003",
-        "Name": "vmss-003",
+        "ResourceName": "AzureMonitorLinuxAgent",
+        "Name": "AzureMonitorLinuxAgent",
         "ExtensionResourceName": null,
-        "ParentResource": null,
-        "Plan": null,
+        "ParentResource": "virtualMachineScaleSets/vmss-001",
         "Properties": {
-            "singlePlacementGroup": true,
-            "upgradePolicy": {
-                "mode": "Manual"
-            },
-            "virtualMachineProfile": {
-                "osProfile": {
-                    "computerNamePrefix": "vmss-003",
-                    "adminUsername": "azureuser",
-                    "linuxConfiguration": {
-                        "ssh": {
-                            "publicKeys": [
-                                {
-                                    "path": "/home/azureuser/.ssh/authorized_keys"
-                                }
-                            ]
-                        },
-                        "provisionVMAgent": true
-                    },
-                    "secrets": [],
-                    "allowExtensionOperations": true,
-                    "requireGuestProvisionSignal": true
-                },
-                "storageProfile": {
-                    "osDisk": {
-                        "createOption": "FromImage",
-                        "caching": "ReadWrite",
-                        "managedDisk": {
-                            "storageAccountType": "Premium_LRS"
-                        },
-                        "diskSizeGB": 100
-                    },
-                    "imageReference": {
-                        "publisher": "microsoft-aks",
-                        "offer": "aks",
-                        "sku": "aks-ubuntu-1604-202003",
-                        "version": "2020.03.05"
-                    }
-                },
-                "networkProfile": {
-                    "networkInterfaceConfigurations": [
-                        {
-                            "name": "vmss-003",
-                            "properties": {
-                                "primary": true,
-                                "enableAcceleratedNetworking": false,
-                                "networkSecurityGroup": {
-                                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-003"
-                                },
-                                "dnsSettings": {
-                                    "dnsServers": []
-                                },
-                                "enableIPForwarding": false,
-                                "ipConfigurations": [
-                                    {
-                                        "name": "ipconfig1",
-                                        "properties": {
-                                            "primary": true,
-                                            "subnet": {
-                                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-003/subnets/subnet-003"
-                                            },
-                                            "privateIPAddressVersion": "IPv4",
-                                            "loadBalancerBackendAddressPools": [
-                                                {
-                                                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "name": "ipconfig2",
-                                        "properties": {
-                                            "subnet": {
-                                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-003/subnets/subnet-003"
-                                            },
-                                            "privateIPAddressVersion": "IPv4"
-                                        }
-                                    },
-                                    {
-                                        "name": "ipconfig3",
-                                        "properties": {
-                                            "subnet": {
-                                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-003/subnets/subnet-003"
-                                            },
-                                            "privateIPAddressVersion": "IPv4"
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                },
-                "extensionProfile": {
-                    "extensions": [
-                        {
-                            "name": "vmssCSE",
-                            "properties": {
-                                "autoUpgradeMinorVersion": true,
-                                "publisher": "Microsoft.Azure.Extensions",
-                                "type": "CustomScript",
-                                "typeHandlerVersion": "2.0",
-                                "settings": {}
-                            }
-                        },
-                        {
-                            "name": "vmss-003-AKSLinuxBilling",
-                            "properties": {
-                                "autoUpgradeMinorVersion": true,
-                                "publisher": "Microsoft.AKS",
-                                "type": "Compute.AKS.Linux.Billing",
-                                "typeHandlerVersion": "1.0",
-                                "settings": {}
-                            }
-                        }
-                    ]
-                }
-            },
-            "provisioningState": "Succeeded",
-            "overprovision": false,
-            "doNotRunExtensionsOnOverprovisionedVMs": false
+          "publisher": "Microsoft.Azure.Monitor",
+          "type": "AzureMonitorLinuxAgent",
+          "typeHandlerVersion": "1.21",
+          "autoUpgradeMinorVersion": true,
+          "settings": {
+            "workspaceId": "00000000-0000-0000-0000-000000000000"
+          }
         },
         "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Compute/virtualMachineScaleSets",
-        "ResourceType": "Microsoft.Compute/virtualMachineScaleSets",
+        "Type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
+        "ResourceType": "Microsoft.Compute/virtualMachineScaleSets/extensions",
         "ExtensionResourceType": null,
-        "Sku": {
-            "Name": "Standard_B2ms",
-            "Tier": "Standard",
-            "Size": null,
-            "Family": null,
-            "Model": null,
-            "Capacity": 1
+        "Sku": null,
+        "SubscriptionId": null
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-002",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-002",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "vmss-002",
+    "Name": "vmss-002",
+    "ExtensionResourceName": null,
+    "ParentResource": null,
+    "Plan": null,
+    "Properties": {
+      "singlePlacementGroup": true,
+      "upgradePolicy": {
+        "mode": "Manual"
+      },
+      "virtualMachineProfile": {
+        "osProfile": {
+          "computerNamePrefix": "vmss-002",
+          "adminUsername": "azureuser",
+          "linuxConfiguration": {
+            "disablePasswordAuthentication": false,
+            "ssh": {
+              "publicKeys": [
+                {
+                  "path": "/home/azureuser/.ssh/authorized_keys"
+                }
+              ]
+            },
+            "provisionVMAgent": true
+          },
+          "secrets": [],
+          "allowExtensionOperations": true,
+          "requireGuestProvisionSignal": true
         },
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    }
+        "storageProfile": {
+          "osDisk": {
+            "createOption": "FromImage",
+            "caching": "ReadWrite",
+            "managedDisk": {
+              "storageAccountType": "Premium_LRS"
+            },
+            "diskSizeGB": 100
+          },
+          "imageReference": {
+            "publisher": "microsoft-aks",
+            "offer": "aks",
+            "sku": "aks-ubuntu-1604-202003",
+            "version": "2020.03.05"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaceConfigurations": [
+            {
+              "name": "vmss-002",
+              "properties": {
+                "primary": true,
+                "enableAcceleratedNetworking": false,
+                "networkSecurityGroup": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-002"
+                },
+                "dnsSettings": {
+                  "dnsServers": []
+                },
+                "enableIPForwarding": false,
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "primary": true,
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-002/subnets/subnet-002"
+                      },
+                      "privateIPAddressVersion": "IPv4",
+                      "loadBalancerBackendAddressPools": [
+                        {
+                          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "ipconfig2",
+                    "properties": {
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-002/subnets/subnet-002"
+                      },
+                      "privateIPAddressVersion": "IPv4"
+                    }
+                  },
+                  {
+                    "name": "ipconfig3",
+                    "properties": {
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-002/subnets/subnet-002"
+                      },
+                      "privateIPAddressVersion": "IPv4"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "extensionProfile": {
+          "extensions": [
+            {
+              "name": "vmssCSE",
+              "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.0",
+                "settings": {}
+              }
+            },
+            {
+              "name": "vmss-002-AKSLinuxBilling",
+              "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.AKS",
+                "type": "Compute.AKS.Linux.Billing",
+                "typeHandlerVersion": "1.0",
+                "settings": {}
+              }
+            }
+          ]
+        }
+      },
+      "provisioningState": "Succeeded",
+      "overprovision": false,
+      "doNotRunExtensionsOnOverprovisionedVMs": false
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/virtualMachineScaleSets",
+    "ResourceType": "Microsoft.Compute/virtualMachineScaleSets",
+    "ExtensionResourceType": null,
+    "Sku": {
+      "Name": "Standard_B2ms",
+      "Tier": "Standard",
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": 1
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-002/extensions/OmsAgentForLinux",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-002/extensions/OmsAgentForLinux",
+        "Location": "region",
+        "ResourceName": "OmsAgentForLinux",
+        "Name": "OmsAgentForLinux",
+        "ExtensionResourceName": null,
+        "ParentResource": "virtualMachineScaleSets/vmss-002",
+        "Properties": {
+          "publisher": "Microsoft.EnterpriseCloud.Monitoring",
+          "type": "OmsAgentForLinux",
+          "typeHandlerVersion": "1.0",
+          "autoUpgradeMinorVersion": true,
+          "settings": {
+            "workspaceId": "00000000-0000-0000-0000-000000000000"
+          }
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
+        "ResourceType": "Microsoft.Compute/virtualMachineScaleSets/extensions",
+        "ExtensionResourceType": null,
+        "Sku": null,
+        "SubscriptionId": null
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-003",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-003",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "vmss-003",
+    "Name": "vmss-003",
+    "ExtensionResourceName": null,
+    "ParentResource": null,
+    "Plan": null,
+    "Properties": {
+      "singlePlacementGroup": true,
+      "upgradePolicy": {
+        "mode": "Manual"
+      },
+      "virtualMachineProfile": {
+        "osProfile": {
+          "computerNamePrefix": "vmss-003",
+          "adminUsername": "azureuser",
+          "linuxConfiguration": {
+            "ssh": {
+              "publicKeys": [
+                {
+                  "path": "/home/azureuser/.ssh/authorized_keys"
+                }
+              ]
+            },
+            "provisionVMAgent": true
+          },
+          "secrets": [],
+          "allowExtensionOperations": true,
+          "requireGuestProvisionSignal": true
+        },
+        "storageProfile": {
+          "osDisk": {
+            "createOption": "FromImage",
+            "caching": "ReadWrite",
+            "managedDisk": {
+              "storageAccountType": "Premium_LRS"
+            },
+            "diskSizeGB": 100
+          },
+          "imageReference": {
+            "publisher": "microsoft-aks",
+            "offer": "aks",
+            "sku": "aks-ubuntu-1604-202003",
+            "version": "2020.03.05"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaceConfigurations": [
+            {
+              "name": "vmss-003",
+              "properties": {
+                "primary": true,
+                "enableAcceleratedNetworking": false,
+                "networkSecurityGroup": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-003"
+                },
+                "dnsSettings": {
+                  "dnsServers": []
+                },
+                "enableIPForwarding": false,
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "primary": true,
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-003/subnets/subnet-003"
+                      },
+                      "privateIPAddressVersion": "IPv4",
+                      "loadBalancerBackendAddressPools": [
+                        {
+                          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "ipconfig2",
+                    "properties": {
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-003/subnets/subnet-003"
+                      },
+                      "privateIPAddressVersion": "IPv4"
+                    }
+                  },
+                  {
+                    "name": "ipconfig3",
+                    "properties": {
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-003/subnets/subnet-003"
+                      },
+                      "privateIPAddressVersion": "IPv4"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "extensionProfile": {
+          "extensions": [
+            {
+              "name": "vmssCSE",
+              "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.0",
+                "settings": {}
+              }
+            },
+            {
+              "name": "vmss-003-AKSLinuxBilling",
+              "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.AKS",
+                "type": "Compute.AKS.Linux.Billing",
+                "typeHandlerVersion": "1.0",
+                "settings": {}
+              }
+            },
+            {
+              "name": "AzureMonitorLinuxAgent",
+              "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.Azure.Monitor",
+                "type": "AzureMonitorLinuxAgent",
+                "typeHandlerVersion": "1.21",
+                "settings": {}
+              }
+            }
+          ]
+        }
+      },
+      "provisioningState": "Succeeded",
+      "overprovision": false,
+      "doNotRunExtensionsOnOverprovisionedVMs": false
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/virtualMachineScaleSets",
+    "ResourceType": "Microsoft.Compute/virtualMachineScaleSets",
+    "ExtensionResourceType": null,
+    "Sku": {
+      "Name": "Standard_B2ms",
+      "Tier": "Standard",
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": 1
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-004",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-004",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "vmss-004",
+    "Name": "vmss-004",
+    "ExtensionResourceName": null,
+    "ParentResource": null,
+    "Plan": null,
+    "Properties": {
+      "singlePlacementGroup": true,
+      "upgradePolicy": {
+        "mode": "Manual"
+      },
+      "virtualMachineProfile": {
+        "osProfile": {
+          "computerNamePrefix": "vmss-004",
+          "adminUsername": "azureuser",
+          "windowsConfiguration": {
+            "enableAutomaticUpdates": true,
+            "enableVMAgentPlatformUpdates": true
+          },
+          "secrets": [],
+          "allowExtensionOperations": true,
+          "requireGuestProvisionSignal": true
+        },
+        "storageProfile": {
+          "osDisk": {
+            "createOption": "FromImage",
+            "caching": "ReadWrite",
+            "managedDisk": {
+              "storageAccountType": "Premium_LRS"
+            },
+            "diskSizeGB": 256
+          },
+          "imageReference": {
+            "publisher": "MicrosoftWindowsServer",
+            "offer": "WindowsServer",
+            "sku": "2022-datacenter-azure-edition-core",
+            "version": "latest"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaceConfigurations": [
+            {
+              "name": "vmss-004",
+              "properties": {
+                "primary": true,
+                "enableAcceleratedNetworking": false,
+                "networkSecurityGroup": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-001"
+                },
+                "dnsSettings": {
+                  "dnsServers": []
+                },
+                "enableIPForwarding": false,
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "primary": true,
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                      },
+                      "privateIPAddressVersion": "IPv4",
+                      "loadBalancerBackendAddressPools": [
+                        {
+                          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/Winfarm/backendAddressPools/Winfarm"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "ipconfig2",
+                    "properties": {
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                      },
+                      "privateIPAddressVersion": "IPv4"
+                    }
+                  },
+                  {
+                    "name": "ipconfig3",
+                    "properties": {
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                      },
+                      "privateIPAddressVersion": "IPv4"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "extensionProfile": {
+          "extensions": [
+            {
+              "name": "vmssCSE",
+              "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.0",
+                "settings": {}
+              }
+            }
+          ]
+        }
+      },
+      "provisioningState": "Succeeded",
+      "overprovision": false,
+      "doNotRunExtensionsOnOverprovisionedVMs": false
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/virtualMachineScaleSets",
+    "ResourceType": "Microsoft.Compute/virtualMachineScaleSets",
+    "ExtensionResourceType": null,
+    "Sku": {
+      "Name": "Standard_B2ms",
+      "Tier": "Standard",
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": 1
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-004/extensions/OMSExtension",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-004/extensions/OMSExtension",
+        "Location": "region",
+        "ResourceName": "OMSExtension",
+        "Name": "OMSExtension",
+        "ExtensionResourceName": null,
+        "ParentResource": "virtualMachineScaleSets/vmss-004",
+        "Properties": {
+          "publisher": "Microsoft.EnterpriseCloud.Monitoring",
+          "type": "MicrosoftMonitoringAgent",
+          "typeHandlerVersion": "1.0",
+          "autoUpgradeMinorVersion": true,
+          "settings": {
+            "workspaceId": "00000000-0000-0000-0000-000000000000"
+          }
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Compute/virtualMachineScaleSets/extensions",
+        "ResourceType": "Microsoft.Compute/virtualMachineScaleSets/extensions",
+        "ExtensionResourceType": null,
+        "Sku": null,
+        "SubscriptionId": null
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-005",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-005",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "vmss-005",
+    "Name": "vmss-005",
+    "ExtensionResourceName": null,
+    "ParentResource": null,
+    "Plan": null,
+    "Properties": {
+      "singlePlacementGroup": true,
+      "upgradePolicy": {
+        "mode": "Manual"
+      },
+      "virtualMachineProfile": {
+        "osProfile": {
+          "computerNamePrefix": "vmss-005",
+          "adminUsername": "azureuser",
+          "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
+            "ssh": {
+              "publicKeys": [
+                {
+                  "path": "/home/azureuser/.ssh/authorized_keys"
+                }
+              ]
+            },
+            "provisionVMAgent": true
+          },
+          "secrets": [],
+          "allowExtensionOperations": true,
+          "requireGuestProvisionSignal": true
+        },
+        "storageProfile": {
+          "osDisk": {
+            "createOption": "FromImage",
+            "caching": "ReadWrite",
+            "managedDisk": {
+              "storageAccountType": "Premium_LRS"
+            },
+            "diskSizeGB": 256
+          },
+          "imageReference": {
+            "publisher": "RedHat",
+            "offer": "RHEL",
+            "sku": "7-LVM",
+            "version": "latest"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaceConfigurations": [
+            {
+              "name": "vmss-005",
+              "properties": {
+                "primary": true,
+                "enableAcceleratedNetworking": false,
+                "networkSecurityGroup": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-001"
+                },
+                "dnsSettings": {
+                  "dnsServers": []
+                },
+                "enableIPForwarding": false,
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "primary": true,
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                      },
+                      "privateIPAddressVersion": "IPv4",
+                      "loadBalancerBackendAddressPools": [
+                        {
+                          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/Winfarm/backendAddressPools/Winfarm"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "name": "ipconfig2",
+                    "properties": {
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                      },
+                      "privateIPAddressVersion": "IPv4"
+                    }
+                  },
+                  {
+                    "name": "ipconfig3",
+                    "properties": {
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                      },
+                      "privateIPAddressVersion": "IPv4"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "extensionProfile": {
+          "extensions": [
+            {
+              "name": "OmsAgentForLinux",
+              "properties": {
+                "autoUpgradeMinorVersion": true,
+                "publisher": "Microsoft.EnterpriseCloud.Monitoring",
+                "type": "OmsAgentForLinux",
+                "typeHandlerVersion": "1.0",
+                "settings": {}
+              }
+            }
+          ]
+        }
+      },
+      "provisioningState": "Succeeded",
+      "overprovision": false,
+      "doNotRunExtensionsOnOverprovisionedVMs": false
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/virtualMachineScaleSets",
+    "ResourceType": "Microsoft.Compute/virtualMachineScaleSets",
+    "ExtensionResourceType": null,
+    "Sku": {
+      "Name": "Standard_B2ms",
+      "Tier": "Standard",
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": 1
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  }
 ]

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualMachine.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualMachine.json
@@ -349,6 +349,30 @@
         "ResourceType": "Microsoft.Network/networkInterfaces",
         "Tags": null,
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+      },
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-A/extensions/AzureMonitorWindowsAgent",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-A/extensions/AzureMonitorWindowsAgent",
+        "Location": "region",
+        "ResourceName": "AzureMonitorWindowsAgent",
+        "Name": "AzureMonitorWindowsAgent",
+        "ExtensionResourceName": null,
+        "ParentResource": "virtualMachines/vm-A",
+        "Properties": {
+          "publisher": "Microsoft.Azure.Monitor",
+          "type": "AzureMonitorWindowsAgent",
+          "typeHandlerVersion": "1.0",
+          "autoUpgradeMinorVersion": true,
+          "settings": {
+            "workspaceId": "00000000-0000-0000-0000-000000000000"
+          }
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Compute/virtualMachines/extensions",
+        "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
+        "ExtensionResourceType": null,
+        "Sku": null,
+        "SubscriptionId": null
       }
     ]
   },
@@ -478,7 +502,7 @@
         "ParentResource": "virtualMachines/vm-B",
         "Properties": {
           "publisher": "Microsoft.EnterpriseCloud.Monitoring",
-          "type": "MicrosoftMonitorAgent",
+          "type": "MicrosoftMonitoringAgent",
           "typeHandlerVersion": "1.0",
           "autoUpgradeMinorVersion": true,
           "settings": {
@@ -1215,6 +1239,30 @@
     "SubscriptionId": "00000000-0000-0000-0000-000000000000",
     "resources": [
       {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-C/extensions/AzureMonitorLinuxAgent",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-C/extensions/AzureMonitorLinuxAgent",
+        "Location": "region",
+        "ResourceName": "AzureMonitorLinuxAgent",
+        "Name": "AzureMonitorLinuxAgent",
+        "ExtensionResourceName": null,
+        "ParentResource": "virtualMachines/vm-C",
+        "Properties": {
+          "publisher": "Microsoft.Azure.Monitor",
+          "type": "AzureMonitorLinuxAgent",
+          "typeHandlerVersion": "1.21",
+          "autoUpgradeMinorVersion": true,
+          "settings": {
+            "workspaceId": "00000000-0000-0000-0000-000000000000"
+          }
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Compute/virtualMachines/extensions",
+        "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
+        "ExtensionResourceType": null,
+        "Sku": null,
+        "SubscriptionId": null
+      },
+      {
         "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-C-NIC",
         "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-C-NIC",
         "Identity": null,
@@ -1494,7 +1542,7 @@
         "ParentResource": "virtualMachines/vm-D",
         "Properties": {
           "publisher": "Microsoft.EnterpriseCloud.Monitoring",
-          "type": "MicrosoftMonitorAgent",
+          "type": "MicrosoftMonitoringAgent",
           "typeHandlerVersion": "1.0",
           "autoUpgradeMinorVersion": true,
           "settings": {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualMachine.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualMachine.json
@@ -1,1665 +1,1689 @@
 [
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/ReplicaVM_DataDisk_0-ASRReplica",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/ReplicaVM_DataDisk_0-ASRReplica",
-        "Location": "region",
-        "ResourceName": "ReplicaVM_DataDisk_0-ASRReplica",
-        "Name": "ReplicaVM_DataDisk_0-ASRReplica",
-        "Properties": {
-            "creationData": {
-                "createOption": "Empty"
-            },
-            "diskSizeGB": 200,
-            "diskIOPSReadWrite": 1100,
-            "diskMBpsReadWrite": 125,
-            "diskState": "ActiveSAS"
-        },
-        "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Compute/disks",
-        "ResourceType": "Microsoft.Compute/disks",
-        "Sku": {
-            "Name": "Premium_LRS",
-            "Tier": "Premium",
-            "Size": null,
-            "Family": null,
-            "Model": null,
-            "Capacity": null
-        },
-        "Tags": {
-            "ASR-ReplicaDisk-00000000-0000-0000-0000-000000000000": "This resource is in use by Recovery Services vault."
-        },
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/ReplicaVM_DataDisk_0-ASRReplica",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/ReplicaVM_DataDisk_0-ASRReplica",
+    "Location": "region",
+    "ResourceName": "ReplicaVM_DataDisk_0-ASRReplica",
+    "Name": "ReplicaVM_DataDisk_0-ASRReplica",
+    "Properties": {
+      "creationData": {
+        "createOption": "Empty"
+      },
+      "diskSizeGB": 200,
+      "diskIOPSReadWrite": 1100,
+      "diskMBpsReadWrite": 125,
+      "diskState": "ActiveSAS"
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-A",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-A",
-        "Location": "region",
-        "ResourceName": "disk-A",
-        "Name": "disk-A",
-        "Properties": {
-            "osType": "Windows",
-            "creationData": {
-                "createOption": "FromImage",
-                "imageReference": {
-                    "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/region/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2016-Datacenter/Versions/2016.000.00000000"
-                }
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/disks",
+    "ResourceType": "Microsoft.Compute/disks",
+    "Sku": {
+      "Name": "Premium_LRS",
+      "Tier": "Premium",
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": null
+    },
+    "Tags": {
+      "ASR-ReplicaDisk-00000000-0000-0000-0000-000000000000": "This resource is in use by Recovery Services vault."
+    },
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-A",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-A",
+    "Location": "region",
+    "ResourceName": "disk-A",
+    "Name": "disk-A",
+    "Properties": {
+      "osType": "Windows",
+      "creationData": {
+        "createOption": "FromImage",
+        "imageReference": {
+          "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/region/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2016-Datacenter/Versions/2016.000.00000000"
+        }
+      },
+      "diskSizeGB": 127,
+      "diskIOPSReadWrite": 500,
+      "diskMBpsReadWrite": 100,
+      "encryptionSettingsCollection": {
+        "enabled": true,
+        "encryptionSettings": [
+          {
+            "diskEncryptionKey": {
+              "sourceVault": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.KeyVault/vaults/keyvault-A"
+              },
+              "secretUrl": "https://keyvault-A.vault.azure.net/secrets/secret-A/version-A"
             },
-            "diskSizeGB": 127,
-            "diskIOPSReadWrite": 500,
-            "diskMBpsReadWrite": 100,
-            "encryptionSettingsCollection": {
-                "enabled": true,
-                "encryptionSettings": [
-                    {
-                        "diskEncryptionKey": {
-                            "sourceVault": {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.KeyVault/vaults/keyvault-A"
-                            },
-                            "secretUrl": "https://keyvault-A.vault.azure.net/secrets/secret-A/version-A"
-                        },
-                        "keyEncryptionKey": {
-                            "sourceVault": {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.KeyVault/vaults/keyvault-A"
-                            },
-                            "keyUrl": "https://keyvault-A.vault.azure.net/keys/key-A/version-A"
-                        }
-                    }
-                ],
-                "encryptionSettingsVersion": "1.1"
-            },
+            "keyEncryptionKey": {
+              "sourceVault": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.KeyVault/vaults/keyvault-A"
+              },
+              "keyUrl": "https://keyvault-A.vault.azure.net/keys/key-A/version-A"
+            }
+          }
+        ],
+        "encryptionSettingsVersion": "1.1"
+      },
+      "provisioningState": "Succeeded",
+      "diskState": "Attached"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/disks",
+    "ResourceType": "Microsoft.Compute/disks",
+    "Sku": {
+      "Name": "Premium_LRS",
+      "Tier": "Premium",
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": null
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/snapshots/disk-A-snap",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/snapshots/disk-A-snap",
+    "Location": "region",
+    "ResourceName": "disk-A-snap",
+    "Name": "disk-A-snap",
+    "Properties": {
+      "osType": "Windows",
+      "creationData": {
+        "createOption": "Copy",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-A"
+      },
+      "diskSizeGB": 127,
+      "provisioningState": "Succeeded",
+      "diskState": "Unattached"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/snapshots",
+    "ResourceType": "Microsoft.Compute/snapshots",
+    "Sku": {
+      "Name": "Standard_LRS",
+      "Tier": "Standard",
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": null
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-B",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-B",
+    "Location": "region",
+    "ResourceName": "disk-B",
+    "Name": "disk-B",
+    "Properties": {
+      "creationData": {
+        "createOption": "Empty"
+      },
+      "diskSizeGB": 100,
+      "diskIOPSReadWrite": 500,
+      "diskMBpsReadWrite": 100,
+      "encryptionSettingsCollection": {
+        "enabled": false,
+        "encryptionSettings": [],
+        "encryptionSettingsVersion": "1.0"
+      },
+      "provisioningState": "Succeeded",
+      "diskState": "Unattached"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/disks",
+    "ResourceType": "Microsoft.Compute/disks",
+    "Sku": {
+      "Name": "Premium_LRS",
+      "Tier": "Premium",
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": null
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-C",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-C",
+    "Location": "region",
+    "ResourceName": "disk-C",
+    "Name": "disk-C",
+    "Properties": {
+      "creationData": {
+        "createOption": "Empty"
+      },
+      "diskSizeGB": 100,
+      "diskIOPSReadWrite": 500,
+      "diskMBpsReadWrite": 100,
+      "encryptionSettingsCollection": {
+        "enabled": false,
+        "encryptionSettings": [],
+        "encryptionSettingsVersion": "1.0"
+      },
+      "provisioningState": "Succeeded",
+      "diskState": "Unattached"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/disks",
+    "ResourceType": "Microsoft.Compute/disks",
+    "Sku": {
+      "Name": "Premium_LRS",
+      "Tier": "Premium",
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": null
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
+    "Location": "region",
+    "ResourceName": "nic-A",
+    "Name": "nic-A",
+    "Properties": {
+      "ipConfigurations": [
+        {
+          "name": "ipconfig1",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A/ipConfigurations/ipconfig1",
+          "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+          "properties": {
             "provisioningState": "Succeeded",
-            "diskState": "Attached"
-        },
-        "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Compute/disks",
-        "ResourceType": "Microsoft.Compute/disks",
-        "Sku": {
-            "Name": "Premium_LRS",
-            "Tier": "Premium",
-            "Size": null,
-            "Family": null,
-            "Model": null,
-            "Capacity": null
-        },
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+            "privateIPAddress": "10.0.0.4",
+            "privateIPAllocationMethod": "Static",
+            "publicIPAddress": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/nic-A-pip"
+            },
+            "subnet": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
+            },
+            "primary": true,
+            "privateIPAddressVersion": "IPv4"
+          }
+        }
+      ],
+      "dnsSettings": {
+        "dnsServers": ["8.8.8.8"],
+        "appliedDnsServers": ["8.8.8.8"],
+        "internalDomainNameSuffix": "example.nn.internal.cloudapp.net"
+      },
+      "macAddress": "00-00-00-00-00-00",
+      "enableAcceleratedNetworking": false,
+      "enableIPForwarding": false,
+      "primary": true,
+      "virtualMachine": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-A"
+      },
+      "hostedWorkloads": [],
+      "tapConfigurations": []
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/snapshots/disk-A-snap",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/snapshots/disk-A-snap",
-        "Location": "region",
-        "ResourceName": "disk-A-snap",
-        "Name": "disk-A-snap",
-        "Properties": {
-            "osType": "Windows",
-            "creationData": {
-                "createOption": "Copy",
-                "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-A"
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Network/networkInterfaces",
+    "ResourceType": "Microsoft.Network/networkInterfaces",
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "Name": "vm-A",
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-A",
+    "ResourceName": "vm-A",
+    "ResourceType": "Microsoft.Compute/virtualMachines",
+    "ResourceGroupName": "test-rg",
+    "Location": "region",
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "Properties": {
+      "hardwareProfile": {
+        "vmSize": "Standard_E32s_v3"
+      },
+      "storageProfile": {
+        "imageReference": {
+          "publisher": "MicrosoftSQLServer",
+          "offer": "SQL2017-WS2016",
+          "sku": "Enterprise",
+          "version": "latest"
+        },
+        "osDisk": {
+          "osType": "Windows",
+          "name": "vm-A_OsDisk_1_0000000000000000000000000000000",
+          "createOption": "FromImage",
+          "caching": "ReadWrite",
+          "managedDisk": {
+            "storageAccountType": "StandardSSD_LRS",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/vm-A_OsDisk_1_0000000000000000000000000000000"
+          },
+          "diskSizeGB": 127
+        },
+        "dataDisks": [
+          {
+            "lun": 0,
+            "name": "vm-A_disk2_0000000000000000000000000000000",
+            "createOption": "Empty",
+            "caching": "ReadOnly",
+            "managedDisk": {
+              "storageAccountType": "StandardSSD_LRS",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/vm-A_disk2_0000000000000000000000000000000"
             },
-            "diskSizeGB": 127,
-            "provisioningState": "Succeeded",
-            "diskState": "Unattached"
+            "diskSizeGB": 1023
+          }
+        ]
+      },
+      "osProfile": {
+        "computerName": "vm-A",
+        "adminUsername": "vm-admin",
+        "windowsConfiguration": {
+          "provisionVMAgent": true,
+          "enableAutomaticUpdates": true
         },
-        "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Compute/snapshots",
-        "ResourceType": "Microsoft.Compute/snapshots",
-        "Sku": {
-            "Name": "Standard_LRS",
-            "Tier": "Standard",
-            "Size": null,
-            "Family": null,
-            "Model": null,
-            "Capacity": null
-        },
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+        "secrets": [],
+        "allowExtensionOperations": true
+      },
+      "networkProfile": {
+        "networkInterfaces": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-A-nic"
+          }
+        ]
+      },
+      "diagnosticsProfile": {
+        "bootDiagnostics": {
+          "enabled": true,
+          "storageUri": "https://storage-A.blob.core.windows.net/"
+        }
+      },
+      "licenseType": "Windows_Server"
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-B",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-B",
-        "Location": "region",
-        "ResourceName": "disk-B",
-        "Name": "disk-B",
-        "Properties": {
-            "creationData": {
-                "createOption": "Empty"
-            },
-            "diskSizeGB": 100,
-            "diskIOPSReadWrite": 500,
-            "diskMBpsReadWrite": 100,
-            "encryptionSettingsCollection": {
-                "enabled": false,
-                "encryptionSettings": [],
-                "encryptionSettingsVersion": "1.0"
-            },
-            "provisioningState": "Succeeded",
-            "diskState": "Unattached"
-        },
-        "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Compute/disks",
-        "ResourceType": "Microsoft.Compute/disks",
-        "Sku": {
-            "Name": "Premium_LRS",
-            "Tier": "Premium",
-            "Size": null,
-            "Family": null,
-            "Model": null,
-            "Capacity": null
-        },
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-C",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-C",
-        "Location": "region",
-        "ResourceName": "disk-C",
-        "Name": "disk-C",
-        "Properties": {
-            "creationData": {
-                "createOption": "Empty"
-            },
-            "diskSizeGB": 100,
-            "diskIOPSReadWrite": 500,
-            "diskMBpsReadWrite": 100,
-            "encryptionSettingsCollection": {
-                "enabled": false,
-                "encryptionSettings": [],
-                "encryptionSettingsVersion": "1.0"
-            },
-            "provisioningState": "Succeeded",
-            "diskState": "Unattached"
-        },
-        "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Compute/disks",
-        "ResourceType": "Microsoft.Compute/disks",
-        "Sku": {
-            "Name": "Premium_LRS",
-            "Tier": "Premium",
-            "Size": null,
-            "Family": null,
-            "Model": null,
-            "Capacity": null
-        },
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
+    "resources": [
+      {
         "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
         "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
         "Location": "region",
         "ResourceName": "nic-A",
         "Name": "nic-A",
         "Properties": {
-            "ipConfigurations": [
-                {
-                    "name": "ipconfig1",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A/ipConfigurations/ipconfig1",
-                    "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
-                    "properties": {
-                        "provisioningState": "Succeeded",
-                        "privateIPAddress": "10.0.0.4",
-                        "privateIPAllocationMethod": "Static",
-                        "publicIPAddress": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/nic-A-pip"
-                        },
-                        "subnet": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
-                        },
-                        "primary": true,
-                        "privateIPAddressVersion": "IPv4"
-                    }
-                }
-            ],
-            "dnsSettings": {
-                "dnsServers": [
-                    "8.8.8.8"
-                ],
-                "appliedDnsServers": [
-                    "8.8.8.8"
-                ],
-                "internalDomainNameSuffix": "example.nn.internal.cloudapp.net"
-            },
-            "macAddress": "00-00-00-00-00-00",
-            "enableAcceleratedNetworking": false,
-            "enableIPForwarding": false,
-            "primary": true,
-            "virtualMachine": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-A"
-            },
-            "hostedWorkloads": [],
-            "tapConfigurations": []
-        },
-        "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Network/networkInterfaces",
-        "ResourceType": "Microsoft.Network/networkInterfaces",
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "Name": "vm-A",
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-A",
-        "ResourceName": "vm-A",
-        "ResourceType": "Microsoft.Compute/virtualMachines",
-        "ResourceGroupName": "test-rg",
-        "Location": "region",
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "Properties": {
-            "hardwareProfile": {
-                "vmSize": "Standard_E32s_v3"
-            },
-            "storageProfile": {
-                "imageReference": {
-                    "publisher": "MicrosoftSQLServer",
-                    "offer": "SQL2017-WS2016",
-                    "sku": "Enterprise",
-                    "version": "latest"
-                },
-                "osDisk": {
-                    "osType": "Windows",
-                    "name": "vm-A_OsDisk_1_0000000000000000000000000000000",
-                    "createOption": "FromImage",
-                    "caching": "ReadWrite",
-                    "managedDisk": {
-                        "storageAccountType": "StandardSSD_LRS",
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/vm-A_OsDisk_1_0000000000000000000000000000000"
-                    },
-                    "diskSizeGB": 127
-                },
-                "dataDisks": [
-                    {
-                        "lun": 0,
-                        "name": "vm-A_disk2_0000000000000000000000000000000",
-                        "createOption": "Empty",
-                        "caching": "ReadOnly",
-                        "managedDisk": {
-                            "storageAccountType": "StandardSSD_LRS",
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/vm-A_disk2_0000000000000000000000000000000"
-                        },
-                        "diskSizeGB": 1023
-                    }
-                ]
-            },
-            "osProfile": {
-                "computerName": "vm-A",
-                "adminUsername": "vm-admin",
-                "windowsConfiguration": {
-                    "provisionVMAgent": true,
-                    "enableAutomaticUpdates": true
-                },
-                "secrets": [],
-                "allowExtensionOperations": true
-            },
-            "networkProfile": {
-                "networkInterfaces": [
-                    {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-A-nic"
-                    }
-                ]
-            },
-            "diagnosticsProfile": {
-                "bootDiagnostics": {
-                    "enabled": true,
-                    "storageUri": "https://storage-A.blob.core.windows.net/"
-                }
-            },
-            "licenseType": "Windows_Server"
-        },
-        "resources": [
+          "ipConfigurations": [
             {
-                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
-                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
-                "Location": "region",
-                "ResourceName": "nic-A",
-                "Name": "nic-A",
-                "Properties": {
-                    "ipConfigurations": [
-                        {
-                            "name": "ipconfig1",
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A/ipConfigurations/ipconfig1",
-                            "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
-                            "properties": {
-                                "provisioningState": "Succeeded",
-                                "privateIPAddress": "10.0.0.4",
-                                "privateIPAllocationMethod": "Static",
-                                "publicIPAddress": {
-                                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/nic-A-pip"
-                                },
-                                "subnet": {
-                                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
-                                },
-                                "primary": true,
-                                "privateIPAddressVersion": "IPv4"
-                            }
-                        }
-                    ],
-                    "dnsSettings": {
-                        "dnsServers": [
-                            "8.8.8.8"
-                        ],
-                        "appliedDnsServers": [
-                            "8.8.8.8"
-                        ],
-                        "internalDomainNameSuffix": "example.nn.internal.cloudapp.net"
-                    },
-                    "macAddress": "00-00-00-00-00-00",
-                    "enableAcceleratedNetworking": true,
-                    "enableIPForwarding": false,
-                    "primary": true,
-                    "virtualMachine": {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-A"
-                    },
-                    "hostedWorkloads": [],
-                    "tapConfigurations": []
+              "name": "ipconfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A/ipConfigurations/ipconfig1",
+              "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.0.0.4",
+                "privateIPAllocationMethod": "Static",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/nic-A-pip"
                 },
-                "ResourceGroupName": "test-rg",
-                "Type": "Microsoft.Network/networkInterfaces",
-                "ResourceType": "Microsoft.Network/networkInterfaces",
-                "Tags": null,
-                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
+                },
+                "primary": true,
+                "privateIPAddressVersion": "IPv4"
+              }
             }
-        ]
-    },
-    {
-        "Name": "vm-B",
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-B",
-        "ResourceName": "vm-B",
-        "ResourceType": "Microsoft.Compute/virtualMachines",
-        "ResourceGroupName": "test-rg",
-        "Location": "region",
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "Properties": {
-            "hardwareProfile": {
-                "vmSize": "Standard_E32s_v3"
-            },
-            "storageProfile": {
-                "imageReference": {
-                    "publisher": "MicrosoftSQLServer",
-                    "offer": "SQL2017-WS2016",
-                    "sku": "Enterprise",
-                    "version": "latest"
-                },
-                "osDisk": {
-                    "osType": "Windows",
-                    "name": "vm-B_OsDisk_1_0000000000000000000000000000000",
-                    "createOption": "FromImage",
-                    "caching": "ReadWrite",
-                    "managedDisk": {
-                        "storageAccountType": "StandardSSD_LRS",
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/vm-B_OsDisk_1_0000000000000000000000000000000"
-                    },
-                    "diskSizeGB": 127
-                },
-                "dataDisks": [
-                    {
-                        "lun": 0,
-                        "name": "vm-B_disk2_0000000000000000000000000000000",
-                        "createOption": "Empty",
-                        "caching": "ReadOnly",
-                        "diskSizeGB": 1023,
-                        "vhd": {
-                            "uri": "[concat('http://testsa.blob.core.windows.net/vhds/vm-B_disk2_0000000000000000000000000000000.vhd')]"
-                        }
-                    }
-                ]
-            },
-            "osProfile": {
-                "computerName": "vm-B",
-                "adminUsername": "vm-admin",
-                "windowsConfiguration": {
-                    "provisionVMAgent": false,
-                    "enableAutomaticUpdates": false
-                },
-                "secrets": [],
-                "allowExtensionOperations": false
-            },
-            "networkProfile": {
-                "networkInterfaces": [
-                    {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-B-nic"
-                    }
-                ]
-            },
-            "diagnosticsProfile": {
-                "bootDiagnostics": {
-                    "enabled": true,
-                    "storageUri": "https://storage-A.blob.core.windows.net/"
-                }
-            }
+          ],
+          "dnsSettings": {
+            "dnsServers": ["8.8.8.8"],
+            "appliedDnsServers": ["8.8.8.8"],
+            "internalDomainNameSuffix": "example.nn.internal.cloudapp.net"
+          },
+          "macAddress": "00-00-00-00-00-00",
+          "enableAcceleratedNetworking": true,
+          "enableIPForwarding": false,
+          "primary": true,
+          "virtualMachine": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-A"
+          },
+          "hostedWorkloads": [],
+          "tapConfigurations": []
         },
-        "resources": [
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Network/networkInterfaces",
+        "ResourceType": "Microsoft.Network/networkInterfaces",
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+      }
+    ]
+  },
+  {
+    "Name": "vm-B",
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-B",
+    "ResourceName": "vm-B",
+    "ResourceType": "Microsoft.Compute/virtualMachines",
+    "ResourceGroupName": "test-rg",
+    "Location": "region",
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "Properties": {
+      "hardwareProfile": {
+        "vmSize": "Standard_E32s_v3"
+      },
+      "storageProfile": {
+        "imageReference": {
+          "publisher": "MicrosoftSQLServer",
+          "offer": "SQL2017-WS2016",
+          "sku": "Enterprise",
+          "version": "latest"
+        },
+        "osDisk": {
+          "osType": "Windows",
+          "name": "vm-B_OsDisk_1_0000000000000000000000000000000",
+          "createOption": "FromImage",
+          "caching": "ReadWrite",
+          "managedDisk": {
+            "storageAccountType": "StandardSSD_LRS",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/vm-B_OsDisk_1_0000000000000000000000000000000"
+          },
+          "diskSizeGB": 127
+        },
+        "dataDisks": [
+          {
+            "lun": 0,
+            "name": "vm-B_disk2_0000000000000000000000000000000",
+            "createOption": "Empty",
+            "caching": "ReadOnly",
+            "diskSizeGB": 1023,
+            "vhd": {
+              "uri": "[concat('http://testsa.blob.core.windows.net/vhds/vm-B_disk2_0000000000000000000000000000000.vhd')]"
+            }
+          }
+        ]
+      },
+      "osProfile": {
+        "computerName": "vm-B",
+        "adminUsername": "vm-admin",
+        "windowsConfiguration": {
+          "provisionVMAgent": false,
+          "enableAutomaticUpdates": false
+        },
+        "secrets": [],
+        "allowExtensionOperations": false
+      },
+      "networkProfile": {
+        "networkInterfaces": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-B-nic"
+          }
+        ]
+      },
+      "diagnosticsProfile": {
+        "bootDiagnostics": {
+          "enabled": true,
+          "storageUri": "https://storage-A.blob.core.windows.net/"
+        }
+      }
+    },
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
+        "Location": "region",
+        "ResourceName": "nic-A",
+        "Name": "nic-A",
+        "Properties": {
+          "ipConfigurations": [
             {
-                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
-                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
-                "Location": "region",
-                "ResourceName": "nic-A",
-                "Name": "nic-A",
-                "Properties": {
-                    "ipConfigurations": [
-                        {
-                            "name": "ipconfig1",
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A/ipConfigurations/ipconfig1",
-                            "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
-                            "properties": {
-                                "provisioningState": "Succeeded",
-                                "privateIPAddress": "10.0.0.4",
-                                "privateIPAllocationMethod": "Static",
-                                "publicIPAddress": {
-                                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/nic-A-pip"
-                                },
-                                "subnet": {
-                                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
-                                },
-                                "primary": true,
-                                "privateIPAddressVersion": "IPv4"
-                            }
-                        }
-                    ],
-                    "dnsSettings": {
-                        "dnsServers": [
-                            "8.8.8.8"
-                        ],
-                        "appliedDnsServers": [
-                            "8.8.8.8"
-                        ],
-                        "internalDomainNameSuffix": "example.nn.internal.cloudapp.net"
-                    },
-                    "macAddress": "00-00-00-00-00-00",
-                    "enableAcceleratedNetworking": false,
-                    "enableIPForwarding": false,
-                    "primary": true,
-                    "virtualMachine": {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-B"
-                    },
-                    "hostedWorkloads": [],
-                    "tapConfigurations": []
+              "name": "ipconfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A/ipConfigurations/ipconfig1",
+              "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.0.0.4",
+                "privateIPAllocationMethod": "Static",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/nic-A-pip"
                 },
-                "ResourceGroupName": "test-rg",
-                "Type": "Microsoft.Network/networkInterfaces",
-                "ResourceType": "Microsoft.Network/networkInterfaces",
-                "Tags": null,
-                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
+                },
+                "primary": true,
+                "privateIPAddressVersion": "IPv4"
+              }
             }
-        ]
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1",
-        "Location": "region",
-        "ResourceName": "aks-agentpool-00000000-1",
-        "Name": "aks-agentpool-00000000-1",
-        "Properties": {
-            "availabilitySet": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/AGENTPOOL-AVAILABILITYSET-00000000"
-            },
-            "hardwareProfile": {
-                "vmSize": "Standard_F2s_v2"
-            },
-            "storageProfile": {
-                "imageReference": {
-                    "publisher": "microsoft-aks",
-                    "offer": "aks",
-                    "sku": "aks-ubuntu-1604-201902",
-                    "version": "2019.02.28"
-                },
-                "osDisk": {
-                    "osType": "Linux",
-                    "name": "aks-agentpool-00000000-1_OsDisk_1_0000000000000000000000000000000",
-                    "createOption": "FromImage",
-                    "caching": "ReadWrite",
-                    "managedDisk": {
-                        "storageAccountType": "Premium_LRS",
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/disks/aks-agentpool-00000000-1_OsDisk_1_0000000000000000000000000000000"
-                    },
-                    "diskSizeGB": 30
-                }
-            },
-            "osProfile": {
-                "computerName": "aks-agentpool-00000000-1",
-                "adminUsername": "azureuser",
-                "linuxConfiguration": {
-                    "disablePasswordAuthentication": true,
-                    "ssh": {
-                        "publicKeys": [
-                            {
-                                "path": "/home/azureuser/.ssh/authorized_keys",
-                                "keyData": "ssh-rsa 000000\n"
-                            }
-                        ]
-                    },
-                    "provisionVMAgent": true
-                },
-                "secrets": [],
-                "allowExtensionOperations": true
-            },
-            "networkProfile": {
-                "networkInterfaces": [
-                    {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-1"
-                    }
-                ]
-            }
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/virtualMachines",
-        "ResourceType": "Microsoft.Compute/virtualMachines",
-        "Tags": {
-            "resourceNameSuffix": "00000000",
-            "orchestrator": "Kubernetes:1.12.6",
-            "aksEngineVersion": "v0.30.1-aks",
-            "poolName": "agentpool",
-            "creationSource": "aksengine-aks-agentpool-00000000-1"
-        },
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1/extensions/computeAksLinuxBilling",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1/extensions/computeAksLinuxBilling",
-        "Location": "region",
-        "ResourceName": "computeAksLinuxBilling",
-        "Name": "computeAksLinuxBilling",
-        "Properties": {
-            "autoUpgradeMinorVersion": true,
-            "settings": {},
-            "provisioningState": "Succeeded",
-            "publisher": "Microsoft.AKS",
-            "type": "Compute.AKS.Linux.Billing",
-            "typeHandlerVersion": "1.0"
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/virtualMachines/extensions",
-        "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1/extensions/cse-agent-1",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1/extensions/cse-agent-1",
-        "Location": "region",
-        "ResourceName": "cse-agent-1",
-        "Name": "cse-agent-1",
-        "Properties": {
-            "autoUpgradeMinorVersion": true,
-            "settings": {},
-            "provisioningState": "Succeeded",
-            "publisher": "Microsoft.Azure.Extensions",
-            "type": "CustomScript",
-            "typeHandlerVersion": "2.0"
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/virtualMachines/extensions",
-        "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1/extensions/OmsAgentForLinux",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1/extensions/OmsAgentForLinux",
-        "Location": "region",
-        "ResourceName": "OmsAgentForLinux",
-        "Name": "OmsAgentForLinux",
-        "Properties": {
-            "autoUpgradeMinorVersion": true,
-            "settings": {
-                "workspaceId": "00000000-0000-0000-0000-000000000000",
-                "stopOnMultipleConnections": true
-            },
-            "provisioningState": "Succeeded",
-            "publisher": "Microsoft.EnterpriseCloud.Monitoring",
-            "type": "OmsAgentForLinux",
-            "typeHandlerVersion": "1.0"
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/virtualMachines/extensions",
-        "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2",
-        "Location": "region",
-        "ResourceName": "aks-agentpool-00000000-2",
-        "Name": "aks-agentpool-00000000-2",
-        "Properties": {
-            "availabilitySet": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/AGENTPOOL-AVAILABILITYSET-00000000"
-            },
-            "hardwareProfile": {
-                "vmSize": "Standard_F2s_v2"
-            },
-            "storageProfile": {
-                "imageReference": {
-                    "publisher": "microsoft-aks",
-                    "offer": "aks",
-                    "sku": "aks-ubuntu-1604-201902",
-                    "version": "2019.02.28"
-                },
-                "osDisk": {
-                    "osType": "Linux",
-                    "name": "aks-agentpool-00000000-2_OsDisk_1_0000000000000000000000000000000",
-                    "createOption": "FromImage",
-                    "caching": "ReadWrite",
-                    "managedDisk": {
-                        "storageAccountType": "Premium_LRS",
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/disks/aks-agentpool-00000000-2_OsDisk_1_0000000000000000000000000000000"
-                    },
-                    "diskSizeGB": 30
-                },
-                "dataDisks": []
-            },
-            "osProfile": {
-                "computerName": "aks-agentpool-00000000-2",
-                "adminUsername": "azureuser",
-                "linuxConfiguration": {
-                    "disablePasswordAuthentication": true,
-                    "ssh": {
-                        "publicKeys": [
-                            {
-                                "path": "/home/azureuser/.ssh/authorized_keys",
-                                "keyData": "ssh-rsa 000000\n"
-                            }
-                        ]
-                    },
-                    "provisionVMAgent": true
-                },
-                "secrets": [],
-                "allowExtensionOperations": true
-            },
-            "networkProfile": {
-                "networkInterfaces": [
-                    {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-2"
-                    }
-                ]
-            },
-            "provisioningState": "Succeeded"
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/virtualMachines",
-        "ResourceType": "Microsoft.Compute/virtualMachines",
-        "Tags": {
-            "resourceNameSuffix": "00000000",
-            "orchestrator": "Kubernetes:1.12.6",
-            "aksEngineVersion": "v0.30.1-aks",
-            "poolName": "agentpool",
-            "creationSource": "aksengine-aks-agentpool-00000000-2"
-        },
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2/extensions/computeAksLinuxBilling",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2/extensions/computeAksLinuxBilling",
-        "Location": "region",
-        "ResourceName": "computeAksLinuxBilling",
-        "Name": "computeAksLinuxBilling",
-        "Properties": {
-            "autoUpgradeMinorVersion": true,
-            "settings": {},
-            "provisioningState": "Succeeded",
-            "publisher": "Microsoft.AKS",
-            "type": "Compute.AKS.Linux.Billing",
-            "typeHandlerVersion": "1.0"
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/virtualMachines/extensions",
-        "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2/extensions/cse-agent-2",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2/extensions/cse-agent-2",
-        "Location": "region",
-        "ResourceName": "cse-agent-2",
-        "Name": "cse-agent-2",
-        "Properties": {
-            "autoUpgradeMinorVersion": true,
-            "settings": {},
-            "provisioningState": "Succeeded",
-            "publisher": "Microsoft.Azure.Extensions",
-            "type": "CustomScript",
-            "typeHandlerVersion": "2.0"
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/virtualMachines/extensions",
-        "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2/extensions/OmsAgentForLinux",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2/extensions/OmsAgentForLinux",
-        "Location": "region",
-        "ResourceName": "OmsAgentForLinux",
-        "Name": "OmsAgentForLinux",
-        "Properties": {
-            "autoUpgradeMinorVersion": true,
-            "settings": {
-                "workspaceId": "00000000-0000-0000-0000-000000000000",
-                "stopOnMultipleConnections": true
-            },
-            "provisioningState": "Succeeded",
-            "publisher": "Microsoft.EnterpriseCloud.Monitoring",
-            "type": "OmsAgentForLinux",
-            "typeHandlerVersion": "1.0"
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/virtualMachines/extensions",
-        "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3",
-        "Location": "region",
-        "ResourceName": "aks-agentpool-00000000-3",
-        "Name": "aks-agentpool-00000000-3",
-        "Properties": {
-            "availabilitySet": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/AGENTPOOL-AVAILABILITYSET-00000000"
-            },
-            "hardwareProfile": {
-                "vmSize": "Standard_F2s_v2"
-            },
-            "storageProfile": {
-                "imageReference": {
-                    "publisher": "microsoft-aks",
-                    "offer": "aks",
-                    "sku": "aks-ubuntu-1604-201902",
-                    "version": "2019.02.28"
-                },
-                "osDisk": {
-                    "osType": "Linux",
-                    "name": "aks-agentpool-00000000-3_OsDisk_1_0000000000000000000000000000000",
-                    "createOption": "FromImage",
-                    "caching": "ReadWrite",
-                    "managedDisk": {
-                        "storageAccountType": "Premium_LRS",
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/disks/aks-agentpool-00000000-3_OsDisk_1_0000000000000000000000000000000"
-                    },
-                    "diskSizeGB": 30
-                },
-                "dataDisks": []
-            },
-            "osProfile": {
-                "computerName": "aks-agentpool-00000000-3",
-                "adminUsername": "azureuser",
-                "linuxConfiguration": {
-                    "disablePasswordAuthentication": true,
-                    "ssh": {
-                        "publicKeys": [
-                            {
-                                "path": "/home/azureuser/.ssh/authorized_keys",
-                                "keyData": "ssh-rsa 000000\n"
-                            }
-                        ]
-                    },
-                    "provisionVMAgent": true
-                },
-                "secrets": [],
-                "allowExtensionOperations": true
-            },
-            "networkProfile": {
-                "networkInterfaces": [
-                    {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-3"
-                    }
-                ]
-            },
-            "provisioningState": "Succeeded"
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/virtualMachines",
-        "ResourceType": "Microsoft.Compute/virtualMachines",
-        "Tags": {
-            "resourceNameSuffix": "00000000",
-            "orchestrator": "Kubernetes:1.12.6",
-            "aksEngineVersion": "v0.30.1-aks",
-            "poolName": "agentpool",
-            "creationSource": "aksengine-aks-agentpool-00000000-3"
-        },
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3/extensions/computeAksLinuxBilling",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3/extensions/computeAksLinuxBilling",
-        "Location": "region",
-        "ResourceName": "computeAksLinuxBilling",
-        "Name": "computeAksLinuxBilling",
-        "Properties": {
-            "autoUpgradeMinorVersion": true,
-            "settings": {},
-            "provisioningState": "Succeeded",
-            "publisher": "Microsoft.AKS",
-            "type": "Compute.AKS.Linux.Billing",
-            "typeHandlerVersion": "1.0"
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/virtualMachines/extensions",
-        "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3/extensions/cse-agent-3",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3/extensions/cse-agent-3",
-        "Location": "region",
-        "ResourceName": "cse-agent-3",
-        "Name": "cse-agent-3",
-        "Properties": {
-            "autoUpgradeMinorVersion": true,
-            "settings": {},
-            "provisioningState": "Succeeded",
-            "publisher": "Microsoft.Azure.Extensions",
-            "type": "CustomScript",
-            "typeHandlerVersion": "2.0"
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/virtualMachines/extensions",
-        "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3/extensions/OmsAgentForLinux",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3/extensions/OmsAgentForLinux",
-        "Location": "region",
-        "ResourceName": "OmsAgentForLinux",
-        "Name": "OmsAgentForLinux",
-        "Properties": {
-            "autoUpgradeMinorVersion": true,
-            "settings": {
-                "workspaceId": "00000000-0000-0000-0000-000000000000",
-                "stopOnMultipleConnections": true
-            },
-            "provisioningState": "Succeeded",
-            "publisher": "Microsoft.EnterpriseCloud.Monitoring",
-            "type": "OmsAgentForLinux",
-            "typeHandlerVersion": "1.0"
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/virtualMachines/extensions",
-        "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-1",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-1",
-        "Location": "region",
-        "ResourceName": "aks-agentpool-00000000-nic-1",
-        "Name": "aks-agentpool-00000000-nic-1",
-        "Properties": {
-            "provisioningState": "Succeeded",
-            "ipConfigurations": [
-                {
-                    "name": "ipconfig1",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-1/ipConfigurations/ipconfig1",
-                    "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
-                    "properties": {
-                        "provisioningState": "Succeeded",
-                        "privateIPAddress": "10.1.1.36",
-                        "privateIPAllocationMethod": "Dynamic",
-                        "subnet": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
-                        },
-                        "primary": true,
-                        "privateIPAddressVersion": "IPv4",
-                        "loadBalancerBackendAddressPools": [
-                            {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "ipconfig2",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-1/ipConfigurations/ipconfig2",
-                    "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
-                    "properties": {
-                        "provisioningState": "Succeeded",
-                        "privateIPAddress": "10.1.1.37",
-                        "privateIPAllocationMethod": "Dynamic",
-                        "subnet": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
-                        },
-                        "primary": false,
-                        "privateIPAddressVersion": "IPv4"
-                    }
-                }
-            ],
-            "dnsSettings": {
-                "dnsServers": [],
-                "appliedDnsServers": [],
-                "internalDomainNameSuffix": "nnn.nn.internal.cloudapp.net"
-            },
-            "macAddress": "00-00-00-00-00-00",
-            "enableAcceleratedNetworking": false,
-            "enableIPForwarding": false,
-            "networkSecurityGroup": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkSecurityGroups/aks-agentpool-00000000-nsg"
-            },
-            "primary": true,
-            "virtualMachine": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1"
-            },
-            "hostedWorkloads": [],
-            "tapConfigurations": []
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Network/networkInterfaces",
-        "ResourceType": "Microsoft.Network/networkInterfaces",
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-2",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-2",
-        "Location": "region",
-        "ResourceName": "aks-agentpool-00000000-nic-2",
-        "Name": "aks-agentpool-00000000-nic-2",
-        "Properties": {
-            "provisioningState": "Succeeded",
-            "ipConfigurations": [
-                {
-                    "name": "ipconfig1",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-2/ipConfigurations/ipconfig1",
-                    "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
-                    "properties": {
-                        "provisioningState": "Succeeded",
-                        "privateIPAddress": "10.1.1.35",
-                        "privateIPAllocationMethod": "Dynamic",
-                        "subnet": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
-                        },
-                        "primary": true,
-                        "privateIPAddressVersion": "IPv4",
-                        "loadBalancerBackendAddressPools": [
-                            {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "ipconfig2",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-2/ipConfigurations/ipconfig2",
-                    "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
-                    "properties": {
-                        "provisioningState": "Succeeded",
-                        "privateIPAddress": "10.1.1.66",
-                        "privateIPAllocationMethod": "Dynamic",
-                        "subnet": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
-                        },
-                        "primary": false,
-                        "privateIPAddressVersion": "IPv4"
-                    }
-                }
-            ],
-            "dnsSettings": {
-                "dnsServers": [],
-                "appliedDnsServers": [],
-                "internalDomainNameSuffix": "nnn.nn.internal.cloudapp.net"
-            },
-            "macAddress": "00-00-00-00-00-00",
-            "enableAcceleratedNetworking": false,
-            "enableIPForwarding": false,
-            "networkSecurityGroup": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkSecurityGroups/aks-agentpool-00000000-nsg"
-            },
-            "primary": true,
-            "virtualMachine": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2"
-            },
-            "hostedWorkloads": [],
-            "tapConfigurations": []
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Network/networkInterfaces",
-        "ResourceType": "Microsoft.Network/networkInterfaces",
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-3",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-3",
-        "Location": "region",
-        "ResourceName": "aks-agentpool-00000000-nic-3",
-        "Name": "aks-agentpool-00000000-nic-3",
-        "Properties": {
-            "provisioningState": "Succeeded",
-            "ipConfigurations": [
-                {
-                    "name": "ipconfig1",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-3/ipConfigurations/ipconfig1",
-                    "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
-                    "properties": {
-                        "provisioningState": "Succeeded",
-                        "privateIPAddress": "10.1.1.97",
-                        "privateIPAllocationMethod": "Dynamic",
-                        "subnet": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
-                        },
-                        "primary": true,
-                        "privateIPAddressVersion": "IPv4",
-                        "loadBalancerBackendAddressPools": [
-                            {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"
-                            }
-                        ]
-                    }
-                }
-            ],
-            "dnsSettings": {
-                "dnsServers": [],
-                "appliedDnsServers": [],
-                "internalDomainNameSuffix": "nnn.nn.internal.cloudapp.net"
-            },
-            "macAddress": "00-00-00-00-00-00",
-            "enableAcceleratedNetworking": false,
-            "enableIPForwarding": false,
-            "networkSecurityGroup": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkSecurityGroups/aks-agentpool-00000000-nsg"
-            },
-            "primary": true,
-            "virtualMachine": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3"
-            },
-            "hostedWorkloads": [],
-            "tapConfigurations": []
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Network/networkInterfaces",
-        "ResourceType": "Microsoft.Network/networkInterfaces",
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/agentpool-availabilitySet-00000000",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/agentpool-availabilitySet-00000000",
-        "Location": "region",
-        "ResourceName": "agentpool-availabilitySet-00000000",
-        "Name": "agentpool-availabilitySet-00000000",
-        "Properties": {
-            "platformUpdateDomainCount": 3,
-            "platformFaultDomainCount": 2,
-            "virtualMachines": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/AKS-AGENTPOOL-00000000-1"
-                },
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/AKS-AGENTPOOL-00000000-2"
-                },
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/AKS-AGENTPOOL-00000000-3"
-                }
-            ]
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/availabilitySets",
-        "ResourceType": "Microsoft.Compute/availabilitySets",
-        "Sku": {
-            "Name": "Aligned",
-            "Tier": null,
-            "Size": null,
-            "Family": null,
-            "Model": null,
-            "Capacity": null
-        },
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/availabilitySet-B",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/availabilitySet-B",
-        "Location": "region",
-        "ResourceName": "availabilitySet-B",
-        "Name": "availabilitySet-B",
-        "Properties": {
-            "platformUpdateDomainCount": 3,
-            "platformFaultDomainCount": 2,
-            "virtualMachines": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/AKS-AGENTPOOL-00000000-1"
-                }
-            ]
-        },
-        "ResourceGroupName": "MC_test-rg",
-        "Type": "Microsoft.Compute/availabilitySets",
-        "ResourceType": "Microsoft.Compute/availabilitySets",
-        "Sku": {
-            "Name": "Classic",
-            "Tier": null,
-            "Size": null,
-            "Family": null,
-            "Model": null,
-            "Capacity": null
-        },
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-C",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-C",
-        "Identity": {
-            "PrincipalId": "00000000-0000-0000-0000-000000000000",
-            "TenantId": "00000000-0000-0000-0000-000000000000",
-            "Type": "SystemAssigned",
-            "UserAssignedIdentities": null
-        },
-        "Kind": null,
-        "Location": "region",
-        "ManagedBy": null,
-        "ResourceName": "vm-C",
-        "Name": "vm-C",
-        "Properties": {
-            "vmId": "00000000-0000-0000-0000-000000000000",
-            "hardwareProfile": {
-                "vmSize": "Standard_D8s_v3"
-            },
-            "storageProfile": {
-                "imageReference": {
-                    "publisher": "Canonical",
-                    "offer": "UbuntuServer",
-                    "sku": "16.04-LTS",
-                    "version": "latest",
-                    "exactVersion": "16.04.201708151"
-                },
-                "osDisk": {
-                    "osType": "Linux",
-                    "name": "vm-C_OsDisk_1",
-                    "createOption": "FromImage",
-                    "caching": "ReadWrite",
-                    "managedDisk": {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/vm-C_OsDisk_1"
-                    }
-                },
-                "dataDisks": []
-            },
-            "osProfile": {
-                "computerName": "vm-C",
-                "adminUsername": "admin-account",
-                "linuxConfiguration": {
-                    "disablePasswordAuthentication": false,
-                    "provisionVMAgent": false
-                },
-                "secrets": []
-            },
-            "networkProfile": {
-                "networkInterfaces": [
-                    {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-C-NIC"
-                    }
-                ]
-            },
-            "provisioningState": "Succeeded"
-        },
-        "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Compute/virtualMachines",
-        "ResourceType": "Microsoft.Compute/virtualMachines",
-        "Sku": null,
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "resources": [
-            {
-                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-C-NIC",
-                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-C-NIC",
-                "Identity": null,
-                "Kind": null,
-                "Location": "region",
-                "ManagedBy": null,
-                "ResourceName": "vm-C-NIC",
-                "Name": "vm-C-NIC",
-                "Properties": {
-                    "provisioningState": "Succeeded",
-                    "ipConfigurations": [
-                        {
-                            "name": "ipconfig1",
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-C-NIC/ipConfigurations/ipconfig1",
-                            "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
-                            "properties": {
-                                "provisioningState": "Succeeded",
-                                "privateIPAddress": "10.5.0.4",
-                                "privateIPAllocationMethod": "Dynamic",
-                                "publicIPAddress": {
-                                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/vm-C-ip"
-                                },
-                                "subnet": {
-                                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
-                                },
-                                "primary": true,
-                                "privateIPAddressVersion": "IPv4"
-                            }
-                        }
-                    ],
-                    "dnsSettings": {
-                        "dnsServers": [],
-                        "appliedDnsServers": []
-                    },
-                    "macAddress": "00-00-00-00-00-00",
-                    "enableAcceleratedNetworking": false,
-                    "enableIPForwarding": false,
-                    "networkSecurityGroup": {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-A"
-                    },
-                    "primary": true,
-                    "virtualMachine": {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-C"
-                    }
-                },
-                "ResourceGroupName": "test-rg",
-                "Type": "Microsoft.Network/networkInterfaces",
-                "ResourceType": "Microsoft.Network/networkInterfaces",
-                "Sku": null,
-                "Tags": null,
-                "SubscriptionId": null
-            }
-        ]
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-B",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-B",
-        "Location": "region",
-        "ResourceName": "nic-B",
-        "Name": "nic-B",
-        "Properties": {
-            "ipConfigurations": [
-                {
-                    "name": "ipconfig1",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-B/ipConfigurations/ipconfig1",
-                    "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
-                    "properties": {
-                        "provisioningState": "Succeeded",
-                        "privateIPAddress": "10.0.0.4",
-                        "privateIPAllocationMethod": "Static",
-                        "publicIPAddress": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/nic-B-pip"
-                        },
-                        "subnet": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
-                        },
-                        "primary": true,
-                        "privateIPAddressVersion": "IPv4"
-                    }
-                }
-            ],
-            "dnsSettings": {
-                "dnsServers": [
-                    "8.8.8.8"
-                ],
-                "appliedDnsServers": [
-                    "8.8.8.8"
-                ],
-                "internalDomainNameSuffix": "example.nn.internal.cloudapp.net"
-            },
-            "macAddress": "00-00-00-00-00-00",
-            "enableAcceleratedNetworking": false,
-            "enableIPForwarding": false,
-            "primary": true,
-            "virtualMachine": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-A"
-            },
-            "hostedWorkloads": [],
-            "tapConfigurations": []
+          ],
+          "dnsSettings": {
+            "dnsServers": ["8.8.8.8"],
+            "appliedDnsServers": ["8.8.8.8"],
+            "internalDomainNameSuffix": "example.nn.internal.cloudapp.net"
+          },
+          "macAddress": "00-00-00-00-00-00",
+          "enableAcceleratedNetworking": false,
+          "enableIPForwarding": false,
+          "primary": true,
+          "virtualMachine": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-B"
+          },
+          "hostedWorkloads": [],
+          "tapConfigurations": []
         },
         "ResourceGroupName": "test-rg",
         "Type": "Microsoft.Network/networkInterfaces",
         "ResourceType": "Microsoft.Network/networkInterfaces",
         "Tags": null,
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-C",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-C",
+      },
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-B/extensions/OMSExtension",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-B/extensions/OMSExtension",
         "Location": "region",
-        "ResourceName": "nic-C",
-        "Name": "nic-C",
+        "ResourceName": "OMSExtension",
+        "Name": "OMSExtension",
+        "ExtensionResourceName": null,
+        "ParentResource": "virtualMachines/vm-B",
         "Properties": {
-            "ipConfigurations": [
-                {
-                    "name": "ipconfig1",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-C/ipConfigurations/ipconfig1",
-                    "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
-                    "properties": {
-                        "provisioningState": "Succeeded",
-                        "privateIPAddress": "10.0.0.5",
-                        "privateIPAllocationMethod": "Static",
-                        "publicIPAddress": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/nic-C-pip"
-                        },
-                        "subnet": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
-                        },
-                        "primary": true,
-                        "privateIPAddressVersion": "IPv4"
-                    }
-                }
-            ],
-            "dnsSettings": {
-                "dnsServers": [
-                    "8.8.8.8"
-                ],
-                "appliedDnsServers": [
-                    "8.8.8.8"
-                ],
-                "internalDomainNameSuffix": "example.nn.internal.cloudapp.net"
-            },
-            "macAddress": "00-00-00-00-00-00",
-            "enableAcceleratedNetworking": false,
-            "enableIPForwarding": false,
-            "primary": true,
-            "hostedWorkloads": [],
-            "tapConfigurations": []
+          "publisher": "Microsoft.EnterpriseCloud.Monitoring",
+          "type": "MicrosoftMonitorAgent",
+          "typeHandlerVersion": "1.0",
+          "autoUpgradeMinorVersion": true,
+          "settings": {
+            "workspaceId": "00000000-0000-0000-0000-000000000000"
+          }
         },
         "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Network/networkInterfaces",
-        "ResourceType": "Microsoft.Network/networkInterfaces",
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-D",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-D",
-        "Identity": null,
-        "Kind": null,
-        "Location": "region",
-        "ManagedBy": null,
-        "ResourceName": "vm-D",
-        "Name": "vm-D",
-        "Plan": null,
-        "Properties": {
-            "hardwareProfile": {
-                "vmSize": "Standard_DS2_v2"
-            },
-            "storageProfile": {
-                "imageReference": {
-                    "publisher": "MicrosoftWindowsDesktop",
-                    "offer": "windows-10",
-                    "sku": "19h2-pro",
-                    "version": "latest"
-                },
-                "osDisk": {
-                    "osType": "Windows",
-                    "name": "vm-D-os",
-                    "createOption": "FromImage",
-                    "caching": "ReadWrite",
-                    "writeAcceleratorEnabled": false,
-                    "managedDisk": {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/vm-D-os"
-                    }
-                },
-                "dataDisks": []
-            },
-            "osProfile": {
-                "computerName": "vm-D",
-                "adminUsername": "vm-admin",
-                "windowsConfiguration": {
-                    "provisionVMAgent": true,
-                    "enableAutomaticUpdates": false,
-                    "patchSettings": {
-                        "patchMode": "Manual"
-                    }
-                },
-                "secrets": [],
-                "allowExtensionOperations": true,
-                "requireGuestProvisionSignal": true
-            },
-            "networkProfile": {
-                "networkInterfaces": [
-                    {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-D-nic"
-                    }
-                ]
-            },
-            "diagnosticsProfile": {
-                "bootDiagnostics": {
-                    "enabled": true,
-                    "storageUri": "https://storage-A.blob.core.windows.net/"
-                }
-            },
-            "licenseType": "Windows_Client",
-            "provisioningState": "Succeeded"
-        },
-        "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Compute/virtualMachines",
-        "ResourceType": "Microsoft.Compute/virtualMachines",
+        "Type": "Microsoft.Compute/virtualMachines/extensions",
+        "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
         "ExtensionResourceType": null,
         "Sku": null,
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "resources": [
-            {
-                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-D-nic",
-                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-D-nic",
-                "Identity": null,
-                "Kind": null,
-                "Location": "region",
-                "ManagedBy": null,
-                "ResourceName": "vm-D-nic",
-                "Name": "vm-D-nic",
-                "Plan": null,
-                "Properties": {
-                    "provisioningState": "Succeeded",
-                    "ipConfigurations": [
-                        {
-                            "name": "ipconfig1",
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-D-nic/ipConfigurations/ipconfig1",
-                            "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
-                            "properties": {
-                                "provisioningState": "Succeeded",
-                                "privateIPAddress": "10.0.0.10",
-                                "privateIPAllocationMethod": "Dynamic",
-                                "subnet": {
-                                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
-                                },
-                                "primary": true,
-                                "privateIPAddressVersion": "IPv4"
-                            }
-                        }
-                    ],
-                    "dnsSettings": {
-                        "dnsServers": [],
-                        "appliedDnsServers": []
-                    },
-                    "enableAcceleratedNetworking": false,
-                    "enableIPForwarding": false,
-                    "networkSecurityGroup": {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/vm-D-nsg"
-                    },
-                    "primary": true,
-                    "virtualMachine": {
-                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-D"
-                    }
-                },
-                "ResourceGroupName": "test-rg",
-                "Type": "Microsoft.Network/networkInterfaces",
-                "ResourceType": "Microsoft.Network/networkInterfaces",
-                "ExtensionResourceType": null,
-                "Sku": null,
-                "Tags": null,
-                "SubscriptionId": null
-            }
-        ]
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/pe-001",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/pe-001",
-        "Identity": null,
-        "Kind": null,
-        "Location": "region",
-        "ManagedBy": null,
-        "ResourceName": "pe-001",
-        "Name": "pe-001",
-        "ExtensionResourceName": null,
-        "ParentResource": null,
-        "Plan": null,
-        "Properties": {
-            "ipConfigurations": [
-                {
-                    "name": "redisCache-redisCache.privateEndpoint",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/pe-001/ipConfigurations/redisCache-redisCache.privateEndpoint",
-                    "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
-                    "properties": {
-                        "privateIPAddress": "10.0.0.4",
-                        "privateIPAllocationMethod": "Dynamic",
-                        "subnet": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/sub-pe"
-                        },
-                        "primary": true,
-                        "privateIPAddressVersion": "IPv4",
-                        "privateLinkConnectionProperties": {
-                            "groupId": "redisCache",
-                            "requiredMemberName": "redisCache",
-                            "fqdns": [
-                                "redis-001.redis.cache.windows.net"
-                            ]
-                        }
-                    }
-                }
-            ],
-            "dnsSettings": {
-                "dnsServers": [],
-                "appliedDnsServers": []
-            },
-            "macAddress": "",
-            "enableAcceleratedNetworking": false,
-            "vnetEncryptionSupported": false,
-            "enableIPForwarding": false,
-            "hostedWorkloads": [],
-            "tapConfigurations": [],
-            "privateEndpoint": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/privateEndpoints/pe-001"
-            },
-            "nicType": "Standard"
+        "SubscriptionId": null
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1",
+    "Location": "region",
+    "ResourceName": "aks-agentpool-00000000-1",
+    "Name": "aks-agentpool-00000000-1",
+    "Properties": {
+      "availabilitySet": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/AGENTPOOL-AVAILABILITYSET-00000000"
+      },
+      "hardwareProfile": {
+        "vmSize": "Standard_F2s_v2"
+      },
+      "storageProfile": {
+        "imageReference": {
+          "publisher": "microsoft-aks",
+          "offer": "aks",
+          "sku": "aks-ubuntu-1604-201902",
+          "version": "2019.02.28"
         },
-        "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Network/networkInterfaces",
-        "ResourceType": "Microsoft.Network/networkInterfaces",
-        "ExtensionResourceType": null,
-        "Sku": null,
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+        "osDisk": {
+          "osType": "Linux",
+          "name": "aks-agentpool-00000000-1_OsDisk_1_0000000000000000000000000000000",
+          "createOption": "FromImage",
+          "caching": "ReadWrite",
+          "managedDisk": {
+            "storageAccountType": "Premium_LRS",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/disks/aks-agentpool-00000000-1_OsDisk_1_0000000000000000000000000000000"
+          },
+          "diskSizeGB": 30
+        }
+      },
+      "osProfile": {
+        "computerName": "aks-agentpool-00000000-1",
+        "adminUsername": "azureuser",
+        "linuxConfiguration": {
+          "disablePasswordAuthentication": true,
+          "ssh": {
+            "publicKeys": [
+              {
+                "path": "/home/azureuser/.ssh/authorized_keys",
+                "keyData": "ssh-rsa 000000\n"
+              }
+            ]
+          },
+          "provisionVMAgent": true
+        },
+        "secrets": [],
+        "allowExtensionOperations": true
+      },
+      "networkProfile": {
+        "networkInterfaces": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-1"
+          }
+        ]
+      }
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/privateEndpoints/pe-001",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/privateEndpoints/pe-001",
-        "Identity": null,
-        "Kind": null,
-        "Location": "region",
-        "ManagedBy": null,
-        "ResourceName": "pe-001",
-        "Name": "pe-001",
-        "ExtensionResourceName": null,
-        "ParentResource": null,
-        "Plan": null,
-        "Properties": {
-            "privateLinkServiceConnections": [
-                {
-                    "name": "pec-001",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/privateEndpoints/pe-001/privateLinkServiceConnections/pec-001",
-                    "properties": {
-                        "privateLinkServiceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Cache/Redis/redis-001",
-                        "groupIds": [
-                            "redisCache"
-                        ],
-                        "privateLinkServiceConnectionState": {
-                            "status": "Approved",
-                            "description": "Auto-Approved",
-                            "actionsRequired": "None"
-                        }
-                    },
-                    "type": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections"
-                }
-            ],
-            "manualPrivateLinkServiceConnections": [],
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/virtualMachines",
+    "ResourceType": "Microsoft.Compute/virtualMachines",
+    "Tags": {
+      "resourceNameSuffix": "00000000",
+      "orchestrator": "Kubernetes:1.12.6",
+      "aksEngineVersion": "v0.30.1-aks",
+      "poolName": "agentpool",
+      "creationSource": "aksengine-aks-agentpool-00000000-1"
+    },
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1/extensions/computeAksLinuxBilling",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1/extensions/computeAksLinuxBilling",
+    "Location": "region",
+    "ResourceName": "computeAksLinuxBilling",
+    "Name": "computeAksLinuxBilling",
+    "Properties": {
+      "autoUpgradeMinorVersion": true,
+      "settings": {},
+      "provisioningState": "Succeeded",
+      "publisher": "Microsoft.AKS",
+      "type": "Compute.AKS.Linux.Billing",
+      "typeHandlerVersion": "1.0"
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/virtualMachines/extensions",
+    "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1/extensions/cse-agent-1",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1/extensions/cse-agent-1",
+    "Location": "region",
+    "ResourceName": "cse-agent-1",
+    "Name": "cse-agent-1",
+    "Properties": {
+      "autoUpgradeMinorVersion": true,
+      "settings": {},
+      "provisioningState": "Succeeded",
+      "publisher": "Microsoft.Azure.Extensions",
+      "type": "CustomScript",
+      "typeHandlerVersion": "2.0"
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/virtualMachines/extensions",
+    "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1/extensions/OmsAgentForLinux",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1/extensions/OmsAgentForLinux",
+    "Location": "region",
+    "ResourceName": "OmsAgentForLinux",
+    "Name": "OmsAgentForLinux",
+    "Properties": {
+      "autoUpgradeMinorVersion": true,
+      "settings": {
+        "workspaceId": "00000000-0000-0000-0000-000000000000",
+        "stopOnMultipleConnections": true
+      },
+      "provisioningState": "Succeeded",
+      "publisher": "Microsoft.EnterpriseCloud.Monitoring",
+      "type": "OmsAgentForLinux",
+      "typeHandlerVersion": "1.0"
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/virtualMachines/extensions",
+    "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2",
+    "Location": "region",
+    "ResourceName": "aks-agentpool-00000000-2",
+    "Name": "aks-agentpool-00000000-2",
+    "Properties": {
+      "availabilitySet": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/AGENTPOOL-AVAILABILITYSET-00000000"
+      },
+      "hardwareProfile": {
+        "vmSize": "Standard_F2s_v2"
+      },
+      "storageProfile": {
+        "imageReference": {
+          "publisher": "microsoft-aks",
+          "offer": "aks",
+          "sku": "aks-ubuntu-1604-201902",
+          "version": "2019.02.28"
+        },
+        "osDisk": {
+          "osType": "Linux",
+          "name": "aks-agentpool-00000000-2_OsDisk_1_0000000000000000000000000000000",
+          "createOption": "FromImage",
+          "caching": "ReadWrite",
+          "managedDisk": {
+            "storageAccountType": "Premium_LRS",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/disks/aks-agentpool-00000000-2_OsDisk_1_0000000000000000000000000000000"
+          },
+          "diskSizeGB": 30
+        },
+        "dataDisks": []
+      },
+      "osProfile": {
+        "computerName": "aks-agentpool-00000000-2",
+        "adminUsername": "azureuser",
+        "linuxConfiguration": {
+          "disablePasswordAuthentication": true,
+          "ssh": {
+            "publicKeys": [
+              {
+                "path": "/home/azureuser/.ssh/authorized_keys",
+                "keyData": "ssh-rsa 000000\n"
+              }
+            ]
+          },
+          "provisionVMAgent": true
+        },
+        "secrets": [],
+        "allowExtensionOperations": true
+      },
+      "networkProfile": {
+        "networkInterfaces": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-2"
+          }
+        ]
+      },
+      "provisioningState": "Succeeded"
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/virtualMachines",
+    "ResourceType": "Microsoft.Compute/virtualMachines",
+    "Tags": {
+      "resourceNameSuffix": "00000000",
+      "orchestrator": "Kubernetes:1.12.6",
+      "aksEngineVersion": "v0.30.1-aks",
+      "poolName": "agentpool",
+      "creationSource": "aksengine-aks-agentpool-00000000-2"
+    },
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2/extensions/computeAksLinuxBilling",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2/extensions/computeAksLinuxBilling",
+    "Location": "region",
+    "ResourceName": "computeAksLinuxBilling",
+    "Name": "computeAksLinuxBilling",
+    "Properties": {
+      "autoUpgradeMinorVersion": true,
+      "settings": {},
+      "provisioningState": "Succeeded",
+      "publisher": "Microsoft.AKS",
+      "type": "Compute.AKS.Linux.Billing",
+      "typeHandlerVersion": "1.0"
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/virtualMachines/extensions",
+    "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2/extensions/cse-agent-2",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2/extensions/cse-agent-2",
+    "Location": "region",
+    "ResourceName": "cse-agent-2",
+    "Name": "cse-agent-2",
+    "Properties": {
+      "autoUpgradeMinorVersion": true,
+      "settings": {},
+      "provisioningState": "Succeeded",
+      "publisher": "Microsoft.Azure.Extensions",
+      "type": "CustomScript",
+      "typeHandlerVersion": "2.0"
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/virtualMachines/extensions",
+    "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2/extensions/OmsAgentForLinux",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2/extensions/OmsAgentForLinux",
+    "Location": "region",
+    "ResourceName": "OmsAgentForLinux",
+    "Name": "OmsAgentForLinux",
+    "Properties": {
+      "autoUpgradeMinorVersion": true,
+      "settings": {
+        "workspaceId": "00000000-0000-0000-0000-000000000000",
+        "stopOnMultipleConnections": true
+      },
+      "provisioningState": "Succeeded",
+      "publisher": "Microsoft.EnterpriseCloud.Monitoring",
+      "type": "OmsAgentForLinux",
+      "typeHandlerVersion": "1.0"
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/virtualMachines/extensions",
+    "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3",
+    "Location": "region",
+    "ResourceName": "aks-agentpool-00000000-3",
+    "Name": "aks-agentpool-00000000-3",
+    "Properties": {
+      "availabilitySet": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/AGENTPOOL-AVAILABILITYSET-00000000"
+      },
+      "hardwareProfile": {
+        "vmSize": "Standard_F2s_v2"
+      },
+      "storageProfile": {
+        "imageReference": {
+          "publisher": "microsoft-aks",
+          "offer": "aks",
+          "sku": "aks-ubuntu-1604-201902",
+          "version": "2019.02.28"
+        },
+        "osDisk": {
+          "osType": "Linux",
+          "name": "aks-agentpool-00000000-3_OsDisk_1_0000000000000000000000000000000",
+          "createOption": "FromImage",
+          "caching": "ReadWrite",
+          "managedDisk": {
+            "storageAccountType": "Premium_LRS",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/disks/aks-agentpool-00000000-3_OsDisk_1_0000000000000000000000000000000"
+          },
+          "diskSizeGB": 30
+        },
+        "dataDisks": []
+      },
+      "osProfile": {
+        "computerName": "aks-agentpool-00000000-3",
+        "adminUsername": "azureuser",
+        "linuxConfiguration": {
+          "disablePasswordAuthentication": true,
+          "ssh": {
+            "publicKeys": [
+              {
+                "path": "/home/azureuser/.ssh/authorized_keys",
+                "keyData": "ssh-rsa 000000\n"
+              }
+            ]
+          },
+          "provisionVMAgent": true
+        },
+        "secrets": [],
+        "allowExtensionOperations": true
+      },
+      "networkProfile": {
+        "networkInterfaces": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-3"
+          }
+        ]
+      },
+      "provisioningState": "Succeeded"
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/virtualMachines",
+    "ResourceType": "Microsoft.Compute/virtualMachines",
+    "Tags": {
+      "resourceNameSuffix": "00000000",
+      "orchestrator": "Kubernetes:1.12.6",
+      "aksEngineVersion": "v0.30.1-aks",
+      "poolName": "agentpool",
+      "creationSource": "aksengine-aks-agentpool-00000000-3"
+    },
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3/extensions/computeAksLinuxBilling",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3/extensions/computeAksLinuxBilling",
+    "Location": "region",
+    "ResourceName": "computeAksLinuxBilling",
+    "Name": "computeAksLinuxBilling",
+    "Properties": {
+      "autoUpgradeMinorVersion": true,
+      "settings": {},
+      "provisioningState": "Succeeded",
+      "publisher": "Microsoft.AKS",
+      "type": "Compute.AKS.Linux.Billing",
+      "typeHandlerVersion": "1.0"
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/virtualMachines/extensions",
+    "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3/extensions/cse-agent-3",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3/extensions/cse-agent-3",
+    "Location": "region",
+    "ResourceName": "cse-agent-3",
+    "Name": "cse-agent-3",
+    "Properties": {
+      "autoUpgradeMinorVersion": true,
+      "settings": {},
+      "provisioningState": "Succeeded",
+      "publisher": "Microsoft.Azure.Extensions",
+      "type": "CustomScript",
+      "typeHandlerVersion": "2.0"
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/virtualMachines/extensions",
+    "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3/extensions/OmsAgentForLinux",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3/extensions/OmsAgentForLinux",
+    "Location": "region",
+    "ResourceName": "OmsAgentForLinux",
+    "Name": "OmsAgentForLinux",
+    "Properties": {
+      "autoUpgradeMinorVersion": true,
+      "settings": {
+        "workspaceId": "00000000-0000-0000-0000-000000000000",
+        "stopOnMultipleConnections": true
+      },
+      "provisioningState": "Succeeded",
+      "publisher": "Microsoft.EnterpriseCloud.Monitoring",
+      "type": "OmsAgentForLinux",
+      "typeHandlerVersion": "1.0"
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/virtualMachines/extensions",
+    "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-1",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-1",
+    "Location": "region",
+    "ResourceName": "aks-agentpool-00000000-nic-1",
+    "Name": "aks-agentpool-00000000-nic-1",
+    "Properties": {
+      "provisioningState": "Succeeded",
+      "ipConfigurations": [
+        {
+          "name": "ipconfig1",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-1/ipConfigurations/ipconfig1",
+          "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+          "properties": {
+            "provisioningState": "Succeeded",
+            "privateIPAddress": "10.1.1.36",
+            "privateIPAllocationMethod": "Dynamic",
             "subnet": {
-                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/sub-pe"
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
             },
-            "ipConfigurations": [],
-            "networkInterfaces": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/pe-001"
-                }
-            ],
-            "customDnsConfigs": []
+            "primary": true,
+            "privateIPAddressVersion": "IPv4",
+            "loadBalancerBackendAddressPools": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"
+              }
+            ]
+          }
+        },
+        {
+          "name": "ipconfig2",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-1/ipConfigurations/ipconfig2",
+          "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+          "properties": {
+            "provisioningState": "Succeeded",
+            "privateIPAddress": "10.1.1.37",
+            "privateIPAllocationMethod": "Dynamic",
+            "subnet": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
+            },
+            "primary": false,
+            "privateIPAddressVersion": "IPv4"
+          }
+        }
+      ],
+      "dnsSettings": {
+        "dnsServers": [],
+        "appliedDnsServers": [],
+        "internalDomainNameSuffix": "nnn.nn.internal.cloudapp.net"
+      },
+      "macAddress": "00-00-00-00-00-00",
+      "enableAcceleratedNetworking": false,
+      "enableIPForwarding": false,
+      "networkSecurityGroup": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkSecurityGroups/aks-agentpool-00000000-nsg"
+      },
+      "primary": true,
+      "virtualMachine": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-1"
+      },
+      "hostedWorkloads": [],
+      "tapConfigurations": []
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Network/networkInterfaces",
+    "ResourceType": "Microsoft.Network/networkInterfaces",
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-2",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-2",
+    "Location": "region",
+    "ResourceName": "aks-agentpool-00000000-nic-2",
+    "Name": "aks-agentpool-00000000-nic-2",
+    "Properties": {
+      "provisioningState": "Succeeded",
+      "ipConfigurations": [
+        {
+          "name": "ipconfig1",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-2/ipConfigurations/ipconfig1",
+          "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+          "properties": {
+            "provisioningState": "Succeeded",
+            "privateIPAddress": "10.1.1.35",
+            "privateIPAllocationMethod": "Dynamic",
+            "subnet": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
+            },
+            "primary": true,
+            "privateIPAddressVersion": "IPv4",
+            "loadBalancerBackendAddressPools": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"
+              }
+            ]
+          }
+        },
+        {
+          "name": "ipconfig2",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-2/ipConfigurations/ipconfig2",
+          "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+          "properties": {
+            "provisioningState": "Succeeded",
+            "privateIPAddress": "10.1.1.66",
+            "privateIPAllocationMethod": "Dynamic",
+            "subnet": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
+            },
+            "primary": false,
+            "privateIPAddressVersion": "IPv4"
+          }
+        }
+      ],
+      "dnsSettings": {
+        "dnsServers": [],
+        "appliedDnsServers": [],
+        "internalDomainNameSuffix": "nnn.nn.internal.cloudapp.net"
+      },
+      "macAddress": "00-00-00-00-00-00",
+      "enableAcceleratedNetworking": false,
+      "enableIPForwarding": false,
+      "networkSecurityGroup": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkSecurityGroups/aks-agentpool-00000000-nsg"
+      },
+      "primary": true,
+      "virtualMachine": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-2"
+      },
+      "hostedWorkloads": [],
+      "tapConfigurations": []
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Network/networkInterfaces",
+    "ResourceType": "Microsoft.Network/networkInterfaces",
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-3",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-3",
+    "Location": "region",
+    "ResourceName": "aks-agentpool-00000000-nic-3",
+    "Name": "aks-agentpool-00000000-nic-3",
+    "Properties": {
+      "provisioningState": "Succeeded",
+      "ipConfigurations": [
+        {
+          "name": "ipconfig1",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkInterfaces/aks-agentpool-00000000-nic-3/ipConfigurations/ipconfig1",
+          "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+          "properties": {
+            "provisioningState": "Succeeded",
+            "privateIPAddress": "10.1.1.97",
+            "privateIPAllocationMethod": "Dynamic",
+            "subnet": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
+            },
+            "primary": true,
+            "privateIPAddressVersion": "IPv4",
+            "loadBalancerBackendAddressPools": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/loadBalancers/kubernetes/backendAddressPools/kubernetes"
+              }
+            ]
+          }
+        }
+      ],
+      "dnsSettings": {
+        "dnsServers": [],
+        "appliedDnsServers": [],
+        "internalDomainNameSuffix": "nnn.nn.internal.cloudapp.net"
+      },
+      "macAddress": "00-00-00-00-00-00",
+      "enableAcceleratedNetworking": false,
+      "enableIPForwarding": false,
+      "networkSecurityGroup": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Network/networkSecurityGroups/aks-agentpool-00000000-nsg"
+      },
+      "primary": true,
+      "virtualMachine": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/aks-agentpool-00000000-3"
+      },
+      "hostedWorkloads": [],
+      "tapConfigurations": []
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Network/networkInterfaces",
+    "ResourceType": "Microsoft.Network/networkInterfaces",
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/agentpool-availabilitySet-00000000",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/agentpool-availabilitySet-00000000",
+    "Location": "region",
+    "ResourceName": "agentpool-availabilitySet-00000000",
+    "Name": "agentpool-availabilitySet-00000000",
+    "Properties": {
+      "platformUpdateDomainCount": 3,
+      "platformFaultDomainCount": 2,
+      "virtualMachines": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/AKS-AGENTPOOL-00000000-1"
+        },
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/AKS-AGENTPOOL-00000000-2"
+        },
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/AKS-AGENTPOOL-00000000-3"
+        }
+      ]
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/availabilitySets",
+    "ResourceType": "Microsoft.Compute/availabilitySets",
+    "Sku": {
+      "Name": "Aligned",
+      "Tier": null,
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": null
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/availabilitySet-B",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/availabilitySets/availabilitySet-B",
+    "Location": "region",
+    "ResourceName": "availabilitySet-B",
+    "Name": "availabilitySet-B",
+    "Properties": {
+      "platformUpdateDomainCount": 3,
+      "platformFaultDomainCount": 2,
+      "virtualMachines": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/virtualMachines/AKS-AGENTPOOL-00000000-1"
+        }
+      ]
+    },
+    "ResourceGroupName": "MC_test-rg",
+    "Type": "Microsoft.Compute/availabilitySets",
+    "ResourceType": "Microsoft.Compute/availabilitySets",
+    "Sku": {
+      "Name": "Classic",
+      "Tier": null,
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": null
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-C",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-C",
+    "Identity": {
+      "PrincipalId": "00000000-0000-0000-0000-000000000000",
+      "TenantId": "00000000-0000-0000-0000-000000000000",
+      "Type": "SystemAssigned",
+      "UserAssignedIdentities": null
+    },
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "vm-C",
+    "Name": "vm-C",
+    "Properties": {
+      "vmId": "00000000-0000-0000-0000-000000000000",
+      "hardwareProfile": {
+        "vmSize": "Standard_D8s_v3"
+      },
+      "storageProfile": {
+        "imageReference": {
+          "publisher": "Canonical",
+          "offer": "UbuntuServer",
+          "sku": "16.04-LTS",
+          "version": "latest",
+          "exactVersion": "16.04.201708151"
+        },
+        "osDisk": {
+          "osType": "Linux",
+          "name": "vm-C_OsDisk_1",
+          "createOption": "FromImage",
+          "caching": "ReadWrite",
+          "managedDisk": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/vm-C_OsDisk_1"
+          }
+        },
+        "dataDisks": []
+      },
+      "osProfile": {
+        "computerName": "vm-C",
+        "adminUsername": "admin-account",
+        "linuxConfiguration": {
+          "disablePasswordAuthentication": false,
+          "provisionVMAgent": false
+        },
+        "secrets": []
+      },
+      "networkProfile": {
+        "networkInterfaces": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-C-NIC"
+          }
+        ]
+      },
+      "provisioningState": "Succeeded"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/virtualMachines",
+    "ResourceType": "Microsoft.Compute/virtualMachines",
+    "Sku": null,
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-C-NIC",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-C-NIC",
+        "Identity": null,
+        "Kind": null,
+        "Location": "region",
+        "ManagedBy": null,
+        "ResourceName": "vm-C-NIC",
+        "Name": "vm-C-NIC",
+        "Properties": {
+          "provisioningState": "Succeeded",
+          "ipConfigurations": [
+            {
+              "name": "ipconfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-C-NIC/ipConfigurations/ipconfig1",
+              "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.5.0.4",
+                "privateIPAllocationMethod": "Dynamic",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/vm-C-ip"
+                },
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
+                },
+                "primary": true,
+                "privateIPAddressVersion": "IPv4"
+              }
+            }
+          ],
+          "dnsSettings": {
+            "dnsServers": [],
+            "appliedDnsServers": []
+          },
+          "macAddress": "00-00-00-00-00-00",
+          "enableAcceleratedNetworking": false,
+          "enableIPForwarding": false,
+          "networkSecurityGroup": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-A"
+          },
+          "primary": true,
+          "virtualMachine": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-C"
+          }
         },
         "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Network/privateEndpoints",
-        "ResourceType": "Microsoft.Network/privateEndpoints",
+        "Type": "Microsoft.Network/networkInterfaces",
+        "ResourceType": "Microsoft.Network/networkInterfaces",
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": null
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-B",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-B",
+    "Location": "region",
+    "ResourceName": "nic-B",
+    "Name": "nic-B",
+    "Properties": {
+      "ipConfigurations": [
+        {
+          "name": "ipconfig1",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-B/ipConfigurations/ipconfig1",
+          "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+          "properties": {
+            "provisioningState": "Succeeded",
+            "privateIPAddress": "10.0.0.4",
+            "privateIPAllocationMethod": "Static",
+            "publicIPAddress": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/nic-B-pip"
+            },
+            "subnet": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
+            },
+            "primary": true,
+            "privateIPAddressVersion": "IPv4"
+          }
+        }
+      ],
+      "dnsSettings": {
+        "dnsServers": ["8.8.8.8"],
+        "appliedDnsServers": ["8.8.8.8"],
+        "internalDomainNameSuffix": "example.nn.internal.cloudapp.net"
+      },
+      "macAddress": "00-00-00-00-00-00",
+      "enableAcceleratedNetworking": false,
+      "enableIPForwarding": false,
+      "primary": true,
+      "virtualMachine": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-A"
+      },
+      "hostedWorkloads": [],
+      "tapConfigurations": []
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Network/networkInterfaces",
+    "ResourceType": "Microsoft.Network/networkInterfaces",
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-C",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-C",
+    "Location": "region",
+    "ResourceName": "nic-C",
+    "Name": "nic-C",
+    "Properties": {
+      "ipConfigurations": [
+        {
+          "name": "ipconfig1",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-C/ipConfigurations/ipconfig1",
+          "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+          "properties": {
+            "provisioningState": "Succeeded",
+            "privateIPAddress": "10.0.0.5",
+            "privateIPAllocationMethod": "Static",
+            "publicIPAddress": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/nic-C-pip"
+            },
+            "subnet": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
+            },
+            "primary": true,
+            "privateIPAddressVersion": "IPv4"
+          }
+        }
+      ],
+      "dnsSettings": {
+        "dnsServers": ["8.8.8.8"],
+        "appliedDnsServers": ["8.8.8.8"],
+        "internalDomainNameSuffix": "example.nn.internal.cloudapp.net"
+      },
+      "macAddress": "00-00-00-00-00-00",
+      "enableAcceleratedNetworking": false,
+      "enableIPForwarding": false,
+      "primary": true,
+      "hostedWorkloads": [],
+      "tapConfigurations": []
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Network/networkInterfaces",
+    "ResourceType": "Microsoft.Network/networkInterfaces",
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-D",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-D",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "vm-D",
+    "Name": "vm-D",
+    "Plan": null,
+    "Properties": {
+      "hardwareProfile": {
+        "vmSize": "Standard_DS2_v2"
+      },
+      "storageProfile": {
+        "imageReference": {
+          "publisher": "MicrosoftWindowsDesktop",
+          "offer": "windows-10",
+          "sku": "19h2-pro",
+          "version": "latest"
+        },
+        "osDisk": {
+          "osType": "Windows",
+          "name": "vm-D-os",
+          "createOption": "FromImage",
+          "caching": "ReadWrite",
+          "writeAcceleratorEnabled": false,
+          "managedDisk": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/vm-D-os"
+          }
+        },
+        "dataDisks": []
+      },
+      "osProfile": {
+        "computerName": "vm-D",
+        "adminUsername": "vm-admin",
+        "windowsConfiguration": {
+          "provisionVMAgent": true,
+          "enableAutomaticUpdates": false,
+          "patchSettings": {
+            "patchMode": "Manual"
+          }
+        },
+        "secrets": [],
+        "allowExtensionOperations": true,
+        "requireGuestProvisionSignal": true
+      },
+      "networkProfile": {
+        "networkInterfaces": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-D-nic"
+          }
+        ]
+      },
+      "diagnosticsProfile": {
+        "bootDiagnostics": {
+          "enabled": true,
+          "storageUri": "https://storage-A.blob.core.windows.net/"
+        }
+      },
+      "licenseType": "Windows_Client",
+      "provisioningState": "Succeeded"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/virtualMachines",
+    "ResourceType": "Microsoft.Compute/virtualMachines",
+    "ExtensionResourceType": null,
+    "Sku": null,
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-D-nic",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-D-nic",
+        "Identity": null,
+        "Kind": null,
+        "Location": "region",
+        "ManagedBy": null,
+        "ResourceName": "vm-D-nic",
+        "Name": "vm-D-nic",
+        "Plan": null,
+        "Properties": {
+          "provisioningState": "Succeeded",
+          "ipConfigurations": [
+            {
+              "name": "ipconfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/vm-D-nic/ipConfigurations/ipconfig1",
+              "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "privateIPAddress": "10.0.0.10",
+                "privateIPAllocationMethod": "Dynamic",
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
+                },
+                "primary": true,
+                "privateIPAddressVersion": "IPv4"
+              }
+            }
+          ],
+          "dnsSettings": {
+            "dnsServers": [],
+            "appliedDnsServers": []
+          },
+          "enableAcceleratedNetworking": false,
+          "enableIPForwarding": false,
+          "networkSecurityGroup": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/vm-D-nsg"
+          },
+          "primary": true,
+          "virtualMachine": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-D"
+          }
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Network/networkInterfaces",
+        "ResourceType": "Microsoft.Network/networkInterfaces",
         "ExtensionResourceType": null,
         "Sku": null,
         "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "CreatedTime": null,
-        "ChangedTime": null
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/offerSaysLinux",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/offerSaysLinux",
-        "Identity": {
-            "PrincipalId": "00000000-0000-0000-0000-000000000000",
-            "TenantId": "00000000-0000-0000-0000-000000000000",
-            "Type": "SystemAssigned",
-            "UserAssignedIdentities": null
-        },
-        "Kind": null,
+        "SubscriptionId": null
+      },
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-D/extensions/OMSExtension",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-D/extensions/OMSExtension",
         "Location": "region",
-        "ManagedBy": null,
-        "ResourceName": "offerSaysLinux",
-        "Name": "offerSaysLinux",
+        "ResourceName": "OMSExtension",
+        "Name": "OMSExtension",
+        "ExtensionResourceName": null,
+        "ParentResource": "virtualMachines/vm-D",
         "Properties": {
-            "vmId": "00000000-0000-0000-0000-000000000000",
-            "storageProfile": {
-                "imageReference": {
-                    "publisher": "anUnkownPublisher",
-                    "offer": "anOfferThatSaysLinux",
-                    "sku": "16.04-LTS",
-                    "version": "latest",
-                    "exactVersion": "16.04.201708151"
-                }
-            },
-            "provisioningState": "Succeeded"
+          "publisher": "Microsoft.EnterpriseCloud.Monitoring",
+          "type": "MicrosoftMonitorAgent",
+          "typeHandlerVersion": "1.0",
+          "autoUpgradeMinorVersion": true,
+          "settings": {
+            "workspaceId": "00000000-0000-0000-0000-000000000000"
+          }
         },
         "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Compute/virtualMachines",
-        "ResourceType": "Microsoft.Compute/virtualMachines",
+        "Type": "Microsoft.Compute/virtualMachines/extensions",
+        "ResourceType": "Microsoft.Compute/virtualMachines/extensions",
+        "ExtensionResourceType": null,
         "Sku": null,
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/offerInConfig",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/offerInConfig",
-        "Identity": {
-            "PrincipalId": "00000000-0000-0000-0000-000000000000",
-            "TenantId": "00000000-0000-0000-0000-000000000000",
-            "Type": "SystemAssigned",
-            "UserAssignedIdentities": null
-        },
-        "Kind": null,
-        "Location": "region",
-        "ManagedBy": null,
-        "ResourceName": "offerInConfig",
-        "Name": "offerInConfig",
-        "Properties": {
-            "vmId": "00000000-0000-0000-0000-000000000000",
-            "storageProfile": {
-                "imageReference": {
-                    "publisher": "anUnkownPublisher",
-                    "offer": "anOfferName",
-                    "sku": "16.04-LTS",
-                    "version": "latest",
-                    "exactVersion": "16.04.201708151"
-                }
+        "SubscriptionId": null
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/pe-001",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/pe-001",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "pe-001",
+    "Name": "pe-001",
+    "ExtensionResourceName": null,
+    "ParentResource": null,
+    "Plan": null,
+    "Properties": {
+      "ipConfigurations": [
+        {
+          "name": "redisCache-redisCache.privateEndpoint",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/pe-001/ipConfigurations/redisCache-redisCache.privateEndpoint",
+          "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+          "properties": {
+            "privateIPAddress": "10.0.0.4",
+            "privateIPAllocationMethod": "Dynamic",
+            "subnet": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/sub-pe"
             },
-            "provisioningState": "Succeeded"
-        },
-        "ResourceGroupName": "test-rg",
-        "Type": "Microsoft.Compute/virtualMachines",
-        "ResourceType": "Microsoft.Compute/virtualMachines",
-        "Sku": null,
-        "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    }
+            "primary": true,
+            "privateIPAddressVersion": "IPv4",
+            "privateLinkConnectionProperties": {
+              "groupId": "redisCache",
+              "requiredMemberName": "redisCache",
+              "fqdns": ["redis-001.redis.cache.windows.net"]
+            }
+          }
+        }
+      ],
+      "dnsSettings": {
+        "dnsServers": [],
+        "appliedDnsServers": []
+      },
+      "macAddress": "",
+      "enableAcceleratedNetworking": false,
+      "vnetEncryptionSupported": false,
+      "enableIPForwarding": false,
+      "hostedWorkloads": [],
+      "tapConfigurations": [],
+      "privateEndpoint": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/privateEndpoints/pe-001"
+      },
+      "nicType": "Standard"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Network/networkInterfaces",
+    "ResourceType": "Microsoft.Network/networkInterfaces",
+    "ExtensionResourceType": null,
+    "Sku": null,
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/privateEndpoints/pe-001",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/privateEndpoints/pe-001",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "pe-001",
+    "Name": "pe-001",
+    "ExtensionResourceName": null,
+    "ParentResource": null,
+    "Plan": null,
+    "Properties": {
+      "privateLinkServiceConnections": [
+        {
+          "name": "pec-001",
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/privateEndpoints/pe-001/privateLinkServiceConnections/pec-001",
+          "properties": {
+            "privateLinkServiceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Cache/Redis/redis-001",
+            "groupIds": ["redisCache"],
+            "privateLinkServiceConnectionState": {
+              "status": "Approved",
+              "description": "Auto-Approved",
+              "actionsRequired": "None"
+            }
+          },
+          "type": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections"
+        }
+      ],
+      "manualPrivateLinkServiceConnections": [],
+      "subnet": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/sub-pe"
+      },
+      "ipConfigurations": [],
+      "networkInterfaces": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/pe-001"
+        }
+      ],
+      "customDnsConfigs": []
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Network/privateEndpoints",
+    "ResourceType": "Microsoft.Network/privateEndpoints",
+    "ExtensionResourceType": null,
+    "Sku": null,
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "CreatedTime": null,
+    "ChangedTime": null
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/offerSaysLinux",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/offerSaysLinux",
+    "Identity": {
+      "PrincipalId": "00000000-0000-0000-0000-000000000000",
+      "TenantId": "00000000-0000-0000-0000-000000000000",
+      "Type": "SystemAssigned",
+      "UserAssignedIdentities": null
+    },
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "offerSaysLinux",
+    "Name": "offerSaysLinux",
+    "Properties": {
+      "vmId": "00000000-0000-0000-0000-000000000000",
+      "storageProfile": {
+        "imageReference": {
+          "publisher": "anUnkownPublisher",
+          "offer": "anOfferThatSaysLinux",
+          "sku": "16.04-LTS",
+          "version": "latest",
+          "exactVersion": "16.04.201708151"
+        }
+      },
+      "provisioningState": "Succeeded"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/virtualMachines",
+    "ResourceType": "Microsoft.Compute/virtualMachines",
+    "Sku": null,
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/offerInConfig",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/offerInConfig",
+    "Identity": {
+      "PrincipalId": "00000000-0000-0000-0000-000000000000",
+      "TenantId": "00000000-0000-0000-0000-000000000000",
+      "Type": "SystemAssigned",
+      "UserAssignedIdentities": null
+    },
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "offerInConfig",
+    "Name": "offerInConfig",
+    "Properties": {
+      "vmId": "00000000-0000-0000-0000-000000000000",
+      "storageProfile": {
+        "imageReference": {
+          "publisher": "anUnkownPublisher",
+          "offer": "anOfferName",
+          "sku": "16.04-LTS",
+          "version": "latest",
+          "exactVersion": "16.04.201708151"
+        }
+      },
+      "provisioningState": "Succeeded"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/virtualMachines",
+    "ResourceType": "Microsoft.Compute/virtualMachines",
+    "Sku": null,
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  }
 ]


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and the checklist -->

Fixes  #1792

Added Azure.VM.MigrateAMA and Azure.VMSS.MigrateAMA rules.

Rules used to ensure that virtual machines and virtual machine scale sets using the new modern `Azure Monitor Agent` instead of the old legacy agent `Log Analytics Agent`. 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
