### PR TITLE
Release v1.21.0

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,43 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.21.0
+
+What's changed since v1.20.2:
+
+- New features:
+  - Mapping of Azure Security Benchmark v3 to security rules by @jagoodwin.
+    [#1610](https://github.com/Azure/PSRule.Rules.Azure/issues/1610)
+- New rules:
+  - Deployment:
+    - Check sensitive resource values use secure parameters by @VeraBE @BernieWhite.
+      [#1773](https://github.com/Azure/PSRule.Rules.Azure/issues/1773)
+  - Service Bus:
+    - Check service bus namespaces uses TLS 1.2 version by @bengeset96.
+      [#1777](https://github.com/Azure/PSRule.Rules.Azure/issues/1777)
+  - Virtual Machine:
+    - Check virtual machines uses Azure Monitor Agent instead of old legacy Log Analytics Agent by @bengeset96.
+      [#1792](https://github.com/Azure/PSRule.Rules.Azure/issues/1792)
+  - Virtual Machine Scale Sets:
+    - Check virtual machine scale sets uses Azure Monitor Agent instead of old legacy Log Analytics Agent by @bengeset96.
+      [#1792](https://github.com/Azure/PSRule.Rules.Azure/issues/1792)
+  - Virtual Network:
+    - Check VNETs with a GatewaySubnet also has a AzureBastionSubnet by @bengeset96.
+      [#1761](https://github.com/Azure/PSRule.Rules.Azure/issues/1761)
+- General improvements:
+  - Added built-in list of ignored policy definitions by @BernieWhite.
+    [#1730](https://github.com/Azure/PSRule.Rules.Azure/issues/1730)
+    - To ignore additional policy definitions, use the `AZURE_POLICY_IGNORE_LIST` configuration option.
+- Engineering:
+  - Bump PSRule to v2.5.3.
+    [#1800](https://github.com/Azure/PSRule.Rules.Azure/pull/1800)
+  - Bump Az.Resources to v6.3.1.
+    [#1800](https://github.com/Azure/PSRule.Rules.Azure/pull/1800)
+
+What's changed since pre-release v1.21.0-B0050:
+
+- No additional changes.
+
 ## v1.21.0-B0050 (pre-release)
 
 What's changed since pre-release v1.21.0-B0027:


### PR DESCRIPTION
## PR Summary

What's changed since v1.20.2:

- New features:
  - Mapping of Azure Security Benchmark v3 to security rules by @jagoodwin.
    [#1610](https://github.com/Azure/PSRule.Rules.Azure/issues/1610)
- New rules:
  - Deployment:
    - Check sensitive resource values use secure parameters by @VeraBE @BernieWhite.
      [#1773](https://github.com/Azure/PSRule.Rules.Azure/issues/1773)
  - Service Bus:
    - Check service bus namespaces uses TLS 1.2 version by @bengeset96.
      [#1777](https://github.com/Azure/PSRule.Rules.Azure/issues/1777)
  - Virtual Machine:
    - Check virtual machines uses Azure Monitor Agent instead of old legacy Log Analytics Agent by @bengeset96.
      [#1792](https://github.com/Azure/PSRule.Rules.Azure/issues/1792)
  - Virtual Machine Scale Sets:
    - Check virtual machine scale sets uses Azure Monitor Agent instead of old legacy Log Analytics Agent by @bengeset96.
      [#1792](https://github.com/Azure/PSRule.Rules.Azure/issues/1792)
  - Virtual Network:
    - Check VNETs with a GatewaySubnet also has a AzureBastionSubnet by @bengeset96.
      [#1761](https://github.com/Azure/PSRule.Rules.Azure/issues/1761)
- General improvements:
  - Added built-in list of ignored policy definitions by @BernieWhite.
    [#1730](https://github.com/Azure/PSRule.Rules.Azure/issues/1730)
    - To ignore additional policy definitions, use the `AZURE_POLICY_IGNORE_LIST` configuration option.
- Engineering:
  - Bump PSRule to v2.5.3.
    [#1800](https://github.com/Azure/PSRule.Rules.Azure/pull/1800)
  - Bump Az.Resources to v6.3.1.
    [#1800](https://github.com/Azure/PSRule.Rules.Azure/pull/1800)

What's changed since pre-release v1.21.0-B0050:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
