### PR TITLE
Added support for the flexible server deployment model in Azure.MySQL.GeoRedundantBackup

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -26,7 +26,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 - New rules:
   - Azure Database for MySQL:
-    -  Check Azure Database for MySQL servers have geo-redundant backup configured by @bengeset96.
+    - Check Azure Database for MySQL Flexible Servers have geo-redundant backup configured by @bengeset96.
+      [#1840](https://github.com/Azure/PSRule.Rules.Azure/issues/1840)
+    - Check Azure Database for MySQL servers have geo-redundant backup configured by @bengeset96.
       [#284](https://github.com/Azure/PSRule.Rules.Azure/issues/284)
 
 ## v1.22.0-B0026 (pre-release)

--- a/docs/en/rules/Azure.MySQL.GeoRedundantBackup.md
+++ b/docs/en/rules/Azure.MySQL.GeoRedundantBackup.md
@@ -14,6 +14,24 @@ Azure Database for MySQL should store backups in a geo-redundant storage.
 
 ## DESCRIPTION
 
+### Azure Database for MySQL Flexible Server
+
+Azure Database for MySQL stores multiple copies of your backups so that your data is protected from planned and unplanned events, including transient hardware failures, network or power outages, and massive natural disasters. Azure Database for MySQL provides the flexibility to choose between locally redundant, zone-redundant or geo-redundant backup storage in Basic, General Purpose and Business Critical tiers. By default, Azure Database for MySQL server backup storage is locally redundant for servers with same-zone high availability (HA) or no high availability configuration, and zone redundant for servers with zone-redundant HA configuration.
+
+**Geo-Redundant backup storage**: When the backups are stored in geo-redundant backup storage, multiple copies are not only stored within the region in which your server is hosted, but are also replicated to its geo-paired region. This provides better protection and ability to restore your server in a different region in the event of a disaster. Also this provides at least 99.99999999999999% (16 9's) durability of Backups objects over a given year.One can enable Geo-Redundancy option at server create time to ensure geo-redundant backup storage. Additionally, you can move from locally redundant storage to geo-redundant storage post server create. Geo redundancy is supported for servers hosted in any of the Azure paired regions.
+
+**Note** Zone-redundant High Availability to support zone redundancy is current surfaced as a create time operation only. Currently, for a Zone-redundant High Availability server geo-redundancy can only be enabled/disabled at server create time.
+
+#### Moving from other backup storage options to geo-redundant backup storage
+
+You can move your existing backups storage to geo-redundant storage using the following suggested ways:
+
+- **Moving from locally redundant to geo-redundant backup storage** - In order to move your backup storage from locally redundant storage to geo-redundant storage, you can change the Compute + Storage server configuration from Azure portal to enable Geo-redundancy for the locally redundant source server. Same Zone Redundant HA servers can also be restored as a geo-redundant server in a similar fashion as the underlying backup storage is locally redundant for the same.
+
+- **Moving from zone-redundant to geo-redundant backup storage** - Azure Database for MySQL does not support zone-redundant storage to geo-redundant storage conversion through Compute + Storage settings change or point-in-time restore operation. In order to move your backup storage from zone-redundant storage to geo-redundant storage, creating a new server and migrating the data using dump and restore is the only supported option.
+
+### Azure Database for MySQL Single Server
+
 Azure Database for MySQL provides the flexibility to choose between locally redundant or geo-redundant backup storage in the General Purpose and Memory Optimized tiers. When the backups are stored in geo-redundant backup storage, they are not only stored within the region in which your server is hosted, but are also replicated to a paired data center. This geo-redundancy provides better protection and ability to restore your server in a different region in the event of a disaster. The Basic tier only offers locally redundant backup storage.
 
 **Important** Configuring locally redundant or geo-redundant storage for backup is only allowed during server create. Once the server is provisioned, you cannot change the backup storage redundancy option. In order to move your backup storage from locally redundant storage to geo-redundant storage, creating a new server and migrating the data using dump and restore is the only supported option.
@@ -26,7 +44,44 @@ Configure geo-redundant backup for Azure Database for MySQL.
 
 ### Configure with Azure template
 
-To deploy Azure Database for MySQL servers that pass this rule:
+To deploy Azure Database for MySQL Flexible Servers that pass this rule:
+
+- Set the `properties.backup.geoRedundantBackup` property to the value `'Enabled'`.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.DBforMySQL/flexibleServers",
+  "apiVersion": "2021-12-01-preview",
+  "name": "[parameters('serverName')]",
+  "location": "[parameters('location')]",
+  "sku": {
+    "name": "Standard_D16as",
+    "tier": "GeneralPurpose"
+  },
+  "properties": {
+    "administratorLogin": "[parameters('administratorLogin')]",
+    "administratorLoginPassword": "[parameters('administratorLoginPassword')]",
+    "storage": {
+      "autoGrow": "Enabled",
+      "iops": "[parameters('StorageIops')]",
+      "storageSizeGB": "[parameters('StorageSizeGB')]"
+    },
+    "createMode": "Default",
+    "version": "[parameters('mysqlVersion')]",
+    "backup": {
+      "backupRetentionDays": 7,
+      "geoRedundantBackup": "Enabled"
+    },
+    "highAvailability": {
+      "mode": "Disabled"
+    }
+  }
+}
+```
+
+To deploy Azure Database for MySQL Single Servers that pass this rule:
 
 - Set the `properties.storageProfile.geoRedundantBackup` property to the value `'Enabled'`.
 
@@ -61,7 +116,42 @@ For example:
 
 ### Configure with Bicep
 
-To deploy Azure Database for MySQL servers that pass this rule:
+To deploy Azure Database for MySQL Flexible Servers that pass this rule:
+
+- Set the `properties.backup.geoRedundantBackup` property to the value `'Enabled'`.
+
+For example:
+
+```bicep
+resource mysqlDbServer 'Microsoft.DBforMySQL/flexibleServers@2021-12-01-preview' = {
+  name: serverName
+  location: location
+  sku: {
+    name: 'Standard_D16as'
+    tier: 'GeneralPurpose'
+  }
+  properties: {
+    administratorLogin: administratorLogin
+    administratorLoginPassword: administratorLoginPassword
+    storage: {
+      autoGrow: 'Enabled'
+      iops: StorageIops
+      storageSizeGB: StorageSizeGB
+    }
+    createMode: 'Default'
+    version: mysqlVersion
+    backup: {
+      backupRetentionDays: 7
+      geoRedundantBackup: 'Enabled'
+    }
+    highAvailability: {
+      mode: 'Disabled'
+    }
+  }
+}
+```
+
+To deploy Azure Database for MySQL Single Servers that pass this rule:
 
 - Set the `properties.storageProfile.geoRedundantBackup` property to the value `'Enabled'`.
 
@@ -94,12 +184,14 @@ resource mysqlDbServer 'Microsoft.DBforMySQL/servers@2017-12-01' = {
 
 ## NOTES
 
-This rule is only applicable for Azure Database for MySQL servers deployed in the Single Server deployment model with `'General Purpose'` and `'Memory Optimized'` tiers. The `'Basic'` tier does not support geo-redundant backup storage.
+This rule is applicable for both the Azure Database for MySQL Flexible Server deployment model and the Azure Database for MySQL Single Server deployment model.
 
-Currently this rule does not run against Azure Database for MySQL using the Flexible Server deployment model.
+For the Single Server deployment model, it runs only against `'General Purpose'` and `'Memory Optimized'` tiers. The `'Basic'` tier does not support geo-redundant backup storage.
 
 ## LINKS
 
 - [Target and non-functional requirements](https://learn.microsoft.com/azure/architecture/framework/resiliency/design-requirements)
-- [Backup and restore in Azure Database for MySQL](https://learn.microsoft.com/azure/mysql/single-server/concepts-backup)
-- [Azure template reference](https://learn.microsoft.com/azure/templates/microsoft.dbformysql/servers)
+- [Backup and restore in Azure Database for MySQL flexible servers](https://learn.microsoft.com/azure/mysql/flexible-server/concepts-backup-restore)
+- [Backup and restore in Azure Database for MySQL single servers](https://learn.microsoft.com/azure/mysql/single-server/concepts-backup)
+- [Azure template reference flexible servers](https://learn.microsoft.com/en-us/azure/templates/microsoft.dbforpostgresql/flexibleservers)
+- [Azure template reference single servers](https://learn.microsoft.com/azure/templates/microsoft.dbformysql/servers)

--- a/docs/en/rules/Azure.MySQL.GeoRedundantBackup.md
+++ b/docs/en/rules/Azure.MySQL.GeoRedundantBackup.md
@@ -16,7 +16,7 @@ Azure Database for MySQL should store backups in a geo-redundant storage.
 
 Geo-redundant backup helps to protect your Azure Database for MySQL Servers against outages impacting backup storage in the primary region and allows you to restore your server to the geo-paired region in the event of a disaster.
 
-When the backups are stored in geo-redundant backup storage, they are not only stored within the region in which your server is hosted, but are also replicated to a paired data center. Both the Azure Database for MySQL Flexible Servers and the Azure Database for MySQL Single Servers deployment model supports geo-redundant backup.
+When the backups are stored in geo-redundant backup storage, they are not only stored within the region in which your server is hosted, but are also replicated to a paired data center. Both the Azure Database for MySQL Flexible Server and the Azure Database for MySQL Single Server deployment model supports geo-redundant backup.
 
 For the flexible deployment model the geo-redundant backup is supported for all tiers, but for the single deployment model either `General Purpose` or `Memory Optimized` tier is required.
 

--- a/docs/en/rules/Azure.MySQL.GeoRedundantBackup.md
+++ b/docs/en/rules/Azure.MySQL.GeoRedundantBackup.md
@@ -14,27 +14,13 @@ Azure Database for MySQL should store backups in a geo-redundant storage.
 
 ## DESCRIPTION
 
-### Azure Database for MySQL Flexible Server
+Geo-redundant backup helps to protect your Azure Database for MySQL Servers against outages impacting backup storage in the primary region and allows you to restore your server to the geo-paired region in the event of a disaster.
 
-Azure Database for MySQL stores multiple copies of your backups so that your data is protected from planned and unplanned events, including transient hardware failures, network or power outages, and massive natural disasters. Azure Database for MySQL provides the flexibility to choose between locally redundant, zone-redundant or geo-redundant backup storage in Basic, General Purpose and Business Critical tiers. By default, Azure Database for MySQL server backup storage is locally redundant for servers with same-zone high availability (HA) or no high availability configuration, and zone redundant for servers with zone-redundant HA configuration.
+When the backups are stored in geo-redundant backup storage, they are not only stored within the region in which your server is hosted, but are also replicated to a paired data center. Both the Azure Database for MySQL Flexible Servers and the Azure Database for MySQL Single Servers deployment model supports geo-redundant backup.
 
-**Geo-Redundant backup storage**: When the backups are stored in geo-redundant backup storage, multiple copies are not only stored within the region in which your server is hosted, but are also replicated to its geo-paired region. This provides better protection and ability to restore your server in a different region in the event of a disaster. Also this provides at least 99.99999999999999% (16 9's) durability of Backups objects over a given year.One can enable Geo-Redundancy option at server create time to ensure geo-redundant backup storage. Additionally, you can move from locally redundant storage to geo-redundant storage post server create. Geo redundancy is supported for servers hosted in any of the Azure paired regions.
+For the flexible deployment model the geo-redundant backup is supported for all tiers, but for the single deployment model either `General Purpose` or `Memory Optimized` tier is required.
 
-**Note** Zone-redundant High Availability to support zone redundancy is current surfaced as a create time operation only. Currently, for a Zone-redundant High Availability server geo-redundancy can only be enabled/disabled at server create time.
-
-#### Moving from other backup storage options to geo-redundant backup storage
-
-You can move your existing backups storage to geo-redundant storage using the following suggested ways:
-
-- **Moving from locally redundant to geo-redundant backup storage** - In order to move your backup storage from locally redundant storage to geo-redundant storage, you can change the Compute + Storage server configuration from Azure portal to enable Geo-redundancy for the locally redundant source server. Same Zone Redundant HA servers can also be restored as a geo-redundant server in a similar fashion as the underlying backup storage is locally redundant for the same.
-
-- **Moving from zone-redundant to geo-redundant backup storage** - Azure Database for MySQL does not support zone-redundant storage to geo-redundant storage conversion through Compute + Storage settings change or point-in-time restore operation. In order to move your backup storage from zone-redundant storage to geo-redundant storage, creating a new server and migrating the data using dump and restore is the only supported option.
-
-### Azure Database for MySQL Single Server
-
-Azure Database for MySQL provides the flexibility to choose between locally redundant or geo-redundant backup storage in the General Purpose and Memory Optimized tiers. When the backups are stored in geo-redundant backup storage, they are not only stored within the region in which your server is hosted, but are also replicated to a paired data center. This geo-redundancy provides better protection and ability to restore your server in a different region in the event of a disaster. The Basic tier only offers locally redundant backup storage.
-
-**Important** Configuring locally redundant or geo-redundant storage for backup is only allowed during server create. Once the server is provisioned, you cannot change the backup storage redundancy option. In order to move your backup storage from locally redundant storage to geo-redundant storage, creating a new server and migrating the data using dump and restore is the only supported option.
+Check out the `NOTES` section for more details about geo-redundant backup for each of the deployment models.
 
 ## RECOMMENDATION
 
@@ -193,5 +179,5 @@ For the Single Server deployment model, it runs only against `'General Purpose'`
 - [Target and non-functional requirements](https://learn.microsoft.com/azure/architecture/framework/resiliency/design-requirements)
 - [Backup and restore in Azure Database for MySQL flexible servers](https://learn.microsoft.com/azure/mysql/flexible-server/concepts-backup-restore)
 - [Backup and restore in Azure Database for MySQL single servers](https://learn.microsoft.com/azure/mysql/single-server/concepts-backup)
-- [Azure template reference flexible servers](https://learn.microsoft.com/en-us/azure/templates/microsoft.dbforpostgresql/flexibleservers)
+- [Azure template reference flexible servers](https://learn.microsoft.com/azure/templates/microsoft.dbforpostgresql/flexibleservers)
 - [Azure template reference single servers](https://learn.microsoft.com/azure/templates/microsoft.dbformysql/servers)

--- a/docs/en/rules/Azure.MySQL.GeoRedundantBackup.md
+++ b/docs/en/rules/Azure.MySQL.GeoRedundantBackup.md
@@ -179,5 +179,5 @@ For the Single Server deployment model, it runs only against `'General Purpose'`
 - [Target and non-functional requirements](https://learn.microsoft.com/azure/architecture/framework/resiliency/design-requirements)
 - [Backup and restore in Azure Database for MySQL flexible servers](https://learn.microsoft.com/azure/mysql/flexible-server/concepts-backup-restore)
 - [Backup and restore in Azure Database for MySQL single servers](https://learn.microsoft.com/azure/mysql/single-server/concepts-backup)
-- [Azure template reference flexible servers](https://learn.microsoft.com/azure/templates/microsoft.dbforpostgresql/flexibleservers)
+- [Azure template reference flexible servers](https://learn.microsoft.com/azure/templates/microsoft.dbformysql/flexibleservers)
 - [Azure template reference single servers](https://learn.microsoft.com/azure/templates/microsoft.dbformysql/servers)

--- a/src/PSRule.Rules.Azure/rules/Azure.MySQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.MySQL.Rule.ps1
@@ -9,16 +9,16 @@
 Rule 'Azure.MySQL.FirewallRuleCount' -Ref 'AZR-000133' -Type 'Microsoft.DBforMySQL/servers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $firewallRules = @(GetSubResources -ResourceType 'Microsoft.DBforMySQL/servers/firewallRules');
     $Assert.
-        LessOrEqual($firewallRules, '.', 10).
-        WithReason(($LocalizedData.DBServerFirewallRuleCount -f $firewallRules.Length, 10), $True);
+    LessOrEqual($firewallRules, '.', 10).
+    WithReason(($LocalizedData.DBServerFirewallRuleCount -f $firewallRules.Length, 10), $True);
 }
 
 # Synopsis: Determine if access from Azure services is required
 Rule 'Azure.MySQL.AllowAzureAccess' -Ref 'AZR-000134' -Type 'Microsoft.DBforMySQL/servers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $firewallRules = @(GetSubResources -ResourceType 'Microsoft.DBforMySQL/servers/firewallRules' | Where-Object {
-        $_.ResourceName -eq 'AllowAllWindowsAzureIps' -or
+            $_.ResourceName -eq 'AllowAllWindowsAzureIps' -or
         ($_.properties.startIpAddress -eq '0.0.0.0' -and $_.properties.endIpAddress -eq '0.0.0.0')
-    })
+        })
     $firewallRules.Length -eq 0;
 }
 
@@ -26,8 +26,8 @@ Rule 'Azure.MySQL.AllowAzureAccess' -Ref 'AZR-000134' -Type 'Microsoft.DBforMySQ
 Rule 'Azure.MySQL.FirewallIPRange' -Ref 'AZR-000135' -Type 'Microsoft.DBforMySQL/servers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $summary = GetIPAddressSummary
     $Assert.
-        LessOrEqual($summary, 'Public', 10).
-        WithReason(($LocalizedData.DBServerFirewallPublicIPRange -f $summary.Public, 10), $True);
+    LessOrEqual($summary, 'Public', 10).
+    WithReason(($LocalizedData.DBServerFirewallPublicIPRange -f $summary.Public, 10), $True);
 }
 
 # Synopsis: Azure SQL logical server names should meet naming requirements.
@@ -44,19 +44,30 @@ Rule 'Azure.MySQL.ServerName' -Ref 'AZR-000136' -Type 'Microsoft.DBforMySQL/serv
 }
 
 # Synopsis: Azure Database for MySQL should store backups in a geo-redundant storage.
-Rule 'Azure.MySQL.GeoRedundantBackup' -Ref 'AZR-000323' -Type 'Microsoft.DBforMySQL/servers' -If { HasGeneralPurposeOrMemoryOptimizedTier } -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
-    $Assert.HasFieldValue($TargetObject, 'properties.storageProfile.geoRedundantBackup', 'Enabled').
-    Reason($LocalizedData.MySQLGeoRedundantBackupNotConfigured, $PSRule.TargetName)
+Rule 'Azure.MySQL.GeoRedundantBackup' -Ref 'AZR-000323' -Type 'Microsoft.DBforMySQL/flexibleServers', 'Microsoft.DBforMySQL/servers' -If { HasTierSupportingGeoRedundantBackup } -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+    if ($PSRule.TargetType -eq 'Microsoft.DBforMySQL/flexibleServers') {
+        $Assert.HasFieldValue($TargetObject, 'properties.backup.geoRedundantBackup', 'Enabled').
+        Reason($LocalizedData.MySQLGeoRedundantBackupNotConfigured, $PSRule.TargetName)
+    }
+    elseif ($PSRule.TargetType -eq 'Microsoft.DBforMySQL/servers') {
+        $Assert.HasFieldValue($TargetObject, 'properties.storageProfile.geoRedundantBackup', 'Enabled').
+        Reason($LocalizedData.MySQLGeoRedundantBackupNotConfigured, $PSRule.TargetName)
+    }
 }
 
 #region Helper functions
 
-function global:HasGeneralPurposeOrMemoryOptimizedTier {
+function global:HasTierSupportingGeoRedundantBackup {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param ()
     process {
-        $Assert.In($TargetObject, 'sku.tier', @('GeneralPurpose', 'MemoryOptimized')).Result
+        if ($PSRule.TargetType -eq 'Microsoft.DBforMySQL/flexibleServers') {
+            $True
+        }
+        elseif ($PSRule.TargetType -eq 'Microsoft.DBforMySQL/servers') {
+            $Assert.In($TargetObject, 'sku.tier', @('GeneralPurpose', 'MemoryOptimized')).Result
+        }
     }
 }
 

--- a/src/PSRule.Rules.Azure/rules/Azure.MySQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.MySQL.Rule.ps1
@@ -44,7 +44,7 @@ Rule 'Azure.MySQL.ServerName' -Ref 'AZR-000136' -Type 'Microsoft.DBforMySQL/serv
 }
 
 # Synopsis: Azure Database for MySQL should store backups in a geo-redundant storage.
-Rule 'Azure.MySQL.GeoRedundantBackup' -Ref 'AZR-000323' -Type 'Microsoft.DBforMySQL/flexibleServers', 'Microsoft.DBforMySQL/servers' -If { HasTierSupportingGeoRedundantBackup } -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+Rule 'Azure.MySQL.GeoRedundantBackup' -Ref 'AZR-000323' -Type 'Microsoft.DBforMySQL/flexibleServers', 'Microsoft.DBforMySQL/servers' -If { HasMySQLTierSupportingGeoRedundantBackup } -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
     if ($PSRule.TargetType -eq 'Microsoft.DBforMySQL/flexibleServers') {
         $Assert.HasFieldValue($TargetObject, 'properties.backup.geoRedundantBackup', 'Enabled').
         Reason($LocalizedData.MySQLGeoRedundantBackupNotConfigured, $PSRule.TargetName)
@@ -57,7 +57,7 @@ Rule 'Azure.MySQL.GeoRedundantBackup' -Ref 'AZR-000323' -Type 'Microsoft.DBforMy
 
 #region Helper functions
 
-function global:HasTierSupportingGeoRedundantBackup {
+function global:HasMySQLTierSupportingGeoRedundantBackup {
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param ()

--- a/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
@@ -129,16 +129,18 @@ Describe 'Azure.MySQL' -Tag 'MySql' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'server-A', 'server-B';
+            $ruleResult.TargetName | Should -BeIn 'server-A', 'server-B', 'server-E', 'server-F';
 
             $ruleResult[0].Reason | Should -BeExactly "The Azure Database for MySQL 'server-B' should have geo-redundant backup configured.";
             $ruleResult[1].Reason | Should -BeExactly "The Azure Database for MySQL 'server-A' should have geo-redundant backup configured.";
+            $ruleResult[2].Reason | Should -BeExactly "The Azure Database for MySQL 'server-E' should have geo-redundant backup configured.";
+            $ruleResult[3].Reason | Should -BeExactly "The Azure Database for MySQL 'server-F' should have geo-redundant backup configured.";
            
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'server-C';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'server-C', 'server-D';
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
@@ -128,7 +128,7 @@ Describe 'Azure.MySQL' -Tag 'MySql' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
+            $ruleResult.Length | Should -Be 4;
             $ruleResult.TargetName | Should -BeIn 'server-A', 'server-B', 'server-E', 'server-F';
 
             $ruleResult[0].Reason | Should -BeExactly "The Azure Database for MySQL 'server-B' should have geo-redundant backup configured.";

--- a/tests/PSRule.Rules.Azure.Tests/Resources.MySQL.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.MySQL.json
@@ -243,5 +243,103 @@
     },
     "Tags": null,
     "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DBforMySQL/flexibleServers/server-D",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DBforMySQL/flexibleServers/server-D",
+    "Location": "region",
+    "ResourceName": "server-D",
+    "Name": "server-D",
+    "Properties": {
+      "administratorLogin": "db-admin",
+      "storage": {
+        "autoGrow": "Enabled",
+        "iops": 360,
+        "storageSizeGB": 20
+      },
+      "backup": {
+        "backupRetentionDays": 35,
+        "geoRedundantBackup": "Enabled"
+      },
+      "highAvailability": {
+        "mode": "Disabled"
+      },
+      "version": "'8.0.21",
+      "createMode": "Default"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.DBforMySQL/flexibleServers",
+    "ResourceType": "Microsoft.DBforMySQL/flexibleServers",
+    "Sku": {
+      "Name": "Standard_B8ms",
+      "Tier": "Burstable"
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DBforMySQL/flexibleServers/server-E",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DBforMySQL/flexibleServers/server-E",
+    "Location": "region",
+    "ResourceName": "server-E",
+    "Name": "server-E",
+    "Properties": {
+      "administratorLogin": "db-admin",
+      "storage": {
+        "autoGrow": "Enabled",
+        "iops": 360,
+        "storageSizeGB": 20
+      },
+      "backup": {
+        "backupRetentionDays": 7
+      },
+      "highAvailability": {
+        "mode": "Disabled"
+      },
+      "version": "'8.0.21",
+      "createMode": "Default"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.DBforMySQL/flexibleServers",
+    "ResourceType": "Microsoft.DBforMySQL/flexibleServers",
+    "Sku": {
+      "Name": "Standard_D16ads_v5",
+      "Tier": "GeneralPurpose"
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DBforMySQL/flexibleServers/server-F",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DBforMySQL/flexibleServers/server-F",
+    "Location": "region",
+    "ResourceName": "server-F",
+    "Name": "server-F",
+    "Properties": {
+      "administratorLogin": "db-admin",
+      "storage": {
+        "autoGrow": "Enabled",
+        "iops": 360,
+        "storageSizeGB": 20
+      },
+      "backup": {
+        "backupRetentionDays": 7,
+        "geoRedundantBackup": "Disabled"
+      },
+      "highAvailability": {
+        "mode": "Disabled"
+      },
+      "version": "'8.0.21",
+      "createMode": "Default"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.DBforMySQL/flexibleServers",
+    "ResourceType": "Microsoft.DBforMySQL/flexibleServers",
+    "Sku": {
+      "Name": "E64",
+      "Tier": "MemoryOptimized"
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
   }
 ]

--- a/tests/PSRule.Rules.Azure.Tests/Resources.MySQL.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.MySQL.json
@@ -264,7 +264,7 @@
       "highAvailability": {
         "mode": "Disabled"
       },
-      "version": "'8.0.21",
+      "version": "8.0.21",
       "createMode": "Default"
     },
     "ResourceGroupName": "test-rg",
@@ -296,7 +296,7 @@
       "highAvailability": {
         "mode": "Disabled"
       },
-      "version": "'8.0.21",
+      "version": "8.0.21",
       "createMode": "Default"
     },
     "ResourceGroupName": "test-rg",
@@ -329,7 +329,7 @@
       "highAvailability": {
         "mode": "Disabled"
       },
-      "version": "'8.0.21",
+      "version": "8.0.21",
       "createMode": "Default"
     },
     "ResourceGroupName": "test-rg",


### PR DESCRIPTION
## PR Summary

Fixes #1840 

Added support for the flexible server deployment model in `Azure.MySQL.GeoRedundantBackup` rule.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
