### PR TITLE
Pre-release v1.22.0-B0026

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -31,7 +31,7 @@ Steps to reproduce the issue:
 **Module in use and version:**
 
 - Module: PSRule.Rules.Azure
-- Version: **[e.g. 1.20.0]**
+- Version: **[e.g. 1.21.2]**
 
 Captured output from `$PSVersionTable`:
 

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.22.0-B0026 (pre-release)
+
 What's changed since pre-release v1.22.0-B0011:
 
 - New rules:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.22.0-B0011:

- New rules:
  - API Management:
    - Check api management instances limits control plane API calls to apim with version `'2021-08-01'` or newer by @bengeset96.
      [#1819](https://github.com/Azure/PSRule.Rules.Azure/issues/1819)
- Engineering:
  - Bump Az.Resources to v6.4.0.
    [#1829](https://github.com/Azure/PSRule.Rules.Azure/pull/1829)
- Bug fixes:
  - Fixed non-Linux VM images flagged as Linux by @BernieWhite.
    [#1825](https://github.com/Azure/PSRule.Rules.Azure/issues/1825)
  - Fixed failed to expand with last function on runtime property by @BernieWhite.
    [#1830](https://github.com/Azure/PSRule.Rules.Azure/issues/1830)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
