### PR TITLE
Fixes ACR content trust with CMK #1810

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,8 @@ What's changed since v1.21.0:
 - Bug fixes:
   - Fixed multiple nested parameter loops returns stack empty exception by @BernieWhite.
     [#1811](https://github.com/Azure/PSRule.Rules.Azure/issues/1811)
+  - Fixed `Azure.ACR.ContentTrust` when customer managed keys are enabled by @BernieWhite.
+    [#1810](https://github.com/Azure/PSRule.Rules.Azure/issues/1810)
 
 ## v1.21.0
 

--- a/docs/en/rules/Azure.ACR.ContentTrust.md
+++ b/docs/en/rules/Azure.ACR.ContentTrust.md
@@ -19,6 +19,9 @@ Signed images provides additional assurance that they have been built on a trust
 
 To enable content trust, the container registry must be using a Premium SKU.
 
+Content trust is currently not supported in a registry that's encrypted with a customer-managed key.
+When using customer-managed keys, content trust can not be enabled.
+
 ## RECOMMENDATION
 
 Consider enabling content trust on registries, clients, and sign container images.
@@ -105,7 +108,8 @@ resource acr 'Microsoft.ContainerRegistry/registries@2021-06-01-preview' = {
 
 ## LINKS
 
-- [Content trust in Azure Container Registry](https://docs.microsoft.com/azure/container-registry/container-registry-content-trust)
 - [Follow best practices for container security](https://learn.microsoft.com/azure/architecture/framework/security/applications-services#follow-best-practices-for-container-security)
+- [Content trust in Azure Container Registry](https://learn.microsoft.com/azure/container-registry/container-registry-content-trust)
 - [Content trust in Docker](https://docs.docker.com/engine/security/trust/content_trust/)
-- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.containerregistry/registries)
+- [Overview of customer-managed keys](https://learn.microsoft.com/azure/container-registry/tutorial-customer-managed-keys#before-you-enable-a-customer-managed-key)
+- [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.containerregistry/registries)

--- a/src/PSRule.Rules.Azure/rules/Azure.ACR.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.ACR.Rule.yaml
@@ -96,11 +96,15 @@ metadata:
   tags:
     release: 'GA'
     ruleSet: '2020_12'
+    Azure.WAF/pillar: 'Security'
 spec:
   with:
   - Azure.ACR.IsPremiumSKU
   type:
   - Microsoft.ContainerRegistry/registries
+  where:
+    field: properties.encryption.keyVaultProperties.identity
+    exists: false
   condition:
     field: Properties.policies.trustPolicy.status
     equals: enabled

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
@@ -50,8 +50,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 7;
-            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C', 'registry-E', 'registry-F', 'registry-G', 'registry-H', 'registry-I';
+            $ruleResult.Length | Should -Be 8;
+            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C', 'registry-E', 'registry-F', 'registry-G', 'registry-H', 'registry-I', 'registry-J';
         }
 
         It 'Azure.ACR.MinSku' {
@@ -67,8 +67,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 8;
-            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C', 'registry-D', 'registry-E', 'registry-F', 'registry-G', 'registry-H', 'registry-I';
+            $ruleResult.Length | Should -Be 9;
+            $ruleResult.TargetName | Should -BeIn 'registry-B', 'registry-C', 'registry-D', 'registry-E', 'registry-F', 'registry-G', 'registry-H', 'registry-I', 'registry-J';
         }
 
         It 'Azure.ACR.Quarantine' {
@@ -77,8 +77,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 7;
-            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-B', 'registry-D', 'registry-F', 'registry-G', 'registry-H', 'registry-I';
+            $ruleResult.Length | Should -Be 8;
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-B', 'registry-D', 'registry-F', 'registry-G', 'registry-H', 'registry-I', 'registry-J';
             $ruleResult.Detail.Reason.Path | Should -BeIn 'Properties.policies.quarantinePolicy.status';
 
             # Pass
@@ -107,8 +107,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 7;
-            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-B', 'registry-C', 'registry-F', 'registry-G', 'registry-H', 'registry-I';
+            $ruleResult.Length | Should -Be 8;
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-B', 'registry-C', 'registry-F', 'registry-G', 'registry-H', 'registry-I', 'registry-J';
         }
 
         It 'Azure.ACR.Retention' {
@@ -117,8 +117,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'registry-D';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'registry-D', 'registry-J';
             $ruleResult.Detail.Reason.Path | Should -BeIn 'Properties.policies.retentionPolicy.status';
 
             # Pass
@@ -140,8 +140,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 8;
-            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-B', 'registry-D', 'registry-E', 'registry-F', 'registry-G', 'registry-H', 'registry-I';
+            $ruleResult.Length | Should -Be 9;
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-B', 'registry-D', 'registry-E', 'registry-F', 'registry-G', 'registry-H', 'registry-I', 'registry-J';
             # TODO: $ruleResult.Detail.Reason.Path | Should -BeIn '';
 
             # Pass
@@ -157,8 +157,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-D', 'registry-F', 'registry-G', 'registry-H', 'registry-I';
+            $ruleResult.Length | Should -Be 7;
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-D', 'registry-F', 'registry-G', 'registry-H', 'registry-I', 'registry-J';
             # TODO: $ruleResult.Detail.Reason.Path | Should -BeIn 'resources';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
@@ -193,8 +193,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-D', 'registry-F', 'registry-G', 'registry-H', 'registry-I';
+            $ruleResult.Length | Should -Be 7;
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-D', 'registry-F', 'registry-G', 'registry-H', 'registry-I', 'registry-J';
         }
 
         It 'Azure.ACR.GeoReplica' {
@@ -203,8 +203,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-D', 'registry-F', 'registry-G', 'registry-H', 'registry-I';
+            $ruleResult.Length | Should -Be 7;
+            $ruleResult.TargetName | Should -BeIn 'registry-A', 'registry-D', 'registry-F', 'registry-G', 'registry-H', 'registry-I', 'registry-J';
             # TODO: $ruleResult.Detail.Reason.Path | Should -BeIn '';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
@@ -235,8 +235,8 @@ Describe 'Azure.ACR' -Tag 'ACR' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'registry-G', 'registry-I';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'registry-G', 'registry-I', 'registry-J';
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Resources.ACR.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.ACR.json
@@ -555,7 +555,7 @@
     "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-G",
     "Location": "region",
     "ResourceName": "registry-G",
-    "Name": "registry-H",
+    "Name": "registry-G",
     "Properties": {
       "loginServer": "registry-G.azurecr.io",
       "adminUserEnabled": false,
@@ -637,7 +637,7 @@
     "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-I",
     "Location": "region",
     "ResourceName": "registry-I",
-    "Name": "registry-H",
+    "Name": "registry-I",
     "Properties": {
       "loginServer": "registry-I.azurecr.io",
       "adminUserEnabled": false,
@@ -661,6 +661,50 @@
     "Sku": {
       "Name": "Standard",
       "Tier": "Standard",
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": null
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-J",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerRegistry/registries/registry-J",
+    "Location": "region",
+    "ResourceName": "registry-J",
+    "Name": "registry-J",
+    "Properties": {
+      "loginServer": "registry-I.azurecr.io",
+      "adminUserEnabled": false,
+      "encryption": {
+        "keyVaultProperties": {
+          "identity": "00000000-0000-0000-0000-000000000000",
+          "keyIdentifier": ""
+        },
+        "status": "enabled"
+      },
+      "policies": {
+        "quarantinePolicy": {
+          "status": "disabled"
+        },
+        "trustPolicy": {
+          "type": "Notary",
+          "status": "disabled"
+        },
+        "softDeletePolicy": {
+          "retentionDays": 90,
+          "status": "enabled"
+        }
+      }
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.ContainerRegistry/registries",
+    "ResourceType": "Microsoft.ContainerRegistry/registries",
+    "Sku": {
+      "Name": "Premium",
+      "Tier": "Premium",
       "Size": null,
       "Family": null,
       "Model": null,


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.ACR.ContentTrust` when customer managed keys are enabled.

Fixes #1810

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
