### PR TITLE
Added Azure.ASE.MigrateV3

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+- New rules:
+  - App Service Environment:
+    - Check app service environments uses version 3 (ASEv3) instead of classic version 1 (ASEv1) and version 2 (ASEv2) by @bengeset96.
+    [#1805](https://github.com/Azure/PSRule.Rules.Azure/issues/1805)
+
 ## v1.21.0-B0050 (pre-release)
 
 What's changed since pre-release v1.21.0-B0027:

--- a/docs/en/rules/Azure.ASE.MigrateV3.md
+++ b/docs/en/rules/Azure.ASE.MigrateV3.md
@@ -169,6 +169,6 @@ resource hostingEnvironment 'Microsoft.Web/hostingEnvironments@2022-03-01' = {
 ## LINKS
 
 - [Infrastructure provisioning](https://learn.microsoft.com/azure/architecture/framework/devops/automation-infrastructure)
-- [App Service Environment version 1 and version 2 will be retired on 31 August 2024](https://azure.microsoft.com/updates/app-service-environment-v1-and-v2-retirement-announcement/)
+- [App Service Environment version 1 and version 2 will be retired on 31 August 2024](https://azure.microsoft.com/updates/app-service-environment-v1-and-v2-retirement-announcement)
 - [Migrate to App Service Environment v3](https://learn.microsoft.com/azure/app-service/environment/migration-alternatives)
 - [Azure template reference](https://learn.microsoft.com/azure/templates/microsoft.web/hostingenvironments)

--- a/docs/en/rules/Azure.ASE.MigrateV3.md
+++ b/docs/en/rules/Azure.ASE.MigrateV3.md
@@ -1,0 +1,174 @@
+---
+severity: Important
+pillar: Operational Excellence
+category: Infrastructure provisioning
+resource: App Service Environment
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ASE.MigrateV3/
+---
+
+# Migrate to App Service Environment v3
+
+## SYNOPSIS
+
+Use ASEv3 as replacement for the classic app service environment versions ASEv1 and ASEv2.
+
+## DESCRIPTION
+
+The classic App Service Environment version 1 (ASEv1) and version 2 (ASEv2) will be retired on August 31, 2024. To avoid service disruption, migrate to App Service Environment version 3 (ASEv3). App Service Environment v3 has advantages and feature differences that provide enhanced support for your workloads and can reduce overall costs.
+
+App Service Environment v3 differs from earlier versions in the following ways:
+
+- There are no networking dependencies on the customer's virtual network. You can secure all inbound and outbound traffic and route outbound traffic as you want.
+- You can deploy an App Service Environment v3 that's enabled for zone redundancy. You set zone redundancy only during creation and only in regions where all App Service Environment v3 dependencies are zone redundant. In this case, each App Service Plan on the App Service Environment will need to have a minimum of three instances so that they can be spread across zones. For more information, see Migrate App Service Environment to availability zone support.
+- You can deploy an App Service Environment v3 on a dedicated host group. Host group deployments aren't zone redundant.
+- Scaling is much faster than with an App Service Environment v2. Although scaling still isn't immediate, as in the multi-tenant service, it's a lot faster.
+- Front-end scaling adjustments are no longer required. App Service Environment v3 front ends automatically scale to meet your needs and are deployed on better hosts.
+- Scaling no longer blocks other scale operations within the App Service Environment v3. Only one scale operation can be in effect for a combination of OS and size. For example, while your Windows small App Service plan is scaling, you could kick off a scale operation to run at the same time on a Windows medium or anything else other than Windows small.
+- You can reach apps in an internal-VIP App Service Environment v3 across global peering. Such access wasn't possible in earlier versions.
+
+A few features that were available in earlier versions of App Service Environment aren't available in App Service Environment v3. For example, you can no longer do the following:
+
+- Monitor your traffic with Network Watcher or network security group (NSG) flow logs.
+- Perform a backup and restore operation on a storage account behind a firewall.
+
+## RECOMMENDATION
+
+Classic App Service Environments should migrate to App Service Environment v3.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy app service environments pass this rule:
+
+- Set `kind` to `'ASEV3'`.
+
+For example:
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.11.1.770",
+      "templateHash": "13381170219553357893"
+    }
+  },
+  "parameters": {
+    "aseName": {
+      "type": "string",
+      "defaultValue": "001-ase",
+      "metadata": {
+        "description": "Name of the App Service Environment"
+      }
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "ase-001-vnet",
+      "metadata": {
+        "description": "The name of the vnet"
+      }
+    },
+    "vnetResourceGroupName": {
+      "type": "string",
+      "defaultValue": "ase-001-rg",
+      "metadata": {
+        "description": "The resource group name that contains the vnet"
+      }
+    },
+    "subnetName": {
+      "type": "string",
+      "defaultValue": "ase-001-sn",
+      "metadata": {
+        "description": "Subnet name that will contain the App Service Environment"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for the resources"
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/hostingEnvironments",
+      "apiVersion": "2022-03-01",
+      "name": "[parameters('aseName')]",
+      "location": "[parameters('location')]",
+      "kind": "ASEV3",
+      "tags": {
+        "displayName": "App Service Environment",
+        "usage": "Hosting awesome applications",
+        "owner": "Platform"
+      },
+      "properties": {
+        "virtualNetwork": {
+          "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('vnetResourceGroupName')), 'Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName'))]"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Configure with Bicep
+
+To deploy app service environments pass this rule:
+
+- Set `kind` to `'ASEV3'`.
+
+For example:
+
+```bicep
+@description('Name of the App Service Environment')
+param aseName string = '001-ase'
+
+@description('The name of the vnet')
+param virtualNetworkName string = 'ase-001-vnet'
+
+@description('The resource group name that contains the vnet')
+param vnetResourceGroupName string = 'ase-001-rg'
+
+@description('Subnet name that will contain the App Service Environment')
+param subnetName string = 'ase-001-sn'
+
+@description('Location for the resources')
+param location string = resourceGroup().location
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2022-05-01' existing = {
+  scope: resourceGroup(vnetResourceGroupName)
+  name: virtualNetworkName
+}
+
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2022-05-01' existing = {
+  parent: virtualNetwork
+  name: subnetName
+}
+
+resource hostingEnvironment 'Microsoft.Web/hostingEnvironments@2022-03-01' = {
+  name: aseName
+  location: location
+  kind: 'ASEV3'
+  tags: {
+    displayName: 'App Service Environment'
+    usage: 'Hosting awesome applications'
+    owner: 'Platform'
+  }
+  properties: {
+    virtualNetwork: {
+      id: subnet.id
+    }
+  }
+}
+```
+
+## LINKS
+
+- [Infrastructure provisioning](https://learn.microsoft.com/azure/architecture/framework/devops/automation-infrastructure)
+- [App Service Environment version 1 and version 2 will be retired on 31 August 2024](https://azure.microsoft.com/updates/app-service-environment-v1-and-v2-retirement-announcement/)
+- [Migrate to App Service Environment v3](https://learn.microsoft.com/azure/app-service/environment/migration-alternatives)
+- [Azure template reference](https://learn.microsoft.com/azure/templates/microsoft.web/hostingenvironments)

--- a/docs/examples-ase.bicep
+++ b/docs/examples-ase.bicep
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Bicep documentation examples
+
+@description('Name of the App Service Environment')
+param aseName string = '001-ase'
+
+@description('The name of the vnet')
+param virtualNetworkName string = 'ase-001-vnet'
+
+@description('The resource group name that contains the vnet')
+param vnetResourceGroupName string = 'ase-001-rg'
+
+@description('Subnet name that will contain the App Service Environment')
+param subnetName string = 'ase-001-sn'
+
+@description('Location for the resources')
+param location string = resourceGroup().location
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2022-05-01' existing = {
+  scope: resourceGroup(vnetResourceGroupName)
+  name: virtualNetworkName
+}
+
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2022-05-01' existing = {
+  parent: virtualNetwork
+  name: subnetName
+}
+
+resource hostingEnvironment 'Microsoft.Web/hostingEnvironments@2022-03-01' = {
+  name: aseName
+  location: location
+  kind: 'ASEV3'
+  tags: {
+    displayName: 'App Service Environment'
+    usage: 'Hosting awesome applications'
+    owner: 'Platform'
+  }
+  properties: {
+    virtualNetwork: {
+      id: subnet.id
+    }
+  }
+}

--- a/docs/examples-ase.json
+++ b/docs/examples-ase.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.11.1.770",
+      "templateHash": "13381170219553357893"
+    }
+  },
+  "parameters": {
+    "aseName": {
+      "type": "string",
+      "defaultValue": "001-ase",
+      "metadata": {
+        "description": "Name of the App Service Environment"
+      }
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "ase-001-vnet",
+      "metadata": {
+        "description": "The name of the vnet"
+      }
+    },
+    "vnetResourceGroupName": {
+      "type": "string",
+      "defaultValue": "ase-001-rg",
+      "metadata": {
+        "description": "The resource group name that contains the vnet"
+      }
+    },
+    "subnetName": {
+      "type": "string",
+      "defaultValue": "ase-001-sn",
+      "metadata": {
+        "description": "Subnet name that will contain the App Service Environment"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for the resources"
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/hostingEnvironments",
+      "apiVersion": "2022-03-01",
+      "name": "[parameters('aseName')]",
+      "location": "[parameters('location')]",
+      "kind": "ASEV3",
+      "tags": {
+        "displayName": "App Service Environment",
+        "usage": "Hosting awesome applications",
+        "owner": "Platform"
+      },
+      "properties": {
+        "virtualNetwork": {
+          "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('vnetResourceGroupName')), 'Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName'))]"
+        }
+      }
+    }
+  ]
+}

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -76,4 +76,5 @@
     BastionSubnetNotFound = "The virtual network '{0}' with a GatewaySubnet also should have an AzureBastionSubnet configured."
     ServiceBusMinTLS = "The service bus namespace '{0}' should minimum use TLS 1.2 version."
     LogAnalyticsAgentDeprecated = "The legacy Log Analytics Agent is deprecated and will be retired on August 31, 2024. Migrate to the Azure Monitor Agent."
+    ClassicASEDeprecated = "The app service environment '{0}' with version '{1}' is deprecated and will be retired on August 31, 2024. Migrate to ASEv3."
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.ASE.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.ASE.Rule.ps1
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Validation rules for Azure App Service Environment
+#
+
+# Synopsis: Use ASEv3 as replacement for the classic app service environment versions ASEv1 and ASEv2.
+Rule 'Azure.ASE.MigrateV3' -Type 'Microsoft.Web/hostingEnvironments' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+    $Assert.HasFieldValue($TargetObject, 'kind', 'ASEV3').Reason($LocalizedData.ClassicASEDeprecated, $PSRule.TargetName, $TargetObject.kind)
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.ASE.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.ASE.Rule.ps1
@@ -6,6 +6,6 @@
 #
 
 # Synopsis: Use ASEv3 as replacement for the classic app service environment versions ASEv1 and ASEv2.
-Rule 'Azure.ASE.MigrateV3' -Type 'Microsoft.Web/hostingEnvironments' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+Rule 'Azure.ASE.MigrateV3' -Ref 'AZR-000319' -Type 'Microsoft.Web/hostingEnvironments' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
     $Assert.HasFieldValue($TargetObject, 'kind', 'ASEV3').Reason($LocalizedData.ClassicASEDeprecated, $PSRule.TargetName, $TargetObject.kind)
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ASE.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ASE.Tests.ps1
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Unit tests for Azure App Service Environment rules
+#
+
+[CmdletBinding()]
+param ()
+
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
+
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
+}
+
+Describe 'Azure.ASE' -Tag 'ASE' {
+    Context 'Conditions' {
+        BeforeAll {
+            $invokeParams = @{
+                Baseline      = 'Azure.All'
+                Module        = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction   = 'Stop'
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.ASE.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
+        }
+
+        It 'Azure.ASE.MigrateV3' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.ASE.MigrateV3' };
+            
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'environment-A', 'environment-B', 'environment-D';
+
+            $ruleResult[0].Reason | Should -BeExactly "The app service environment 'environment-A' with version 'ASEV1' is deprecated and will be retired on August 31, 2024. Migrate to ASEv3.";
+            $ruleResult[1].Reason | Should -BeExactly "The app service environment 'environment-A' with version 'ASEV2' is deprecated and will be retired on August 31, 2024. Migrate to ASEv3.";
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'environment-C';
+        }
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ASE.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ASE.Tests.ps1
@@ -46,7 +46,7 @@ Describe 'Azure.ASE' -Tag 'ASE' {
             $ruleResult.TargetName | Should -BeIn 'environment-A', 'environment-B', 'environment-D';
 
             $ruleResult[0].Reason | Should -BeExactly "The app service environment 'environment-A' with version 'ASEV1' is deprecated and will be retired on August 31, 2024. Migrate to ASEv3.";
-            $ruleResult[1].Reason | Should -BeExactly "The app service environment 'environment-A' with version 'ASEV2' is deprecated and will be retired on August 31, 2024. Migrate to ASEv3.";
+            $ruleResult[1].Reason | Should -BeExactly "The app service environment 'environment-B' with version 'ASEV2' is deprecated and will be retired on August 31, 2024. Migrate to ASEv3.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Resources.ASE.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.ASE.json
@@ -1,0 +1,171 @@
+[
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/hostingEnvironments/environment-A",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/hostingEnvironments/environment-A",
+    "Identity": null,
+    "Location": "westeurope",
+    "ManagedBy": null,
+    "ResourceName": "environment-A",
+    "Name": "environment-A",
+    "Kind": "ASEV1",
+    "Properties": {
+      "upgradePreference": "Early",
+      "virtualNetwork": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A",
+        "subnet": "subnet-A"
+      },
+      "zoneRedundant": true
+    },
+    "ResourceGroupName": "rg-test",
+    "Type": "microsoft.web/hostingenvironments",
+    "ResourceType": "microsoft.web/hostingenvironments",
+    "Sku": null,
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/hostingEnvironments/environment-B",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/hostingEnvironments/environment-B",
+    "Identity": null,
+    "Location": "westeurope",
+    "ManagedBy": null,
+    "ResourceName": "environment-B",
+    "Name": "environment-B",
+    "Kind": "ASEV2",
+    "Properties": {
+      "upgradePreference": "Late",
+      "virtualNetwork": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A",
+        "subnet": "subnet-A"
+      },
+      "zoneRedundant": false
+    },
+    "ResourceGroupName": "rg-test",
+    "Type": "microsoft.web/hostingenvironments",
+    "ResourceType": "microsoft.web/hostingenvironments",
+    "Sku": null,
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Web/hostingEnvironments/environment-B/serverfarms/plan-A",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Web/hostingEnvironments/environment-B/serverfarms/plan-A",
+        "Identity": null,
+        "Kind": null,
+        "Location": "region",
+        "ManagedBy": null,
+        "ResourceName": "plan-A",
+        "Name": "plan-A",
+        "ExtensionResourceName": null,
+        "ParentResource": null,
+        "Plan": null,
+        "sku": {
+          "capacity": 1,
+          "family": "I",
+          "name": "I2",
+          "size": "I2",
+          "tier": "Isolated"
+        },
+        "properties": {
+          "hostingEnvironmentProfile": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/hostingEnvironments/environment-B"
+          }
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Web/serverfarms",
+        "ResourceType": "Microsoft.Web/serverfarms",
+        "ExtensionResourceType": null,
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "CreatedTime": null,
+        "ChangedTime": null,
+        "ETag": null
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/hostingEnvironments/environment-C",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/hostingEnvironments/environment-C",
+    "Identity": null,
+    "Location": "westeurope",
+    "ManagedBy": null,
+    "ResourceName": "environment-C",
+    "Name": "environment-C",
+    "Kind": "ASEV3",
+    "Properties": {
+      "upgradePreference": "Early",
+      "virtualNetwork": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A",
+        "subnet": "subnet-A"
+      },
+      "zoneRedundant": false
+    },
+    "ResourceGroupName": "rg-test",
+    "Type": "microsoft.web/hostingenvironments",
+    "ResourceType": "microsoft.web/hostingenvironments",
+    "Sku": null,
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Web/hostingEnvironments/environment-C/serverfarms/plan-A",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Web/hostingEnvironments/environment-C/serverfarms/plan-A",
+        "Identity": null,
+        "Kind": null,
+        "Location": "region",
+        "ManagedBy": null,
+        "ResourceName": "plan-A",
+        "Name": "plan-A",
+        "ExtensionResourceName": null,
+        "ParentResource": null,
+        "Plan": null,
+        "sku": {
+          "capacity": 1,
+          "family": "I",
+          "name": "I1v2",
+          "size": "I1v2",
+          "tier": "IsolatedV2"
+        },
+        "properties": {
+          "hostingEnvironmentProfile": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/hostingEnvironments/environment-C"
+          }
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Web/serverfarms",
+        "ResourceType": "Microsoft.Web/serverfarms",
+        "ExtensionResourceType": null,
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "CreatedTime": null,
+        "ChangedTime": null,
+        "ETag": null
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/hostingEnvironments/environment-D",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Web/hostingEnvironments/environment-D",
+    "Identity": null,
+    "Location": "westeurope",
+    "ManagedBy": null,
+    "ResourceName": "environment-D",
+    "Name": "environment-D",
+    "Properties": {
+      "upgradePreference": "Early",
+      "virtualNetwork": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A",
+        "subnet": "subnet-A"
+      },
+      "zoneRedundant": true
+    },
+    "ResourceGroupName": "rg-test",
+    "Type": "microsoft.web/hostingenvironments",
+    "ResourceType": "microsoft.web/hostingenvironments",
+    "Sku": null,
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  }
+]


### PR DESCRIPTION
## PR Summary

Fixes #1805 

Added Azure.ASE.MigrateV3 rule to check for app service environments running with classic versions that will be fully retired on August 31, 2024.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
