### PR TITLE
Added Azure.FrontDoor.UseCaching

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+- New rules:
+  - Front Door:
+    - Check front door uses caching by @bengeset96.
+    [#548](https://github.com/Azure/PSRule.Rules.Azure/issues/548)
+
 What's changed since v1.21.0:
 
 - New rules:

--- a/docs/en/rules/Azure.FrontDoor.UseCaching.md
+++ b/docs/en/rules/Azure.FrontDoor.UseCaching.md
@@ -1,0 +1,264 @@
+---
+severity: Important
+pillar: Performance Efficiency 
+category: Performance patterns
+resource: Front Door
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.FrontDoor.UseCaching/
+---
+
+# Use caching
+
+## SYNOPSIS
+
+Use caching to reduce retrieving contents from origins.
+
+## DESCRIPTION
+
+Azure Front Door delivers large files without a cap on file size. Front Door uses a technique called object chunking. When a large file is requested, Front Door retrieves smaller pieces of the file from the backend. After receiving a full or byte-range file request, the Front Door environment requests the file from the backend in chunks of 8 MB.
+
+After the chunk arrives at the Front Door environment, it's cached and immediately served to the user. Front Door then pre-fetches the next chunk in parallel. This pre-fetch ensures that the content stays one chunk ahead of the user, which reduces latency. This process continues until the entire file gets downloaded (if requested) or the client closes the connection.
+
+For more information on the byte-range request, read RFC 7233. Front Door caches any chunks as they're received so the entire file doesn't need to be cached on the Front Door cache. Ensuing requests for the file or byte ranges are served from the cache. If the chunks aren't all cached, pre-fetching is used to request chunks from the backend. This optimization relies on the backend's ability to support byte-range requests. If the backend doesn't support byte-range requests, this optimization isn't effective.
+
+## RECOMMENDATION
+
+Use caching to reduce retrieving contents from origins and improve overall performance.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy front door instances pass this rule:
+
+- Configure `properties.routingRules.properties.routeConfiguration.cacheConfiguration`.
+
+**Important** The rule checks also for rule sets (child resources) that are overwriting the cache configuration from routing rules. Check the link `Routing architecture overview` for more information around this.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.Network/frontDoors",
+  "apiVersion": "2021-06-01",
+  "name": "[parameters('frontDoorName')]",
+  "location": "global",
+  "properties": {
+    "enabledState": "Enabled",
+    "frontendEndpoints": [
+      {
+        "name": "[variables('frontEndEndpointName')]",
+        "properties": {
+          "hostName": "[format('{0}.azurefd.net', parameters('frontDoorName'))]",
+          "sessionAffinityEnabledState": "Disabled"
+        }
+      }
+    ],
+    "loadBalancingSettings": [
+      {
+        "name": "[variables('loadBalancingSettingsName')]",
+        "properties": {
+          "sampleSize": 4,
+          "successfulSamplesRequired": 2
+        }
+      }
+    ],
+    "healthProbeSettings": [
+      {
+        "name": "[variables('healthProbeSettingsName')]",
+        "properties": {
+          "path": "/",
+          "protocol": "Http",
+          "intervalInSeconds": 120
+        }
+      }
+    ],
+    "backendPools": [
+      {
+        "name": "[variables('backendPoolName')]",
+        "properties": {
+          "backends": [
+            {
+              "address": "[parameters('backendAddress')]",
+              "backendHostHeader": "[parameters('backendAddress')]",
+              "httpPort": 80,
+              "httpsPort": 443,
+              "weight": 50,
+              "priority": 1,
+              "enabledState": "Enabled"
+            }
+          ],
+          "loadBalancingSettings": {
+            "id": "[resourceId('Microsoft.Network/frontDoors/loadBalancingSettings', parameters('frontDoorName'), variables('loadBalancingSettingsName'))]"
+          },
+          "healthProbeSettings": {
+            "id": "[resourceId('Microsoft.Network/frontDoors/healthProbeSettings', parameters('frontDoorName'), variables('healthProbeSettingsName'))]"
+          }
+        }
+      }
+    ],
+    "routingRules": [
+      {
+        "name": "[variables('routingRuleName')]",
+        "properties": {
+          "frontendEndpoints": [
+            {
+              "id": "[resourceId('Microsoft.Network/frontDoors/frontEndEndpoints', parameters('frontDoorName'), variables('frontEndEndpointName'))]"
+            }
+          ],
+          "acceptedProtocols": [
+            "Http",
+            "Https"
+          ],
+          "patternsToMatch": [
+            "/*"
+          ],
+          "routeConfiguration": {
+            "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
+            "cacheConfiguration": {
+              "cacheDuration": "P12DT1H",
+              "dynamicCompression": "Disabled",
+              "queryParameters": "customerId",
+              "queryParameterStripDirective": "StripAll"
+            },
+            "forwardingProtocol": "MatchRequest",
+            "backendPool": {
+              "id": "[resourceId('Microsoft.Network/frontDoors/backEndPools', parameters('frontDoorName'), variables('backendPoolName'))]"
+            }
+          },
+          "enabledState": "Enabled"
+        }
+      }
+    ]
+  }
+}
+```
+
+### Configure with Bicep
+
+To deploy front door instances pass this rule:
+
+- Configure `properties.routingRules.properties.routeConfiguration.cacheConfiguration`.
+
+**Important** The rule checks also for rule sets (child resources) that are overwriting the cache configuration from routing rules. Check the link `Routing architecture overview` for more information around this.
+
+For example:
+
+```bicep
+@description('The name of the frontdoor resource.')
+param frontDoorName string
+
+@description('The hostname of the backend. Must be an IP address or FQDN.')
+param backendAddress string
+
+var frontEndEndpointName = 'frontEndEndpoint'
+var loadBalancingSettingsName = 'loadBalancingSettings'
+var healthProbeSettingsName = 'healthProbeSettings'
+var routingRuleName = 'routingRule'
+var backendPoolName = 'backendPool'
+
+resource frontDoor 'Microsoft.Network/frontDoors@2021-06-01' = {
+  name: frontDoorName
+  location: 'global'
+  properties: {
+    enabledState: 'Enabled'
+
+    frontendEndpoints: [
+      {
+        name: frontEndEndpointName
+        properties: {
+          hostName: '${frontDoorName}.azurefd.net'
+          sessionAffinityEnabledState: 'Disabled'
+        }
+      }
+    ]
+
+    loadBalancingSettings: [
+      {
+        name: loadBalancingSettingsName
+        properties: {
+          sampleSize: 4
+          successfulSamplesRequired: 2
+        }
+      }
+    ]
+
+    healthProbeSettings: [
+      {
+        name: healthProbeSettingsName
+        properties: {
+          path: '/'
+          protocol: 'Http'
+          intervalInSeconds: 120
+        }
+      }
+    ]
+
+    backendPools: [
+      {
+        name: backendPoolName
+        properties: {
+          backends: [
+            {
+              address: backendAddress
+              backendHostHeader: backendAddress
+              httpPort: 80
+              httpsPort: 443
+              weight: 50
+              priority: 1
+              enabledState: 'Enabled'
+            }
+          ]
+          loadBalancingSettings: {
+            id: resourceId('Microsoft.Network/frontDoors/loadBalancingSettings', frontDoorName, loadBalancingSettingsName)
+          }
+          healthProbeSettings: {
+            id: resourceId('Microsoft.Network/frontDoors/healthProbeSettings', frontDoorName, healthProbeSettingsName)
+          }
+        }
+      }
+    ]
+
+    routingRules: [
+      {
+        name: routingRuleName
+        properties: {
+          frontendEndpoints: [
+            {
+              id: resourceId('Microsoft.Network/frontDoors/frontEndEndpoints', frontDoorName, frontEndEndpointName)
+            }
+          ]
+          acceptedProtocols: [
+            'Http'
+            'Https'
+          ]
+          patternsToMatch: [
+            '/*'
+          ]
+          routeConfiguration: {
+            '@odata.type': '#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration'
+            cacheConfiguration: {
+              cacheDuration: 'P12DT1H'
+              dynamicCompression: 'Disabled'
+              queryParameters: 'customerId'
+              queryParameterStripDirective: 'StripAll'
+            }
+            forwardingProtocol: 'MatchRequest'
+            backendPool: {
+              id: resourceId('Microsoft.Network/frontDoors/backEndPools', frontDoorName, backendPoolName)
+            }
+          }
+          enabledState: 'Enabled'
+        }
+      }
+    ]
+  }
+}
+```
+
+## LINKS
+
+- [Performance patterns](https://learn.microsoft.com/azure/architecture/framework/scalability/performance-efficiency-patterns)
+- [Caching with Azure Front Door](https://learn.microsoft.com/azure/frontdoor/front-door-caching)
+- [Routing architecture overview](https://learn.microsoft.com/azure/frontdoor/front-door-routing-architecture)
+- [Azure template reference](https://learn.microsoft.com/azure/templates/microsoft.network/frontdoors)
+- [Azure template reference](https://learn.microsoft.com/azure/templates/microsoft.network/frontdoors/rulesengines)

--- a/docs/en/rules/Azure.FrontDoor.UseCaching.md
+++ b/docs/en/rules/Azure.FrontDoor.UseCaching.md
@@ -255,6 +255,10 @@ resource frontDoor 'Microsoft.Network/frontDoors@2021-06-01' = {
 }
 ```
 
+## NOTES
+
+This rule only applies to Front Door Classic `(Microsoft.Network/frontDoors)`.
+
 ## LINKS
 
 - [Performance patterns](https://learn.microsoft.com/azure/architecture/framework/scalability/performance-efficiency-patterns)

--- a/docs/examples-frontdoor.bicep
+++ b/docs/examples-frontdoor.bicep
@@ -37,3 +37,113 @@ resource waf 'Microsoft.Network/FrontDoorWebApplicationFirewallPolicies@2022-05-
     }
   }
 }
+
+@description('The name of the frontdoor resource.')
+param frontDoorName string
+
+@description('The hostname of the backend. Must be an IP address or FQDN.')
+param backendAddress string
+
+var frontEndEndpointName = 'frontEndEndpoint'
+var loadBalancingSettingsName = 'loadBalancingSettings'
+var healthProbeSettingsName = 'healthProbeSettings'
+var routingRuleName = 'routingRule'
+var backendPoolName = 'backendPool'
+
+resource frontDoor 'Microsoft.Network/frontDoors@2021-06-01' = {
+  name: frontDoorName
+  location: 'global'
+  properties: {
+    enabledState: 'Enabled'
+
+    frontendEndpoints: [
+      {
+        name: frontEndEndpointName
+        properties: {
+          hostName: '${frontDoorName}.azurefd.net'
+          sessionAffinityEnabledState: 'Disabled'
+        }
+      }
+    ]
+
+    loadBalancingSettings: [
+      {
+        name: loadBalancingSettingsName
+        properties: {
+          sampleSize: 4
+          successfulSamplesRequired: 2
+        }
+      }
+    ]
+
+    healthProbeSettings: [
+      {
+        name: healthProbeSettingsName
+        properties: {
+          path: '/'
+          protocol: 'Http'
+          intervalInSeconds: 120
+        }
+      }
+    ]
+
+    backendPools: [
+      {
+        name: backendPoolName
+        properties: {
+          backends: [
+            {
+              address: backendAddress
+              backendHostHeader: backendAddress
+              httpPort: 80
+              httpsPort: 443
+              weight: 50
+              priority: 1
+              enabledState: 'Enabled'
+            }
+          ]
+          loadBalancingSettings: {
+            id: resourceId('Microsoft.Network/frontDoors/loadBalancingSettings', frontDoorName, loadBalancingSettingsName)
+          }
+          healthProbeSettings: {
+            id: resourceId('Microsoft.Network/frontDoors/healthProbeSettings', frontDoorName, healthProbeSettingsName)
+          }
+        }
+      }
+    ]
+
+    routingRules: [
+      {
+        name: routingRuleName
+        properties: {
+          frontendEndpoints: [
+            {
+              id: resourceId('Microsoft.Network/frontDoors/frontEndEndpoints', frontDoorName, frontEndEndpointName)
+            }
+          ]
+          acceptedProtocols: [
+            'Http'
+            'Https'
+          ]
+          patternsToMatch: [
+            '/*'
+          ]
+          routeConfiguration: {
+            '@odata.type': '#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration'
+            cacheConfiguration: {
+              cacheDuration: 'P12DT1H'
+              dynamicCompression: 'Disabled'
+              queryParameters: 'customerId'
+              queryParameterStripDirective: 'StripAll'
+            }
+            forwardingProtocol: 'MatchRequest'
+            backendPool: {
+              id: resourceId('Microsoft.Network/frontDoors/backEndPools', frontDoorName, backendPoolName)
+            }
+          }
+          enabledState: 'Enabled'
+        }
+      }
+    ]
+  }
+}

--- a/docs/examples-frontdoor.json
+++ b/docs/examples-frontdoor.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.10.61.36676",
-      "templateHash": "8538999798863753976"
+      "version": "0.11.1.770",
+      "templateHash": "12572116388662855024"
     }
   },
   "parameters": {
@@ -15,7 +15,26 @@
       "metadata": {
         "description": "The name of the resource."
       }
+    },
+    "frontDoorName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the frontdoor resource."
+      }
+    },
+    "backendAddress": {
+      "type": "string",
+      "metadata": {
+        "description": "The hostname of the backend. Must be an IP address or FQDN."
+      }
     }
+  },
+  "variables": {
+    "frontEndEndpointName": "frontEndEndpoint",
+    "loadBalancingSettingsName": "loadBalancingSettings",
+    "healthProbeSettingsName": "healthProbeSettings",
+    "routingRuleName": "routingRule",
+    "backendPoolName": "backendPool"
   },
   "resources": [
     {
@@ -49,6 +68,100 @@
           "enabledState": "Enabled",
           "mode": "Prevention"
         }
+      }
+    },
+    {
+      "type": "Microsoft.Network/frontDoors",
+      "apiVersion": "2021-06-01",
+      "name": "[parameters('frontDoorName')]",
+      "location": "global",
+      "properties": {
+        "enabledState": "Enabled",
+        "frontendEndpoints": [
+          {
+            "name": "[variables('frontEndEndpointName')]",
+            "properties": {
+              "hostName": "[format('{0}.azurefd.net', parameters('frontDoorName'))]",
+              "sessionAffinityEnabledState": "Disabled"
+            }
+          }
+        ],
+        "loadBalancingSettings": [
+          {
+            "name": "[variables('loadBalancingSettingsName')]",
+            "properties": {
+              "sampleSize": 4,
+              "successfulSamplesRequired": 2
+            }
+          }
+        ],
+        "healthProbeSettings": [
+          {
+            "name": "[variables('healthProbeSettingsName')]",
+            "properties": {
+              "path": "/",
+              "protocol": "Http",
+              "intervalInSeconds": 120
+            }
+          }
+        ],
+        "backendPools": [
+          {
+            "name": "[variables('backendPoolName')]",
+            "properties": {
+              "backends": [
+                {
+                  "address": "[parameters('backendAddress')]",
+                  "backendHostHeader": "[parameters('backendAddress')]",
+                  "httpPort": 80,
+                  "httpsPort": 443,
+                  "weight": 50,
+                  "priority": 1,
+                  "enabledState": "Enabled"
+                }
+              ],
+              "loadBalancingSettings": {
+                "id": "[resourceId('Microsoft.Network/frontDoors/loadBalancingSettings', parameters('frontDoorName'), variables('loadBalancingSettingsName'))]"
+              },
+              "healthProbeSettings": {
+                "id": "[resourceId('Microsoft.Network/frontDoors/healthProbeSettings', parameters('frontDoorName'), variables('healthProbeSettingsName'))]"
+              }
+            }
+          }
+        ],
+        "routingRules": [
+          {
+            "name": "[variables('routingRuleName')]",
+            "properties": {
+              "frontendEndpoints": [
+                {
+                  "id": "[resourceId('Microsoft.Network/frontDoors/frontEndEndpoints', parameters('frontDoorName'), variables('frontEndEndpointName'))]"
+                }
+              ],
+              "acceptedProtocols": [
+                "Http",
+                "Https"
+              ],
+              "patternsToMatch": [
+                "/*"
+              ],
+              "routeConfiguration": {
+                "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
+                "cacheConfiguration": {
+                  "cacheDuration": "P12DT1H",
+                  "dynamicCompression": "Disabled",
+                  "queryParameters": "customerId",
+                  "queryParameterStripDirective": "StripAll"
+                },
+                "forwardingProtocol": "MatchRequest",
+                "backendPool": {
+                  "id": "[resourceId('Microsoft.Network/frontDoors/backEndPools', parameters('frontDoorName'), variables('backendPoolName'))]"
+                }
+              },
+              "enabledState": "Enabled"
+            }
+          }
+        ]
       }
     }
   ]

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -77,4 +77,5 @@
     ServiceBusMinTLS = "The service bus namespace '{0}' should minimum use TLS 1.2 version."
     LogAnalyticsAgentDeprecated = "The legacy Log Analytics Agent is deprecated and will be retired on August 31, 2024. Migrate to the Azure Monitor Agent."
     ClassicASEDeprecated = "The app service environment '{0}' with version '{1}' is deprecated and will be retired on August 31, 2024. Migrate to ASEv3."
+    FrontDoorCachingDisabled = "The front door instance should have caching enabled for routing rules and rule sets to reduce retrieving contents from origins."
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.FrontDoor.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.FrontDoor.Tests.ps1
@@ -42,8 +42,8 @@ Describe 'Azure.FrontDoor' -Tag 'Network', 'FrontDoor' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'frontdoor-B', 'frontdoor-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-B', 'frontdoor-C', 'frontdoor-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -64,8 +64,8 @@ Describe 'Azure.FrontDoor' -Tag 'Network', 'FrontDoor' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C', 'frontdoor-D';
         }
 
         It 'Azure.FrontDoor.Logs' {
@@ -83,8 +83,8 @@ Describe 'Azure.FrontDoor' -Tag 'Network', 'FrontDoor' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C', 'frontdoor-D';
         }
 
         It 'Azure.FrontDoor.Probe' {
@@ -99,8 +99,8 @@ Describe 'Azure.FrontDoor' -Tag 'Network', 'FrontDoor' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C', 'frontdoor-D';
         }
 
         It 'Azure.FrontDoor.ProbeMethod' {
@@ -115,8 +115,8 @@ Describe 'Azure.FrontDoor' -Tag 'Network', 'FrontDoor' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C', 'frontdoor-D';
         }
 
         It 'Azure.FrontDoor.ProbePath' {
@@ -134,8 +134,8 @@ Describe 'Azure.FrontDoor' -Tag 'Network', 'FrontDoor' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C', 'frontdoor-D';
         }
 
         It 'Azure.FrontDoor.UseWAF' {
@@ -150,8 +150,8 @@ Describe 'Azure.FrontDoor' -Tag 'Network', 'FrontDoor' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C', 'frontdoor-D';
         }
 
         It 'Azure.FrontDoor.WAF.Mode' {
@@ -203,7 +203,7 @@ Describe 'Azure.FrontDoor' -Tag 'Network', 'FrontDoor' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'frondoor-A';
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A';
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.FrontDoor.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.FrontDoor.Tests.ps1
@@ -185,6 +185,26 @@ Describe 'Azure.FrontDoor' -Tag 'Network', 'FrontDoor' {
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'frontdoor-waf-A';
         }
+
+        It 'Azure.FrontDoor.UseCaching' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.FrontDoor.UseCaching' };
+            
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-B', 'frontdoor-C', 'frontdoor-D';
+
+            $ruleResult[0].Reason | Should -BeExactly "The front door instance should have caching enabled for routing rules and rule sets to reduce retrieving contents from origins.";
+            $ruleResult[1].Reason | Should -BeExactly "The front door instance should have caching enabled for routing rules and rule sets to reduce retrieving contents from origins.";
+            $ruleResult[2].Reason | Should -BeExactly "The front door instance should have caching enabled for routing rules and rule sets to reduce retrieving contents from origins.";
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'frondoor-A';
+        }
     }
 
     Context 'Resource name - Azure.FrontDoor.Name' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.FrontDoor.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.FrontDoor.json
@@ -1,768 +1,1092 @@
 [
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-A",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-A",
-        "Identity": null,
-        "Kind": null,
-        "Location": "region",
-        "ManagedBy": null,
-        "ResourceName": "frontdoor-A",
-        "Name": "frontdoor-A",
-        "Properties": {
-            "provisioningState": "Succeeded",
-            "resourceState": "Enabled",
-            "backendPools": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/BackendPools/backend-A",
-                    "name": "backend-A",
-                    "type": "Microsoft.Network/Frontdoors/BackendPools",
-                    "properties": {
-                        "backends": [
-                            {
-                                "address": "ww1.contoso.com",
-                                "httpPort": 80,
-                                "httpsPort": 443,
-                                "priority": 2,
-                                "weight": 50,
-                                "backendHostHeader": "ww1.contoso.com",
-                                "enabledState": "Disabled"
-                            },
-                            {
-                                "address": "ww2.contoso.com",
-                                "httpPort": 80,
-                                "httpsPort": 443,
-                                "priority": 1,
-                                "weight": 50,
-                                "backendHostHeader": "ww2.contoso.com",
-                                "enabledState": "Enabled"
-                            }
-                        ],
-                        "healthProbeSettings": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/HealthProbeSettings/frontdoor-A-backend-health"
-                        },
-                        "loadBalancingSettings": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/LoadBalancingSettings/frontdoor-A-lb"
-                        },
-                        "resourceState": "Enabled"
-                    }
-                }
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-A",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-A",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "frontdoor-A",
+    "Name": "frontdoor-A",
+    "Properties": {
+      "provisioningState": "Succeeded",
+      "resourceState": "Enabled",
+      "backendPools": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/BackendPools/backend-A",
+          "name": "backend-A",
+          "type": "Microsoft.Network/Frontdoors/BackendPools",
+          "properties": {
+            "backends": [
+              {
+                "address": "ww1.contoso.com",
+                "httpPort": 80,
+                "httpsPort": 443,
+                "priority": 2,
+                "weight": 50,
+                "backendHostHeader": "ww1.contoso.com",
+                "enabledState": "Disabled"
+              },
+              {
+                "address": "ww2.contoso.com",
+                "httpPort": 80,
+                "httpsPort": 443,
+                "priority": 1,
+                "weight": 50,
+                "backendHostHeader": "ww2.contoso.com",
+                "enabledState": "Enabled"
+              }
             ],
-            "healthProbeSettings": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/HealthProbeSettings/frontdoor-A-backend-health",
-                    "name": "frontdoor-A-backend-health",
-                    "type": "Microsoft.Network/Frontdoors/HealthProbeSettings",
-                    "properties": {
-                        "intervalInSeconds": 255,
-                        "path": "/healthz/",
-                        "protocol": "Https",
-                        "resourceState": "Enabled",
-                        "enabledState": "Enabled",
-                        "healthProbeMethod": "Head"
-                    }
-                }
-            ],
-            "frontendEndpoints": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/FrontendEndpoints/frontdoor-A",
-                    "name": "frontdoor-A",
-                    "type": "Microsoft.Network/Frontdoors/FrontendEndpoints",
-                    "properties": {
-                        "hostName": "frontdoor-A.azurefd.net",
-                        "sessionAffinityEnabledState": "Disabled",
-                        "sessionAffinityTtlSeconds": 0,
-                        "webApplicationFirewallPolicyLink": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/frontdoor-waf-A"
-                        },
-                        "customHttpsProvisioningState": null,
-                        "customHttpsProvisioningSubstate": null,
-                        "customHttpsConfiguration": null,
-                        "resourceState": "Enabled"
-                    }
-                }
-            ],
-            "loadBalancingSettings": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/LoadBalancingSettings/frontdoor-A-lb",
-                    "name": "frontdoor-A-lb",
-                    "type": "Microsoft.Network/Frontdoors/LoadBalancingSettings",
-                    "properties": {
-                        "additionalLatencyMilliseconds": 0,
-                        "sampleSize": 4,
-                        "successfulSamplesRequired": 2,
-                        "resourceState": "Enabled"
-                    }
-                }
-            ],
-            "routingRules": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/RoutingRules/https-forward",
-                    "name": "https-forward",
-                    "type": "Microsoft.Network/Frontdoors/RoutingRules",
-                    "properties": {
-                        "frontendEndpoints": [
-                            {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/FrontendEndpoints/frontdoor-A"
-                            }
-                        ],
-                        "acceptedProtocols": [
-                            "Https"
-                        ],
-                        "patternsToMatch": [
-                            "/*"
-                        ],
-                        "enabledState": "Enabled",
-                        "resourceState": "Enabled",
-                        "routeConfiguration": {
-                            "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
-                            "customForwardingPath": null,
-                            "forwardingProtocol": "HttpsOnly",
-                            "cacheConfiguration": {
-                                "queryParameterStripDirective": "StripNone",
-                                "dynamicCompression": "Disabled"
-                            },
-                            "backendPool": {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/BackendPools/backend-A"
-                            }
-                        }
-                    }
-                },
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/RoutingRules/http-Redirect",
-                    "name": "http-Redirect",
-                    "type": "Microsoft.Network/Frontdoors/RoutingRules",
-                    "properties": {
-                        "frontendEndpoints": [
-                            {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/FrontendEndpoints/frontdoor-A"
-                            }
-                        ],
-                        "acceptedProtocols": [
-                            "Http"
-                        ],
-                        "patternsToMatch": [
-                            "/*"
-                        ],
-                        "enabledState": "Enabled",
-                        "resourceState": "Enabled",
-                        "routeConfiguration": {
-                            "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorRedirectConfiguration",
-                            "customFragment": null,
-                            "customHost": "frontdoor-A.azurefd.net",
-                            "customPath": "",
-                            "redirectProtocol": "HttpsOnly",
-                            "customQueryString": null,
-                            "redirectType": "Found"
-                        }
-                    }
-                }
-            ],
-            "backendPoolsSettings": {
-                "enforceCertificateNameCheck": "Disabled",
-                "sendRecvTimeoutSeconds": 30
+            "healthProbeSettings": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/HealthProbeSettings/frontdoor-A-backend-health"
             },
+            "loadBalancingSettings": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/LoadBalancingSettings/frontdoor-A-lb"
+            },
+            "resourceState": "Enabled"
+          }
+        }
+      ],
+      "healthProbeSettings": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/HealthProbeSettings/frontdoor-A-backend-health",
+          "name": "frontdoor-A-backend-health",
+          "type": "Microsoft.Network/Frontdoors/HealthProbeSettings",
+          "properties": {
+            "intervalInSeconds": 255,
+            "path": "/healthz/",
+            "protocol": "Https",
+            "resourceState": "Enabled",
             "enabledState": "Enabled",
-            "cName": "frontdoor-A.azurefd.net",
-            "friendlyName": ""
-        },
-        "ResourceGroupName": "rg-test",
-        "Type": "Microsoft.Network/frontdoors",
-        "ResourceType": "Microsoft.Network/frontdoors",
-        "Sku": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "resources": [
-            {
-                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-A/providers/microsoft.insights/diagnosticSettings/access-logs",
-                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-A/providers/microsoft.insights/diagnosticSettings/access-logs",
-                "Identity": null,
-                "Kind": null,
-                "Location": null,
-                "ManagedBy": null,
-                "ResourceName": "access-logs",
-                "Name": "access-logs",
-                "ExtensionResourceName": "access-logs",
-                "ParentResource": null,
-                "Plan": null,
-                "Properties": {
-                    "storageAccountId": null,
-                    "serviceBusRuleId": null,
-                    "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
-                    "eventHubAuthorizationRuleId": null,
-                    "eventHubName": null,
-                    "metrics": [
-                        {
-                            "category": "AllMetrics",
-                            "enabled": false,
-                            "retentionPolicy": {
-                                "enabled": false,
-                                "days": 0
-                            }
-                        }
-                    ],
-                    "logs": [
-                        {
-                            "category": "FrontdoorAccessLog",
-                            "enabled": true,
-                            "retentionPolicy": {
-                                "enabled": false,
-                                "days": 0
-                            }
-                        }
-                    ],
-                    "logAnalyticsDestinationType": null
-                },
-                "ResourceGroupName": "rg-test",
-                "Type": "microsoft.network/frontdoors",
-                "ResourceType": "microsoft.network/frontdoors",
-                "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
-                "Sku": null,
-                "Tags": null,
-                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-                "CreatedTime": null,
-                "ChangedTime": null,
-                "ETag": null
-            }
-        ]
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-B",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-B",
-        "Identity": null,
-        "Kind": null,
-        "Location": "region",
-        "ManagedBy": null,
-        "ResourceName": "frontdoor-B",
-        "Name": "frontdoor-B",
-        "Properties": {
-            "provisioningState": "Succeeded",
-            "resourceState": "Enabled",
-            "backendPools": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/BackendPools/backend-A",
-                    "name": "backend-A",
-                    "type": "Microsoft.Network/Frontdoors/BackendPools",
-                    "properties": {
-                        "backends": [
-                            {
-                                "address": "ww1.contoso.com",
-                                "httpPort": 80,
-                                "httpsPort": 443,
-                                "priority": 2,
-                                "weight": 50,
-                                "backendHostHeader": "ww1.contoso.com",
-                                "enabledState": "Disabled"
-                            },
-                            {
-                                "address": "ww2.contoso.com",
-                                "httpPort": 80,
-                                "httpsPort": 443,
-                                "priority": 1,
-                                "weight": 50,
-                                "backendHostHeader": "ww2.contoso.com",
-                                "enabledState": "Enabled"
-                            }
-                        ],
-                        "healthProbeSettings": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/HealthProbeSettings/frontdoor-B-backend-health"
-                        },
-                        "loadBalancingSettings": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/LoadBalancingSettings/frontdoor-B-lb"
-                        },
-                        "resourceState": "Enabled"
-                    }
-                }
-            ],
-            "healthProbeSettings": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/HealthProbeSettings/frontdoor-B-backend-health",
-                    "name": "frontdoor-B-backend-health",
-                    "type": "Microsoft.Network/Frontdoors/HealthProbeSettings",
-                    "properties": {
-                        "intervalInSeconds": 255,
-                        "path": "/",
-                        "protocol": "Https",
-                        "resourceState": "Enabled",
-                        "enabledState": "Disabled",
-                        "healthProbeMethod": "Get"
-                    }
-                }
-            ],
+            "healthProbeMethod": "Head"
+          }
+        }
+      ],
+      "frontendEndpoints": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/FrontendEndpoints/frontdoor-A",
+          "name": "frontdoor-A",
+          "type": "Microsoft.Network/Frontdoors/FrontendEndpoints",
+          "properties": {
+            "hostName": "frontdoor-A.azurefd.net",
+            "sessionAffinityEnabledState": "Disabled",
+            "sessionAffinityTtlSeconds": 0,
+            "webApplicationFirewallPolicyLink": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/frontdoor-waf-A"
+            },
+            "customHttpsProvisioningState": null,
+            "customHttpsProvisioningSubstate": null,
+            "customHttpsConfiguration": null,
+            "resourceState": "Enabled"
+          }
+        }
+      ],
+      "loadBalancingSettings": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/LoadBalancingSettings/frontdoor-A-lb",
+          "name": "frontdoor-A-lb",
+          "type": "Microsoft.Network/Frontdoors/LoadBalancingSettings",
+          "properties": {
+            "additionalLatencyMilliseconds": 0,
+            "sampleSize": 4,
+            "successfulSamplesRequired": 2,
+            "resourceState": "Enabled"
+          }
+        }
+      ],
+      "routingRules": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/RoutingRules/https-forward",
+          "name": "https-forward",
+          "type": "Microsoft.Network/Frontdoors/RoutingRules",
+          "properties": {
             "frontendEndpoints": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/FrontendEndpoints/frontdoor-B",
-                    "name": "frontdoor-B",
-                    "type": "Microsoft.Network/Frontdoors/FrontendEndpoints",
-                    "properties": {
-                        "hostName": "frontdoor-B.azurefd.net",
-                        "sessionAffinityEnabledState": "Disabled",
-                        "sessionAffinityTtlSeconds": 0,
-                        "customHttpsProvisioningState": null,
-                        "customHttpsProvisioningSubstate": null,
-                        "customHttpsConfiguration": {
-                            "minimumTlsVersion": "1.0"
-                        },
-                        "resourceState": "Enabled"
-                    }
-                }
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/FrontendEndpoints/frontdoor-A"
+              }
             ],
-            "loadBalancingSettings": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/LoadBalancingSettings/frontdoor-B-lb",
-                    "name": "frontdoor-B-lb",
-                    "type": "Microsoft.Network/Frontdoors/LoadBalancingSettings",
-                    "properties": {
-                        "additionalLatencyMilliseconds": 0,
-                        "sampleSize": 4,
-                        "successfulSamplesRequired": 2,
-                        "resourceState": "Enabled"
-                    }
-                }
-            ],
-            "routingRules": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/RoutingRules/https-forward",
-                    "name": "https-forward",
-                    "type": "Microsoft.Network/Frontdoors/RoutingRules",
-                    "properties": {
-                        "frontendEndpoints": [
-                            {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/FrontendEndpoints/frontdoor-B"
-                            }
-                        ],
-                        "acceptedProtocols": [
-                            "Https"
-                        ],
-                        "patternsToMatch": [
-                            "/*"
-                        ],
-                        "enabledState": "Enabled",
-                        "resourceState": "Enabled",
-                        "routeConfiguration": {
-                            "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
-                            "customForwardingPath": null,
-                            "forwardingProtocol": "HttpsOnly",
-                            "cacheConfiguration": {
-                                "queryParameterStripDirective": "StripNone",
-                                "dynamicCompression": "Disabled"
-                            },
-                            "backendPool": {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/BackendPools/backend-A"
-                            }
-                        }
-                    }
-                },
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/RoutingRules/http-Redirect",
-                    "name": "http-Redirect",
-                    "type": "Microsoft.Network/Frontdoors/RoutingRules",
-                    "properties": {
-                        "frontendEndpoints": [
-                            {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/FrontendEndpoints/frontdoor-B"
-                            }
-                        ],
-                        "acceptedProtocols": [
-                            "Http"
-                        ],
-                        "patternsToMatch": [
-                            "/*"
-                        ],
-                        "enabledState": "Enabled",
-                        "resourceState": "Enabled",
-                        "routeConfiguration": {
-                            "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorRedirectConfiguration",
-                            "customFragment": null,
-                            "customHost": "frontdoor-B.azurefd.net",
-                            "customPath": "",
-                            "redirectProtocol": "HttpsOnly",
-                            "customQueryString": null,
-                            "redirectType": "Found"
-                        }
-                    }
-                }
-            ],
-            "backendPoolsSettings": {
-                "enforceCertificateNameCheck": "Disabled",
-                "sendRecvTimeoutSeconds": 30
-            },
-            "enabledState": "Disabled",
-            "cName": "frontdoor-B.azurefd.net",
-            "friendlyName": ""
-        },
-        "ResourceGroupName": "rg-test",
-        "Type": "Microsoft.Network/frontdoors",
-        "ResourceType": "Microsoft.Network/frontdoors",
-        "Sku": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "ETag": null
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-C",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-C",
-        "Identity": null,
-        "Kind": null,
-        "Location": "region",
-        "ManagedBy": null,
-        "ResourceName": "frontdoor-C",
-        "Name": "frontdoor-C",
-        "Properties": {
-            "provisioningState": "Succeeded",
+            "acceptedProtocols": ["Https"],
+            "patternsToMatch": ["/*"],
+            "enabledState": "Enabled",
             "resourceState": "Enabled",
-            "backendPools": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/BackendPools/backend-A",
-                    "name": "backend-A",
-                    "type": "Microsoft.Network/Frontdoors/BackendPools",
-                    "properties": {
-                        "backends": [
-                            {
-                                "address": "ww1.contoso.com",
-                                "httpPort": 80,
-                                "httpsPort": 443,
-                                "priority": 2,
-                                "weight": 50,
-                                "backendHostHeader": "ww1.contoso.com",
-                                "enabledState": "Disabled"
-                            },
-                            {
-                                "address": "ww2.contoso.com",
-                                "httpPort": 80,
-                                "httpsPort": 443,
-                                "priority": 1,
-                                "weight": 50,
-                                "backendHostHeader": "ww2.contoso.com",
-                                "enabledState": "Enabled"
-                            }
-                        ],
-                        "healthProbeSettings": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/HealthProbeSettings/frontdoor-C-backend-health"
-                        },
-                        "loadBalancingSettings": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/LoadBalancingSettings/frontdoor-C-lb"
-                        },
-                        "resourceState": "Enabled"
-                    }
-                }
-            ],
-            "healthProbeSettings": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/HealthProbeSettings/frontdoor-C-backend-health",
-                    "name": "frontdoor-C-backend-health",
-                    "type": "Microsoft.Network/Frontdoors/HealthProbeSettings",
-                    "properties": {
-                        "intervalInSeconds": 255,
-                        "path": "/healthz/",
-                        "protocol": "Https",
-                        "resourceState": "Enabled",
-                        "enabledState": "Enabled",
-                        "healthProbeMethod": "Head"
-                    }
-                }
-            ],
-            "frontendEndpoints": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/FrontendEndpoints/frontdoor-C",
-                    "name": "frontdoor-C",
-                    "type": "Microsoft.Network/Frontdoors/FrontendEndpoints",
-                    "properties": {
-                        "hostName": "frontdoor-C.azurefd.net",
-                        "sessionAffinityEnabledState": "Disabled",
-                        "sessionAffinityTtlSeconds": 0,
-                        "webApplicationFirewallPolicyLink": {
-                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/frontdoor-waf-A"
-                        },
-                        "customHttpsProvisioningState": null,
-                        "customHttpsProvisioningSubstate": null,
-                        "customHttpsConfiguration": {
-                            "minimumTlsVersion": "1.2"
-                        },
-                        "resourceState": "Enabled"
-                    }
-                }
-            ],
-            "loadBalancingSettings": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/LoadBalancingSettings/frontdoor-C-lb",
-                    "name": "frontdoor-C-lb",
-                    "type": "Microsoft.Network/Frontdoors/LoadBalancingSettings",
-                    "properties": {
-                        "additionalLatencyMilliseconds": 0,
-                        "sampleSize": 4,
-                        "successfulSamplesRequired": 2,
-                        "resourceState": "Enabled"
-                    }
-                }
-            ],
-            "routingRules": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/RoutingRules/https-forward",
-                    "name": "https-forward",
-                    "type": "Microsoft.Network/Frontdoors/RoutingRules",
-                    "properties": {
-                        "frontendEndpoints": [
-                            {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/FrontendEndpoints/frontdoor-C"
-                            }
-                        ],
-                        "acceptedProtocols": [
-                            "Https"
-                        ],
-                        "patternsToMatch": [
-                            "/*"
-                        ],
-                        "enabledState": "Enabled",
-                        "resourceState": "Enabled",
-                        "routeConfiguration": {
-                            "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
-                            "customForwardingPath": null,
-                            "forwardingProtocol": "HttpsOnly",
-                            "cacheConfiguration": {
-                                "queryParameterStripDirective": "StripNone",
-                                "dynamicCompression": "Disabled"
-                            },
-                            "backendPool": {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/BackendPools/backend-A"
-                            }
-                        }
-                    }
-                },
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/RoutingRules/http-Redirect",
-                    "name": "http-Redirect",
-                    "type": "Microsoft.Network/Frontdoors/RoutingRules",
-                    "properties": {
-                        "frontendEndpoints": [
-                            {
-                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/FrontendEndpoints/frontdoor-C"
-                            }
-                        ],
-                        "acceptedProtocols": [
-                            "Http"
-                        ],
-                        "patternsToMatch": [
-                            "/*"
-                        ],
-                        "enabledState": "Enabled",
-                        "resourceState": "Enabled",
-                        "routeConfiguration": {
-                            "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorRedirectConfiguration",
-                            "customFragment": null,
-                            "customHost": "frontdoor-C.azurefd.net",
-                            "customPath": "",
-                            "redirectProtocol": "HttpsOnly",
-                            "customQueryString": null,
-                            "redirectType": "Found"
-                        }
-                    }
-                }
-            ],
-            "backendPoolsSettings": {
-                "enforceCertificateNameCheck": "Disabled",
-                "sendRecvTimeoutSeconds": 30
-            },
-            "enabledState": "Disabled",
-            "cName": "frontdoor-C.azurefd.net",
-            "friendlyName": ""
-        },
-        "ResourceGroupName": "rg-test",
-        "Type": "Microsoft.Network/frontdoors",
-        "ResourceType": "Microsoft.Network/frontdoors",
-        "Sku": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "resources": [
-            {
-                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-C/providers/microsoft.insights/diagnosticSettings/access-logs",
-                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-C/providers/microsoft.insights/diagnosticSettings/access-logs",
-                "Identity": null,
-                "Kind": null,
-                "Location": null,
-                "ManagedBy": null,
-                "ResourceName": "access-logs",
-                "Name": "access-logs",
-                "ExtensionResourceName": "access-logs",
-                "ParentResource": null,
-                "Plan": null,
-                "Properties": {
-                    "storageAccountId": null,
-                    "serviceBusRuleId": null,
-                    "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
-                    "eventHubAuthorizationRuleId": null,
-                    "eventHubName": null,
-                    "metrics": [
-                        {
-                            "category": "AllMetrics",
-                            "enabled": false,
-                            "retentionPolicy": {
-                                "enabled": false,
-                                "days": 0
-                            }
-                        }
-                    ],
-                    "logs": [
-                        {
-                            "category": "FrontdoorWebApplicationFirewallLog",
-                            "enabled": true,
-                            "retentionPolicy": {
-                                "enabled": false,
-                                "days": 0
-                            }
-                        },
-                        {
-                            "category": "FrontdoorAccessLog",
-                            "enabled": true,
-                            "retentionPolicy": {
-                                "enabled": false,
-                                "days": 0
-                            }
-                        }
-                    ],
-                    "logAnalyticsDestinationType": null
-                },
-                "ResourceGroupName": "rg-test",
-                "Type": "microsoft.network/frontdoors",
-                "ResourceType": "microsoft.network/frontdoors",
-                "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
-                "Sku": null,
-                "Tags": null,
-                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-                "CreatedTime": null,
-                "ChangedTime": null,
-                "ETag": null
+            "routeConfiguration": {
+              "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
+              "customForwardingPath": null,
+              "forwardingProtocol": "HttpsOnly",
+              "cacheConfiguration": {
+                "queryParameterStripDirective": "StripNone",
+                "dynamicCompression": "Disabled"
+              },
+              "backendPool": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/BackendPools/backend-A"
+              }
             }
+          }
+        },
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/RoutingRules/http-Redirect",
+          "name": "http-Redirect",
+          "type": "Microsoft.Network/Frontdoors/RoutingRules",
+          "properties": {
+            "frontendEndpoints": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-A/FrontendEndpoints/frontdoor-A"
+              }
+            ],
+            "acceptedProtocols": ["Http"],
+            "patternsToMatch": ["/*"],
+            "enabledState": "Enabled",
+            "resourceState": "Enabled",
+            "routeConfiguration": {
+              "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorRedirectConfiguration",
+              "customFragment": null,
+              "customHost": "frontdoor-A.azurefd.net",
+              "customPath": "",
+              "redirectProtocol": "HttpsOnly",
+              "customQueryString": null,
+              "redirectType": "Found"
+            }
+          }
+        }
+      ],
+      "backendPoolsSettings": {
+        "enforceCertificateNameCheck": "Disabled",
+        "sendRecvTimeoutSeconds": 30
+      },
+      "enabledState": "Enabled",
+      "cName": "frontdoor-A.azurefd.net",
+      "friendlyName": ""
+    },
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.Network/frontdoors",
+    "ResourceType": "Microsoft.Network/frontdoors",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-A/providers/microsoft.insights/diagnosticSettings/access-logs",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-A/providers/microsoft.insights/diagnosticSettings/access-logs",
+        "Identity": null,
+        "Kind": null,
+        "Location": null,
+        "ManagedBy": null,
+        "ResourceName": "access-logs",
+        "Name": "access-logs",
+        "ExtensionResourceName": "access-logs",
+        "ParentResource": null,
+        "Plan": null,
+        "Properties": {
+          "storageAccountId": null,
+          "serviceBusRuleId": null,
+          "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
+          "eventHubAuthorizationRuleId": null,
+          "eventHubName": null,
+          "metrics": [
+            {
+              "category": "AllMetrics",
+              "enabled": false,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logs": [
+            {
+              "category": "FrontdoorAccessLog",
+              "enabled": true,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logAnalyticsDestinationType": null
+        },
+        "ResourceGroupName": "rg-test",
+        "Type": "microsoft.network/frontdoors",
+        "ResourceType": "microsoft.network/frontdoors",
+        "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "CreatedTime": null,
+        "ChangedTime": null,
+        "ETag": null
+      },
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-A/providers/microsoft.network/frontdoors/rulesengines/ruleset-A",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-A/providers/microsoft.network/frontdoors/rulesengines/ruleset-A",
+        "Identity": null,
+        "Kind": null,
+        "Location": null,
+        "ManagedBy": null,
+        "ResourceName": "ruleset-A",
+        "Name": "ruleset-A",
+        "ExtensionResourceName": null,
+        "ParentResource": null,
+        "Plan": null,
+        "properties": {
+          "rules": [
+            {
+              "action": {
+                "requestHeaderActions": [
+                  {
+                    "headerActionType": "string",
+                    "headerName": "string",
+                    "value": "string"
+                  }
+                ],
+                "responseHeaderActions": [
+                  {
+                    "headerActionType": "string",
+                    "headerName": "string",
+                    "value": "string"
+                  }
+                ],
+                "routeConfigurationOverride": {
+                  "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
+                  "cacheConfiguration": {
+                    "queryStringCachingBehavior": "IncludeSpecifiedQueryStrings",
+                    "queryParameters": "customerId",
+                    "isCompressionEnabled": "Enabled",
+                    "cacheBehavior": "HonorOrigin",
+                    "cacheDuration": null
+                  }
+                }
+              },
+              "matchConditions": [
+                {
+                  "negateCondition": "bool",
+                  "rulesEngineMatchValue": ["string"],
+                  "rulesEngineMatchVariable": "string",
+                  "rulesEngineOperator": "string",
+                  "selector": "string",
+                  "transforms": ["string"]
+                }
+              ],
+              "matchProcessingBehavior": "string",
+              "name": "rule-A",
+              "priority": "int"
+            }
+          ]
+        },
+        "ResourceGroupName": "rg-test",
+        "Type": "microsoft.network/frontdoors/rulesengines",
+        "ResourceType": "microsoft.network/rulesengines",
+        "ExtensionResourceType": null,
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "CreatedTime": null,
+        "ChangedTime": null,
+        "ETag": null
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-B",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-B",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "frontdoor-B",
+    "Name": "frontdoor-B",
+    "Properties": {
+      "provisioningState": "Succeeded",
+      "resourceState": "Enabled",
+      "backendPools": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/BackendPools/backend-A",
+          "name": "backend-A",
+          "type": "Microsoft.Network/Frontdoors/BackendPools",
+          "properties": {
+            "backends": [
+              {
+                "address": "ww1.contoso.com",
+                "httpPort": 80,
+                "httpsPort": 443,
+                "priority": 2,
+                "weight": 50,
+                "backendHostHeader": "ww1.contoso.com",
+                "enabledState": "Disabled"
+              },
+              {
+                "address": "ww2.contoso.com",
+                "httpPort": 80,
+                "httpsPort": 443,
+                "priority": 1,
+                "weight": 50,
+                "backendHostHeader": "ww2.contoso.com",
+                "enabledState": "Enabled"
+              }
+            ],
+            "healthProbeSettings": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/HealthProbeSettings/frontdoor-B-backend-health"
+            },
+            "loadBalancingSettings": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/LoadBalancingSettings/frontdoor-B-lb"
+            },
+            "resourceState": "Enabled"
+          }
+        }
+      ],
+      "healthProbeSettings": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/HealthProbeSettings/frontdoor-B-backend-health",
+          "name": "frontdoor-B-backend-health",
+          "type": "Microsoft.Network/Frontdoors/HealthProbeSettings",
+          "properties": {
+            "intervalInSeconds": 255,
+            "path": "/",
+            "protocol": "Https",
+            "resourceState": "Enabled",
+            "enabledState": "Disabled",
+            "healthProbeMethod": "Get"
+          }
+        }
+      ],
+      "frontendEndpoints": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/FrontendEndpoints/frontdoor-B",
+          "name": "frontdoor-B",
+          "type": "Microsoft.Network/Frontdoors/FrontendEndpoints",
+          "properties": {
+            "hostName": "frontdoor-B.azurefd.net",
+            "sessionAffinityEnabledState": "Disabled",
+            "sessionAffinityTtlSeconds": 0,
+            "customHttpsProvisioningState": null,
+            "customHttpsProvisioningSubstate": null,
+            "customHttpsConfiguration": {
+              "minimumTlsVersion": "1.0"
+            },
+            "resourceState": "Enabled"
+          }
+        }
+      ],
+      "loadBalancingSettings": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/LoadBalancingSettings/frontdoor-B-lb",
+          "name": "frontdoor-B-lb",
+          "type": "Microsoft.Network/Frontdoors/LoadBalancingSettings",
+          "properties": {
+            "additionalLatencyMilliseconds": 0,
+            "sampleSize": 4,
+            "successfulSamplesRequired": 2,
+            "resourceState": "Enabled"
+          }
+        }
+      ],
+      "routingRules": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/RoutingRules/https-forward",
+          "name": "https-forward",
+          "type": "Microsoft.Network/Frontdoors/RoutingRules",
+          "properties": {
+            "frontendEndpoints": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/FrontendEndpoints/frontdoor-B"
+              }
+            ],
+            "acceptedProtocols": ["Https"],
+            "patternsToMatch": ["/*"],
+            "enabledState": "Enabled",
+            "resourceState": "Enabled",
+            "routeConfiguration": {
+              "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
+              "customForwardingPath": null,
+              "forwardingProtocol": "HttpsOnly",
+              "cacheConfiguration": {
+                "queryParameterStripDirective": "StripNone",
+                "dynamicCompression": "Disabled"
+              },
+              "backendPool": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/BackendPools/backend-A"
+              }
+            }
+          }
+        },
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/RoutingRules/http-Redirect",
+          "name": "http-Redirect",
+          "type": "Microsoft.Network/Frontdoors/RoutingRules",
+          "properties": {
+            "frontendEndpoints": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-B/FrontendEndpoints/frontdoor-B"
+              }
+            ],
+            "acceptedProtocols": ["Http"],
+            "patternsToMatch": ["/*"],
+            "enabledState": "Enabled",
+            "resourceState": "Enabled",
+            "routeConfiguration": {
+              "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorRedirectConfiguration",
+              "customFragment": null,
+              "customHost": "frontdoor-B.azurefd.net",
+              "customPath": "",
+              "redirectProtocol": "HttpsOnly",
+              "customQueryString": null,
+              "redirectType": "Found"
+            }
+          }
+        }
+      ],
+      "backendPoolsSettings": {
+        "enforceCertificateNameCheck": "Disabled",
+        "sendRecvTimeoutSeconds": 30
+      },
+      "enabledState": "Disabled",
+      "cName": "frontdoor-B.azurefd.net",
+      "friendlyName": ""
+    },
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.Network/frontdoors",
+    "ResourceType": "Microsoft.Network/frontdoors",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-B/providers/microsoft.network/frontdoors/rulesengines/ruleset-A",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-B/providers/microsoft.network/frontdoors/rulesengines/ruleset-A",
+        "Identity": null,
+        "Kind": null,
+        "Location": null,
+        "ManagedBy": null,
+        "ResourceName": "ruleset-A",
+        "Name": "ruleset-A",
+        "ExtensionResourceName": null,
+        "ParentResource": null,
+        "Plan": null,
+        "properties": {
+          "rules": [
+            {
+              "action": {
+                "requestHeaderActions": [
+                  {
+                    "headerActionType": "string",
+                    "headerName": "string",
+                    "value": "string"
+                  }
+                ],
+                "responseHeaderActions": [
+                  {
+                    "headerActionType": "string",
+                    "headerName": "string",
+                    "value": "string"
+                  }
+                ],
+                "routeConfigurationOverride": {
+                  "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
+                  "cacheConfiguration": null
+                }
+              },
+              "matchConditions": [
+                {
+                  "negateCondition": "bool",
+                  "rulesEngineMatchValue": ["string"],
+                  "rulesEngineMatchVariable": "string",
+                  "rulesEngineOperator": "string",
+                  "selector": "string",
+                  "transforms": ["string"]
+                }
+              ],
+              "matchProcessingBehavior": "string",
+              "name": "rule-A",
+              "priority": "int"
+            }
+          ]
+        },
+        "ResourceGroupName": "rg-test",
+        "Type": "microsoft.network/frontdoors/rulesengines",
+        "ResourceType": "microsoft.network/rulesengines",
+        "ExtensionResourceType": null,
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "CreatedTime": null,
+        "ChangedTime": null,
+        "ETag": null
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-C",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-C",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "frontdoor-C",
+    "Name": "frontdoor-C",
+    "Properties": {
+      "provisioningState": "Succeeded",
+      "resourceState": "Enabled",
+      "backendPools": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/BackendPools/backend-A",
+          "name": "backend-A",
+          "type": "Microsoft.Network/Frontdoors/BackendPools",
+          "properties": {
+            "backends": [
+              {
+                "address": "ww1.contoso.com",
+                "httpPort": 80,
+                "httpsPort": 443,
+                "priority": 2,
+                "weight": 50,
+                "backendHostHeader": "ww1.contoso.com",
+                "enabledState": "Disabled"
+              },
+              {
+                "address": "ww2.contoso.com",
+                "httpPort": 80,
+                "httpsPort": 443,
+                "priority": 1,
+                "weight": 50,
+                "backendHostHeader": "ww2.contoso.com",
+                "enabledState": "Enabled"
+              }
+            ],
+            "healthProbeSettings": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/HealthProbeSettings/frontdoor-C-backend-health"
+            },
+            "loadBalancingSettings": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/LoadBalancingSettings/frontdoor-C-lb"
+            },
+            "resourceState": "Enabled"
+          }
+        }
+      ],
+      "healthProbeSettings": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/HealthProbeSettings/frontdoor-C-backend-health",
+          "name": "frontdoor-C-backend-health",
+          "type": "Microsoft.Network/Frontdoors/HealthProbeSettings",
+          "properties": {
+            "intervalInSeconds": 255,
+            "path": "/healthz/",
+            "protocol": "Https",
+            "resourceState": "Enabled",
+            "enabledState": "Enabled",
+            "healthProbeMethod": "Head"
+          }
+        }
+      ],
+      "frontendEndpoints": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/FrontendEndpoints/frontdoor-C",
+          "name": "frontdoor-C",
+          "type": "Microsoft.Network/Frontdoors/FrontendEndpoints",
+          "properties": {
+            "hostName": "frontdoor-C.azurefd.net",
+            "sessionAffinityEnabledState": "Disabled",
+            "sessionAffinityTtlSeconds": 0,
+            "webApplicationFirewallPolicyLink": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/frontdoor-waf-A"
+            },
+            "customHttpsProvisioningState": null,
+            "customHttpsProvisioningSubstate": null,
+            "customHttpsConfiguration": {
+              "minimumTlsVersion": "1.2"
+            },
+            "resourceState": "Enabled"
+          }
+        }
+      ],
+      "loadBalancingSettings": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/LoadBalancingSettings/frontdoor-C-lb",
+          "name": "frontdoor-C-lb",
+          "type": "Microsoft.Network/Frontdoors/LoadBalancingSettings",
+          "properties": {
+            "additionalLatencyMilliseconds": 0,
+            "sampleSize": 4,
+            "successfulSamplesRequired": 2,
+            "resourceState": "Enabled"
+          }
+        }
+      ],
+      "routingRules": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/RoutingRules/https-forward",
+          "name": "https-forward",
+          "type": "Microsoft.Network/Frontdoors/RoutingRules",
+          "properties": {
+            "frontendEndpoints": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/FrontendEndpoints/frontdoor-C"
+              }
+            ],
+            "acceptedProtocols": ["Https"],
+            "patternsToMatch": ["/*"],
+            "enabledState": "Enabled",
+            "resourceState": "Enabled",
+            "routeConfiguration": {
+              "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
+              "customForwardingPath": null,
+              "forwardingProtocol": "HttpsOnly",
+              "cacheConfiguration": null,
+              "backendPool": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/BackendPools/backend-A"
+              }
+            }
+          }
+        },
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/RoutingRules/http-Redirect",
+          "name": "http-Redirect",
+          "type": "Microsoft.Network/Frontdoors/RoutingRules",
+          "properties": {
+            "frontendEndpoints": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-C/FrontendEndpoints/frontdoor-C"
+              }
+            ],
+            "acceptedProtocols": ["Http"],
+            "patternsToMatch": ["/*"],
+            "enabledState": "Enabled",
+            "resourceState": "Enabled",
+            "routeConfiguration": {
+              "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorRedirectConfiguration",
+              "customFragment": null,
+              "customHost": "frontdoor-C.azurefd.net",
+              "customPath": "",
+              "redirectProtocol": "HttpsOnly",
+              "customQueryString": null,
+              "redirectType": "Found"
+            }
+          }
+        }
+      ],
+      "backendPoolsSettings": {
+        "enforceCertificateNameCheck": "Disabled",
+        "sendRecvTimeoutSeconds": 30
+      },
+      "enabledState": "Disabled",
+      "cName": "frontdoor-C.azurefd.net",
+      "friendlyName": ""
+    },
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.Network/frontdoors",
+    "ResourceType": "Microsoft.Network/frontdoors",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-C/providers/microsoft.insights/diagnosticSettings/access-logs",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-C/providers/microsoft.insights/diagnosticSettings/access-logs",
+        "Identity": null,
+        "Kind": null,
+        "Location": null,
+        "ManagedBy": null,
+        "ResourceName": "access-logs",
+        "Name": "access-logs",
+        "ExtensionResourceName": "access-logs",
+        "ParentResource": null,
+        "Plan": null,
+        "Properties": {
+          "storageAccountId": null,
+          "serviceBusRuleId": null,
+          "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
+          "eventHubAuthorizationRuleId": null,
+          "eventHubName": null,
+          "metrics": [
+            {
+              "category": "AllMetrics",
+              "enabled": false,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logs": [
+            {
+              "category": "FrontdoorWebApplicationFirewallLog",
+              "enabled": true,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            },
+            {
+              "category": "FrontdoorAccessLog",
+              "enabled": true,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logAnalyticsDestinationType": null
+        },
+        "ResourceGroupName": "rg-test",
+        "Type": "microsoft.network/frontdoors",
+        "ResourceType": "microsoft.network/frontdoors",
+        "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "CreatedTime": null,
+        "ChangedTime": null,
+        "ETag": null
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-D",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-D",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "frontdoor-D",
+    "Name": "frontdoor-D",
+    "Properties": {
+      "provisioningState": "Succeeded",
+      "resourceState": "Enabled",
+      "backendPools": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-D/BackendPools/backend-A",
+          "name": "backend-A",
+          "type": "Microsoft.Network/Frontdoors/BackendPools",
+          "properties": {
+            "backends": [
+              {
+                "address": "ww1.contoso.com",
+                "httpPort": 80,
+                "httpsPort": 443,
+                "priority": 2,
+                "weight": 50,
+                "backendHostHeader": "ww1.contoso.com",
+                "enabledState": "Disabled"
+              },
+              {
+                "address": "ww2.contoso.com",
+                "httpPort": 80,
+                "httpsPort": 443,
+                "priority": 1,
+                "weight": 50,
+                "backendHostHeader": "ww2.contoso.com",
+                "enabledState": "Enabled"
+              }
+            ],
+            "healthProbeSettings": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-D/HealthProbeSettings/frontdoor-D-backend-health"
+            },
+            "loadBalancingSettings": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-D/LoadBalancingSettings/frontdoor-D-lb"
+            },
+            "resourceState": "Enabled"
+          }
+        }
+      ],
+      "healthProbeSettings": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-D/HealthProbeSettings/frontdoor-D-backend-health",
+          "name": "frontdoor-C-backend-health",
+          "type": "Microsoft.Network/Frontdoors/HealthProbeSettings",
+          "properties": {
+            "intervalInSeconds": 255,
+            "path": "/healthz/",
+            "protocol": "Https",
+            "resourceState": "Enabled",
+            "enabledState": "Enabled",
+            "healthProbeMethod": "Head"
+          }
+        }
+      ],
+      "frontendEndpoints": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-D/FrontendEndpoints/frontdoor-D",
+          "name": "frontdoor-D",
+          "type": "Microsoft.Network/Frontdoors/FrontendEndpoints",
+          "properties": {
+            "hostName": "frontdoor-D.azurefd.net",
+            "sessionAffinityEnabledState": "Disabled",
+            "sessionAffinityTtlSeconds": 0,
+            "webApplicationFirewallPolicyLink": {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/frontdoor-waf-A"
+            },
+            "customHttpsProvisioningState": null,
+            "customHttpsProvisioningSubstate": null,
+            "customHttpsConfiguration": {
+              "minimumTlsVersion": "1.2"
+            },
+            "resourceState": "Enabled"
+          }
+        }
+      ],
+      "loadBalancingSettings": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-D/LoadBalancingSettings/frontdoor-D-lb",
+          "name": "frontdoor-D-lb",
+          "type": "Microsoft.Network/Frontdoors/LoadBalancingSettings",
+          "properties": {
+            "additionalLatencyMilliseconds": 0,
+            "sampleSize": 4,
+            "successfulSamplesRequired": 2,
+            "resourceState": "Enabled"
+          }
+        }
+      ],
+      "routingRules": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-D/RoutingRules/https-forward",
+          "name": "https-forward",
+          "type": "Microsoft.Network/Frontdoors/RoutingRules",
+          "properties": {
+            "frontendEndpoints": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-D/FrontendEndpoints/frontdoor-D"
+              }
+            ],
+            "acceptedProtocols": ["Https"],
+            "patternsToMatch": ["/*"],
+            "enabledState": "Enabled",
+            "resourceState": "Enabled",
+            "routeConfiguration": {
+              "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
+              "customForwardingPath": null,
+              "forwardingProtocol": "HttpsOnly",
+              "cacheConfiguration": null,
+              "backendPool": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-D/BackendPools/backend-A"
+              }
+            }
+          }
+        },
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-D/RoutingRules/http-Redirect",
+          "name": "http-Redirect",
+          "type": "Microsoft.Network/Frontdoors/RoutingRules",
+          "properties": {
+            "frontendEndpoints": [
+              {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/Frontdoors/frontdoor-D/FrontendEndpoints/frontdoor-D"
+              }
+            ],
+            "acceptedProtocols": ["Http"],
+            "patternsToMatch": ["/*"],
+            "enabledState": "Enabled",
+            "resourceState": "Enabled",
+            "routeConfiguration": {
+              "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorRedirectConfiguration",
+              "customFragment": null,
+              "customHost": "frontdoor-D.azurefd.net",
+              "customPath": "",
+              "redirectProtocol": "HttpsOnly",
+              "customQueryString": null,
+              "redirectType": "Found"
+            }
+          }
+        }
+      ],
+      "backendPoolsSettings": {
+        "enforceCertificateNameCheck": "Disabled",
+        "sendRecvTimeoutSeconds": 30
+      },
+      "enabledState": "Disabled",
+      "cName": "frontdoor-D.azurefd.net",
+      "friendlyName": ""
+    },
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.Network/frontdoors",
+    "ResourceType": "Microsoft.Network/frontdoors",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-D/providers/microsoft.insights/diagnosticSettings/access-logs",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.network/frontdoors/frontdoor-D/providers/microsoft.insights/diagnosticSettings/access-logs",
+        "Identity": null,
+        "Kind": null,
+        "Location": null,
+        "ManagedBy": null,
+        "ResourceName": "access-logs",
+        "Name": "access-logs",
+        "ExtensionResourceName": "access-logs",
+        "ParentResource": null,
+        "Plan": null,
+        "Properties": {
+          "storageAccountId": null,
+          "serviceBusRuleId": null,
+          "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
+          "eventHubAuthorizationRuleId": null,
+          "eventHubName": null,
+          "metrics": [
+            {
+              "category": "AllMetrics",
+              "enabled": false,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logs": [
+            {
+              "category": "FrontdoorWebApplicationFirewallLog",
+              "enabled": true,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            },
+            {
+              "category": "FrontdoorAccessLog",
+              "enabled": true,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logAnalyticsDestinationType": null
+        },
+        "ResourceGroupName": "rg-test",
+        "Type": "microsoft.network/frontdoors",
+        "ResourceType": "microsoft.network/frontdoors",
+        "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "CreatedTime": null,
+        "ChangedTime": null,
+        "ETag": null
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/frontdoor-waf-A",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/frontdoor-waf-A",
+    "Identity": null,
+    "Kind": null,
+    "Location": "Global",
+    "ManagedBy": null,
+    "ResourceName": "frontdoor-waf-A",
+    "Name": "frontdoor-waf-A",
+    "Properties": {
+      "resourceState": "Enabled",
+      "provisioningState": "Succeeded",
+      "policySettings": {
+        "enabledState": "Enabled",
+        "mode": "Prevention",
+        "redirectUrl": null,
+        "customBlockResponseStatusCode": 403,
+        "customBlockResponseBody": ""
+      },
+      "customRules": {
+        "rules": [
+          {
+            "name": "IPBlacklist",
+            "enabledState": "Disabled",
+            "priority": 1,
+            "ruleType": "MatchRule",
+            "rateLimitDurationInMinutes": 1,
+            "rateLimitThreshold": 10,
+            "matchConditions": [
+              {
+                "matchVariable": "RemoteAddr",
+                "selector": null,
+                "operator": "IPMatch",
+                "negateCondition": false,
+                "matchValue": ["10.0.0.0"],
+                "transforms": []
+              }
+            ],
+            "action": "Block"
+          }
         ]
+      },
+      "managedRules": {
+        "managedRuleSets": [
+          {
+            "ruleSetType": "DefaultRuleSet",
+            "ruleSetVersion": "1.0",
+            "ruleGroupOverrides": [],
+            "exclusions": []
+          }
+        ]
+      },
+      "frontendEndpointLinks": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-A/frontendendpoints/frontdoor-A"
+        }
+      ]
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/frontdoor-waf-A",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/frontdoor-waf-A",
-        "Identity": null,
-        "Kind": null,
-        "Location": "Global",
-        "ManagedBy": null,
-        "ResourceName": "frontdoor-waf-A",
-        "Name": "frontdoor-waf-A",
-        "Properties": {
-            "resourceState": "Enabled",
-            "provisioningState": "Succeeded",
-            "policySettings": {
-                "enabledState": "Enabled",
-                "mode": "Prevention",
-                "redirectUrl": null,
-                "customBlockResponseStatusCode": 403,
-                "customBlockResponseBody": ""
-            },
-            "customRules": {
-                "rules": [
-                    {
-                        "name": "IPBlacklist",
-                        "enabledState": "Disabled",
-                        "priority": 1,
-                        "ruleType": "MatchRule",
-                        "rateLimitDurationInMinutes": 1,
-                        "rateLimitThreshold": 10,
-                        "matchConditions": [
-                            {
-                                "matchVariable": "RemoteAddr",
-                                "selector": null,
-                                "operator": "IPMatch",
-                                "negateCondition": false,
-                                "matchValue": [
-                                    "10.0.0.0"
-                                ],
-                                "transforms": []
-                            }
-                        ],
-                        "action": "Block"
-                    }
-                ]
-            },
-            "managedRules": {
-                "managedRuleSets": [
-                    {
-                        "ruleSetType": "DefaultRuleSet",
-                        "ruleSetVersion": "1.0",
-                        "ruleGroupOverrides": [],
-                        "exclusions": []
-                    }
-                ]
-            },
-            "frontendEndpointLinks": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-A/frontendendpoints/frontdoor-A"
-                }
-            ]
-        },
-        "ResourceGroupName": "rg-test",
-        "Type": "Microsoft.Network/frontdoorwebapplicationfirewallpolicies",
-        "ResourceType": "Microsoft.Network/frontdoorwebapplicationfirewallpolicies",
-        "Sku": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "ETag": null
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.Network/frontdoorwebapplicationfirewallpolicies",
+    "ResourceType": "Microsoft.Network/frontdoorwebapplicationfirewallpolicies",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "ETag": null
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/frontdoor-waf-B",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/frontdoor-waf-B",
+    "Identity": null,
+    "Kind": null,
+    "Location": "Global",
+    "ManagedBy": null,
+    "ResourceName": "frontdoor-waf-B",
+    "Name": "frontdoor-waf-B",
+    "Properties": {
+      "resourceState": "Enabled",
+      "provisioningState": "Succeeded",
+      "policySettings": {
+        "enabledState": "Disabled",
+        "mode": "Detection",
+        "redirectUrl": null,
+        "customBlockResponseStatusCode": 403,
+        "customBlockResponseBody": ""
+      },
+      "customRules": {
+        "rules": [
+          {
+            "name": "IPBlacklist",
+            "enabledState": "Disabled",
+            "priority": 1,
+            "ruleType": "MatchRule",
+            "rateLimitDurationInMinutes": 1,
+            "rateLimitThreshold": 10,
+            "matchConditions": [
+              {
+                "matchVariable": "RemoteAddr",
+                "selector": null,
+                "operator": "IPMatch",
+                "negateCondition": false,
+                "matchValue": ["10.0.0.0"],
+                "transforms": []
+              }
+            ],
+            "action": "Block"
+          }
+        ]
+      },
+      "managedRules": {
+        "managedRuleSets": [
+          {
+            "ruleSetType": "DefaultRuleSet",
+            "ruleSetVersion": "1.0",
+            "ruleGroupOverrides": [],
+            "exclusions": []
+          }
+        ]
+      },
+      "frontendEndpointLinks": [
+        {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-B/frontendendpoints/frontdoor-B"
+        }
+      ]
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/frontdoor-waf-B",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/frontdoor-waf-B",
-        "Identity": null,
-        "Kind": null,
-        "Location": "Global",
-        "ManagedBy": null,
-        "ResourceName": "frontdoor-waf-B",
-        "Name": "frontdoor-waf-B",
-        "Properties": {
-            "resourceState": "Enabled",
-            "provisioningState": "Succeeded",
-            "policySettings": {
-                "enabledState": "Disabled",
-                "mode": "Detection",
-                "redirectUrl": null,
-                "customBlockResponseStatusCode": 403,
-                "customBlockResponseBody": ""
-            },
-            "customRules": {
-                "rules": [
-                    {
-                        "name": "IPBlacklist",
-                        "enabledState": "Disabled",
-                        "priority": 1,
-                        "ruleType": "MatchRule",
-                        "rateLimitDurationInMinutes": 1,
-                        "rateLimitThreshold": 10,
-                        "matchConditions": [
-                            {
-                                "matchVariable": "RemoteAddr",
-                                "selector": null,
-                                "operator": "IPMatch",
-                                "negateCondition": false,
-                                "matchValue": [
-                                    "10.0.0.0"
-                                ],
-                                "transforms": []
-                            }
-                        ],
-                        "action": "Block"
-                    }
-                ]
-            },
-            "managedRules": {
-                "managedRuleSets": [
-                    {
-                        "ruleSetType": "DefaultRuleSet",
-                        "ruleSetVersion": "1.0",
-                        "ruleGroupOverrides": [],
-                        "exclusions": []
-                    }
-                ]
-            },
-            "frontendEndpointLinks": [
-                {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Network/frontdoors/frontdoor-B/frontendendpoints/frontdoor-B"
-                }
-            ]
-        },
-        "ResourceGroupName": "rg-test",
-        "Type": "Microsoft.Network/frontdoorwebapplicationfirewallpolicies",
-        "ResourceType": "Microsoft.Network/frontdoorwebapplicationfirewallpolicies",
-        "Sku": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "ETag": null
-    }
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.Network/frontdoorwebapplicationfirewallpolicies",
+    "ResourceType": "Microsoft.Network/frontdoorwebapplicationfirewallpolicies",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "ETag": null
+  }
 ]


### PR DESCRIPTION
## PR Summary

Fixes #548 

Added Azure.FrontDoor.UseCaching rule.

This rule ensures that front door instances uses caching to reduce retrieving contents from origins and improve overall performance.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
