### PR TITLE
Pre-release v1.21.0-B0050

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A suite of rules to validate Azure resources and infrastructure as code (IaC) us
 
 Features of PSRule for Azure include:
 
-- [Ready to go][2] - Leverage over 300 pre-built rules to validate Azure resources.
+- [Ready to go][2] - Leverage over 310 pre-built rules to validate Azure resources.
 - [DevOps][3] - Validate resources and infrastructure code pre or post-deployment.
 - [Cross-platform][4] - Run on MacOS, Linux, and Windows.
 

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,10 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.21.0-B0050 (pre-release)
+
+What's changed since pre-release v1.21.0-B0027:
+
 - New rules:
   - Virtual Machine:
     - Check virtual machines uses Azure Monitor Agent instead of old legacy Log Analytics Agent by @bengeset96.
@@ -31,9 +35,6 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
   - Virtual Machine Scale Sets:
     - Check virtual machine scale sets uses Azure Monitor Agent instead of old legacy Log Analytics Agent by @bengeset96.
       [#1792](https://github.com/Azure/PSRule.Rules.Azure/issues/1792)
-
-What's changed since pre-release v1.21.0-B0027:
-
 - Engineering:
   - Bump PSRule to v2.5.3.
     [#1800](https://github.com/Azure/PSRule.Rules.Azure/pull/1800)

--- a/docs/features.md
+++ b/docs/features.md
@@ -25,7 +25,7 @@ This allows you to explore and learn the context of each WAF principle.
 
 ## Ready to go
 
-PSRule for Azure includes over 300 rules for validating resources against configuration recommendations.
+PSRule for Azure includes over 310 rules for validating resources against configuration recommendations.
 Rules automatically detect and analyze resources from Azure IaC artifacts.
 This allows you to quickly light up unit testing of Azure resources from templates and Bicep deployments.
 

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -316,7 +316,7 @@
                 <div>
                     {% include ".icons/octicons/rocket-24.svg" %}
                     <h3 class="h4 text-brand font-weight-600 mb-3">Ready to go</h3>
-                    <p>Leverage over 300 pre-built rules to test Azure resources.</p>
+                    <p>Leverage over 310 pre-built rules to test Azure resources.</p>
                 </div>
             </a>
             <a class="tile" href="{{ page.next_page.url | url }}#devops" target="_self" rel="noopener">


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.21.0-B0027:

- New rules:
  - Virtual Machine:
    - Check virtual machines uses Azure Monitor Agent instead of old legacy Log Analytics Agent by @bengeset96.
      [#1792](https://github.com/Azure/PSRule.Rules.Azure/issues/1792)
  - Virtual Machine Scale Sets:
    - Check virtual machine scale sets uses Azure Monitor Agent instead of old legacy Log Analytics Agent by @bengeset96.
      [#1792](https://github.com/Azure/PSRule.Rules.Azure/issues/1792)
- Engineering:
  - Bump PSRule to v2.5.3.
    [#1800](https://github.com/Azure/PSRule.Rules.Azure/pull/1800)
  - Bump Az.Resources to v6.3.1.
    [#1800](https://github.com/Azure/PSRule.Rules.Azure/pull/1800)
- Bug fixes:
  - Fixed contains function unable to match array by @BernieWhite.
    [#1793](https://github.com/Azure/PSRule.Rules.Azure/issues/1793)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
