### PR TITLE
Fixed missing support for category groups in Azure.KeyVault.Logs

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+- Bug fixes:
+  - Fixed missing support for diagnostic settings category groups by @bengeset96.
+    [#1873](https://github.com/Azure/PSRule.Rules.Azure/issues/1873)
 - New rules:
   - Azure Database for MariaDB:
     - Check Azure Database for MariaDB servers have Microsoft Defender configured by @bengeset96.

--- a/docs/en/rules/Azure.KeyVault.Logs.md
+++ b/docs/en/rules/Azure.KeyVault.Logs.md
@@ -10,19 +10,23 @@ online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVau
 
 ## SYNOPSIS
 
-Audit and monitor access to Key Vault data.
+Ensure audit diagnostics logs are enabled to audit Key Vault access.
 
 ## DESCRIPTION
 
-To capture access to Key Vault data, diagnostic settings must be configured.
-When configuring diagnostics settings enable access logs.
+To capture logs that record interactions with data or the settings of key vault, diagnostic settings must be configured.
+
+When configuring diagnostics settings, enable one of the following:
+
+- `AuditEvent` category.
+- `audit` category group.
+- `allLogs` category group.
 
 Management operations for Key Vault is captured automatically within Azure Activity Logs.
 
 ## RECOMMENDATION
 
-Consider configuring diagnostic settings to log access for Key Vault data.
-Also consider, storing the access data into Azure Monitor and using Key Vault Analytics.
+Configure audit diagnostics logs to audit Key Vault access.
 
 ## EXAMPLES
 
@@ -30,8 +34,8 @@ Also consider, storing the access data into Azure Monitor and using Key Vault An
 
 To deploy key vaults that pass this rule:
 
-- Deploy a diagnostic settings sub-resource.
-- Enable logging for the `AuditEvent` category.
+- Deploy a diagnostic settings sub-resource (extension resource).
+- Enable `AuditEvent` category or `audit` category group or `allLogs` category group.
 
 For example:
 
@@ -40,7 +44,7 @@ For example:
     "comments": "Create or update a Key Vault.",
     "type": "Microsoft.KeyVault/vaults",
     "name": "[parameters('vaultName')]",
-    "apiVersion": "2019-09-01",
+    "apiVersion": "2022-07-01",
     "location": "[parameters('location')]",
     "properties": {
         "accessPolicies": [],
@@ -55,7 +59,7 @@ For example:
             "comments": "Enable monitoring of Key Vault operations.",
             "type": "Microsoft.KeyVault/vaults/providers/diagnosticSettings",
             "name": "[concat(parameters('vaultName'), '/Microsoft.Insights/service')]",
-            "apiVersion": "2016-09-01",
+            "apiVersion": "2021-05-01-preview",
             "location": "[parameters('location')]",
             "dependsOn": [
                 "[concat('Microsoft.KeyVault/vaults/', parameters('vaultName'))]"
@@ -78,13 +82,13 @@ For example:
 
 To deploy key vaults that pass this rule:
 
-- Deploy a diagnostic settings sub-resource.
-- Enable logging for the `AuditEvent` category.
+- Deploy a diagnostic settings sub-resource (extension resource).
+- Enable `AuditEvent` category or `audit` category group or `allLogs` category group.
 
 For example:
 
 ```bicep
-resource keyVaultResource 'Microsoft.KeyVault/vaults@2019-09-01' = {
+resource keyVaultResource 'Microsoft.KeyVault/vaults@2022-07-01' = {
   name: parmVaultName
   location: parmLocation
   properties: {
@@ -97,7 +101,7 @@ resource keyVaultResource 'Microsoft.KeyVault/vaults@2019-09-01' = {
   }
 }
 
-resource keyVaultInsightsResource 'Microsoft.KeyVault/vaults/providers/diagnosticSettings@2016-09-01' = {
+resource keyVaultInsightsResource 'Microsoft.KeyVault/vaults/providers/diagnosticSettings@2022-05-01-preview' = {
   name: '${parmVaultName}/Microsoft.Insights/service'
   dependsOn: [
     keyVaultResource
@@ -117,8 +121,9 @@ resource keyVaultInsightsResource 'Microsoft.KeyVault/vaults/providers/diagnosti
 
 ## LINKS
 
-- [Best practices to use Key Vault](https://docs.microsoft.com/azure/key-vault/general/best-practices)
-- [Azure Key Vault logging](https://docs.microsoft.com/azure/key-vault/general/logging)
-- [Azure Key Vault security](https://docs.microsoft.com/azure/key-vault/general/security-overview#logging-and-monitoring)
-- [Monitoring your key vault service with Azure Monitor for Key Vault](https://docs.microsoft.com/azure/azure-monitor/insights/key-vault-insights-overview)
 - [Security logs and alerts using Azure services](https://learn.microsoft.com/azure/architecture/framework/security/monitor-logs-alerts)
+- [Best practices to use Key Vault](https://learn.microsoft.com/azure/key-vault/general/best-practices)
+- [Azure Key Vault logging](hhttps://learn.microsoft.com/azure/key-vault/general/logging)
+- [Azure Key Vault security](https://learn.microsoft.com/azure/key-vault/general/security-features#logging-and-monitoring)
+- [Monitoring your Key Vault service with Key Vault insights](https://learn.microsoft.com/azure/key-vault/key-vault-insights-overview)
+- [Template Reference](https://learn.microsoft.com/azure/templates/microsoft.insights/diagnosticsettings)

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -86,4 +86,5 @@
     MariaDBGeoRedundantBackupNotConfigured = "The Azure Database for MariaDB '{0}' should have geo-redundant backup configured."
     PostgreSQLGeoRedundantBackupNotConfigured = "The Azure Database for PostgreSQL '{0}' should have geo-redundant backup configured."
     SQLServerVMDisks = "The virtual machine used for running SQL Server should use Premium disks or greater."
+    KeyVaultAuditDiagnosticSetting = "Minimum one diagnostic setting should have ({0}) configured or category group ({1}) configured."
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.KeyVault.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.KeyVault.Tests.ps1
@@ -93,19 +93,18 @@ Describe 'Azure.KeyVault' -Tag 'KeyVault' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 7;
-            $ruleResult.TargetName | Should -BeIn 'keyvault-B', 'keyvault-C', 'keyvault-D', 'keyvault-E', 'keyvault-F', 'keyvault-G', 'keyvault-H';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'keyvault-B', 'keyvault-C', 'keyvault-D', 'keyvault-E', 'keyvault-G';
 
-            $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[0].Reason | Should -BeExactly "Diagnostic settings is not configured to log events for 'AuditEvent'.";
-            $ruleResult[1].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[1].Reason | Should -BeExactly "Diagnostic settings is not configured to log events for 'AuditEvent'.";
+            $ruleResult[0].Reason | Should -BeExactly "Minimum one diagnostic setting should have (AuditEvent) configured or category group (audit, allLogs) configured.";
+            $ruleResult[1].Reason | Should -BeExactly "Minimum one diagnostic setting should have (AuditEvent) configured or category group (audit, allLogs) configured.";
+            $ruleResult[2].Reason | Should -BeExactly "Minimum one diagnostic setting should have (AuditEvent) configured or category group (audit, allLogs) configured.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'keyvault-A';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'keyvault-A', 'keyvault-F', 'keyvault-H';
         }
 
         It 'Azure.KeyVault.AutoRotationPolicy' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.KeyVault.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.KeyVault.json
@@ -1,631 +1,723 @@
 [
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-A",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-A",
-        "Identity": null,
-        "Kind": null,
-        "Location": "region",
-        "ManagedBy": null,
-        "ResourceName": "keyvault-A",
-        "Name": "keyvault-A",
-        "Properties": {
-            "sku": {
-                "family": "A",
-                "name": "Premium"
-            },
-            "tenantId": "00000000-0000-0000-0000-000000000000",
-            "accessPolicies": [
-                {
-                    "tenantId": "00000000-0000-0000-0000-000000000000",
-                    "objectId": "00000000-0000-0000-0000-000000000000",
-                    "permissions": {
-                        "certificates": [
-                            "Get",
-                            "List"
-                        ],
-                        "keys": [
-                            "Get",
-                            "List"
-                        ],
-                        "secrets": [
-                            "Get",
-                            "List",
-                            "Set"
-                        ]
-                    }
-                }
-            ],
-            "enabledForDeployment": true,
-            "enabledForDiskEncryption": true,
-            "enabledForTemplateDeployment": true,
-            "enableSoftDelete": true,
-            "enablePurgeProtection": true,
-            "vaultUri": "https://keyvault-A.vault.azure.net/",
-            "provisioningState": "Succeeded"
-        },
-        "ResourceGroupName": "rg-test",
-        "Type": "Microsoft.KeyVault/vaults",
-        "ResourceType": "Microsoft.KeyVault/vaults",
-        "Sku": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "resources": [
-            {
-                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-A/providers/microsoft.insights/diagnosticSettings/monitor",
-                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-A/providers/microsoft.insights/diagnosticSettings/monitor",
-                "Identity": null,
-                "Kind": null,
-                "Location": null,
-                "ManagedBy": null,
-                "ResourceName": "monitor",
-                "Name": "monitor",
-                "ExtensionResourceName": "monitor",
-                "Properties": {
-                    "storageAccountId": null,
-                    "serviceBusRuleId": null,
-                    "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
-                    "eventHubAuthorizationRuleId": null,
-                    "eventHubName": null,
-                    "metrics": [
-                        {
-                            "category": "AllMetrics",
-                            "enabled": false,
-                            "retentionPolicy": {
-                                "enabled": false,
-                                "days": 0
-                            }
-                        }
-                    ],
-                    "logs": [
-                        {
-                            "category": "AuditEvent",
-                            "enabled": true,
-                            "retentionPolicy": {
-                                "enabled": false,
-                                "days": 0
-                            }
-                        }
-                    ],
-                    "logAnalyticsDestinationType": null
-                },
-                "ResourceGroupName": "rg-test",
-                "Type": "microsoft.keyvault/vaults",
-                "ResourceType": "microsoft.keyvault/vaults",
-                "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
-                "Sku": null,
-                "Tags": null,
-                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-            }
-        ]
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-A",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-A",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "keyvault-A",
+    "Name": "keyvault-A",
+    "Properties": {
+      "sku": {
+        "family": "A",
+        "name": "Premium"
+      },
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "accessPolicies": [
+        {
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "objectId": "00000000-0000-0000-0000-000000000000",
+          "permissions": {
+            "certificates": ["Get", "List"],
+            "keys": ["Get", "List"],
+            "secrets": ["Get", "List", "Set"]
+          }
+        }
+      ],
+      "enabledForDeployment": true,
+      "enabledForDiskEncryption": true,
+      "enabledForTemplateDeployment": true,
+      "enableSoftDelete": true,
+      "enablePurgeProtection": true,
+      "vaultUri": "https://keyvault-A.vault.azure.net/",
+      "provisioningState": "Succeeded"
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-B",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-B",
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.KeyVault/vaults",
+    "ResourceType": "Microsoft.KeyVault/vaults",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-A/providers/microsoft.insights/diagnosticSettings/monitor",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-A/providers/microsoft.insights/diagnosticSettings/monitor",
         "Identity": null,
         "Kind": null,
-        "Location": "region",
+        "Location": null,
         "ManagedBy": null,
-        "ResourceName": "keyvault-B",
-        "Name": "keyvault-B",
+        "ResourceName": "monitor",
+        "Name": "monitor",
+        "ExtensionResourceName": "monitor",
         "Properties": {
-            "sku": {
-                "family": "A",
-                "name": "Premium"
-            },
-            "tenantId": "00000000-0000-0000-0000-000000000000",
-            "accessPolicies": [
-                {
-                    "tenantId": "00000000-0000-0000-0000-000000000000",
-                    "objectId": "00000000-0000-0000-0000-000000000000",
-                    "permissions": {
-                        "certificates": [
-                            "All"
-                        ],
-                        "keys": [
-                            "All"
-                        ],
-                        "secrets": [
-                            "Get",
-                            "Set",
-                            "List",
-                            "Purge"
-                        ]
-                    }
-                }
-            ],
-            "enabledForDeployment": true,
-            "enabledForDiskEncryption": true,
-            "enabledForTemplateDeployment": true,
-            "enableSoftDelete": false,
-            "vaultUri": "https://keyvault-B.vault.azure.net/",
-            "provisioningState": "Succeeded"
+          "storageAccountId": null,
+          "serviceBusRuleId": null,
+          "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
+          "eventHubAuthorizationRuleId": null,
+          "eventHubName": null,
+          "metrics": [
+            {
+              "category": "AllMetrics",
+              "enabled": false,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logs": [
+            {
+              "category": "AuditEvent",
+              "enabled": true,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logAnalyticsDestinationType": null
         },
         "ResourceGroupName": "rg-test",
-        "Type": "Microsoft.KeyVault/vaults",
-        "ResourceType": "Microsoft.KeyVault/vaults",
+        "Type": "microsoft.keyvault/vaults",
+        "ResourceType": "microsoft.keyvault/vaults",
+        "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
         "Sku": null,
+        "Tags": null,
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-B",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-B",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "keyvault-B",
+    "Name": "keyvault-B",
+    "Properties": {
+      "sku": {
+        "family": "A",
+        "name": "Premium"
+      },
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "accessPolicies": [
+        {
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "objectId": "00000000-0000-0000-0000-000000000000",
+          "permissions": {
+            "certificates": ["All"],
+            "keys": ["All"],
+            "secrets": ["Get", "Set", "List", "Purge"]
+          }
+        }
+      ],
+      "enabledForDeployment": true,
+      "enabledForDiskEncryption": true,
+      "enabledForTemplateDeployment": true,
+      "enableSoftDelete": false,
+      "vaultUri": "https://keyvault-B.vault.azure.net/",
+      "provisioningState": "Succeeded"
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-C",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-C",
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.KeyVault/vaults",
+    "ResourceType": "Microsoft.KeyVault/vaults",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-C",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-C",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "keyvault-C",
+    "Name": "keyvault-C",
+    "Properties": {
+      "sku": {
+        "family": "A",
+        "name": "Premium"
+      },
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "accessPolicies": [],
+      "enabledForDeployment": true,
+      "enabledForDiskEncryption": true,
+      "enabledForTemplateDeployment": true,
+      "enableSoftDelete": true,
+      "enablePurgeProtection": false,
+      "vaultUri": "https://keyvault-C.vault.azure.net/",
+      "provisioningState": "Succeeded"
+    },
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.KeyVault/vaults",
+    "ResourceType": "Microsoft.KeyVault/vaults",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-B/providers/microsoft.insights/diagnosticSettings/monitor",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-B/providers/microsoft.insights/diagnosticSettings/monitor",
         "Identity": null,
         "Kind": null,
-        "Location": "region",
+        "Location": null,
         "ManagedBy": null,
-        "ResourceName": "keyvault-C",
-        "Name": "keyvault-C",
+        "ResourceName": "monitor",
+        "Name": "monitor",
+        "ExtensionResourceName": "monitor",
         "Properties": {
-            "sku": {
-                "family": "A",
-                "name": "Premium"
-            },
-            "tenantId": "00000000-0000-0000-0000-000000000000",
-            "accessPolicies": [],
-            "enabledForDeployment": true,
-            "enabledForDiskEncryption": true,
-            "enabledForTemplateDeployment": true,
-            "enableSoftDelete": true,
-            "enablePurgeProtection": false,
-            "vaultUri": "https://keyvault-C.vault.azure.net/",
-            "provisioningState": "Succeeded"
+          "storageAccountId": null,
+          "serviceBusRuleId": null,
+          "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
+          "eventHubAuthorizationRuleId": null,
+          "eventHubName": null,
+          "metrics": [
+            {
+              "category": "AllMetrics",
+              "enabled": false,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logs": [
+            {
+              "category": "AuditEvent",
+              "enabled": false,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logAnalyticsDestinationType": null
         },
         "ResourceGroupName": "rg-test",
-        "Type": "Microsoft.KeyVault/vaults",
-        "ResourceType": "Microsoft.KeyVault/vaults",
+        "Type": "microsoft.keyvault/vaults",
+        "ResourceType": "microsoft.keyvault/vaults",
+        "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
         "Sku": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "resources": [
-            {
-                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-B/providers/microsoft.insights/diagnosticSettings/monitor",
-                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-B/providers/microsoft.insights/diagnosticSettings/monitor",
-                "Identity": null,
-                "Kind": null,
-                "Location": null,
-                "ManagedBy": null,
-                "ResourceName": "monitor",
-                "Name": "monitor",
-                "ExtensionResourceName": "monitor",
-                "Properties": {
-                    "storageAccountId": null,
-                    "serviceBusRuleId": null,
-                    "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
-                    "eventHubAuthorizationRuleId": null,
-                    "eventHubName": null,
-                    "metrics": [
-                        {
-                            "category": "AllMetrics",
-                            "enabled": false,
-                            "retentionPolicy": {
-                                "enabled": false,
-                                "days": 0
-                            }
-                        }
-                    ],
-                    "logs": [
-                        {
-                            "category": "AuditEvent",
-                            "enabled": false,
-                            "retentionPolicy": {
-                                "enabled": false,
-                                "days": 0
-                            }
-                        }
-                    ],
-                    "logAnalyticsDestinationType": null
-                },
-                "ResourceGroupName": "rg-test",
-                "Type": "microsoft.keyvault/vaults",
-                "ResourceType": "microsoft.keyvault/vaults",
-                "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
-                "Sku": null,
-                "Tags": null,
-                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-            }
-        ]
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-D",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-D",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "keyvault-D",
+    "Name": "keyvault-D",
+    "Properties": {
+      "sku": {
+        "family": "A",
+        "name": "Premium"
+      },
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "accessPolicies": [],
+      "enabledForDeployment": true,
+      "enabledForDiskEncryption": true,
+      "enabledForTemplateDeployment": true,
+      "enableSoftDelete": true,
+      "enablePurgeProtection": true,
+      "vaultUri": "https://keyvault-D.vault.azure.net/",
+      "provisioningState": "Succeeded"
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-D",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-D",
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.KeyVault/vaults",
+    "ResourceType": "Microsoft.KeyVault/vaults",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-B/providers/microsoft.insights/diagnosticSettings/monitor",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-B/providers/microsoft.insights/diagnosticSettings/monitor",
         "Identity": null,
         "Kind": null,
-        "Location": "region",
+        "Location": null,
         "ManagedBy": null,
-        "ResourceName": "keyvault-D",
-        "Name": "keyvault-D",
+        "ResourceName": "monitor",
+        "Name": "monitor",
+        "ExtensionResourceName": "monitor",
         "Properties": {
-            "sku": {
-                "family": "A",
-                "name": "Premium"
-            },
-            "tenantId": "00000000-0000-0000-0000-000000000000",
-            "accessPolicies": [],
-            "enabledForDeployment": true,
-            "enabledForDiskEncryption": true,
-            "enabledForTemplateDeployment": true,
-            "enableSoftDelete": true,
-            "enablePurgeProtection": true,
-            "vaultUri": "https://keyvault-D.vault.azure.net/",
-            "provisioningState": "Succeeded"
+          "storageAccountId": null,
+          "serviceBusRuleId": null,
+          "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
+          "eventHubAuthorizationRuleId": null,
+          "eventHubName": null,
+          "metrics": [
+            {
+              "category": "AllMetrics",
+              "enabled": false,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logAnalyticsDestinationType": null
         },
         "ResourceGroupName": "rg-test",
-        "Type": "Microsoft.KeyVault/vaults",
-        "ResourceType": "Microsoft.KeyVault/vaults",
+        "Type": "microsoft.keyvault/vaults",
+        "ResourceType": "microsoft.keyvault/vaults",
+        "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
         "Sku": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "resources": [
-            {
-                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-B/providers/microsoft.insights/diagnosticSettings/monitor",
-                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-B/providers/microsoft.insights/diagnosticSettings/monitor",
-                "Identity": null,
-                "Kind": null,
-                "Location": null,
-                "ManagedBy": null,
-                "ResourceName": "monitor",
-                "Name": "monitor",
-                "ExtensionResourceName": "monitor",
-                "Properties": {
-                    "storageAccountId": null,
-                    "serviceBusRuleId": null,
-                    "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
-                    "eventHubAuthorizationRuleId": null,
-                    "eventHubName": null,
-                    "metrics": [
-                        {
-                            "category": "AllMetrics",
-                            "enabled": false,
-                            "retentionPolicy": {
-                                "enabled": false,
-                                "days": 0
-                            }
-                        }
-                    ],
-                    "logAnalyticsDestinationType": null
-                },
-                "ResourceGroupName": "rg-test",
-                "Type": "microsoft.keyvault/vaults",
-                "ResourceType": "microsoft.keyvault/vaults",
-                "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
-                "Sku": null,
-                "Tags": null,
-                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-            }
-        ]
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-E",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-E",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "keyvault-E",
+    "Name": "keyvault-E",
+    "Properties": {
+      "sku": {
+        "family": "A",
+        "name": "Premium"
+      },
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "accessPolicies": [],
+      "enabledForDeployment": true,
+      "enabledForDiskEncryption": true,
+      "enabledForTemplateDeployment": true,
+      "enableSoftDelete": true,
+      "enablePurgeProtection": true,
+      "vaultUri": "https://keyvault-E.vault.azure.net/",
+      "provisioningState": "Succeeded"
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-E",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-E",
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.KeyVault/vaults",
+    "ResourceType": "Microsoft.KeyVault/vaults",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-E/providers/microsoft.insights/diagnosticSettings/monitor",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-E/providers/microsoft.insights/diagnosticSettings/monitor",
         "Identity": null,
         "Kind": null,
-        "Location": "region",
+        "Location": null,
         "ManagedBy": null,
-        "ResourceName": "keyvault-E",
-        "Name": "keyvault-E",
+        "ResourceName": "monitor",
+        "Name": "monitor",
+        "ExtensionResourceName": "monitor",
         "Properties": {
-            "sku": {
-                "family": "A",
-                "name": "Premium"
-            },
-            "tenantId": "00000000-0000-0000-0000-000000000000",
-            "accessPolicies": [],
-            "enabledForDeployment": true,
-            "enabledForDiskEncryption": true,
-            "enabledForTemplateDeployment": true,
-            "enableSoftDelete": true,
-            "enablePurgeProtection": true,
-            "vaultUri": "https://keyvault-E.vault.azure.net/",
-            "provisioningState": "Succeeded"
+          "storageAccountId": null,
+          "serviceBusRuleId": null,
+          "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
+          "eventHubAuthorizationRuleId": null,
+          "eventHubName": null,
+          "metrics": [""],
+          "logs": [
+            {
+              "categoryGroup": "audit",
+              "enabled": false,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logAnalyticsDestinationType": null
         },
         "ResourceGroupName": "rg-test",
-        "Type": "Microsoft.KeyVault/vaults",
-        "ResourceType": "Microsoft.KeyVault/vaults",
+        "Type": "microsoft.keyvault/vaults",
+        "ResourceType": "microsoft.keyvault/vaults",
+        "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
         "Sku": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "resources": [
-            {
-                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-B/providers/microsoft.insights/diagnosticSettings/monitor",
-                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-B/providers/microsoft.insights/diagnosticSettings/monitor",
-                "Identity": null,
-                "Kind": null,
-                "Location": null,
-                "ManagedBy": null,
-                "ResourceName": "monitor",
-                "Name": "monitor",
-                "ExtensionResourceName": "monitor",
-                "Properties": {
-                    "storageAccountId": null,
-                    "serviceBusRuleId": null,
-                    "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
-                    "eventHubAuthorizationRuleId": null,
-                    "eventHubName": null,
-                    "metrics": [
-                        {
-                            "category": "AllMetrics",
-                            "enabled": false,
-                            "retentionPolicy": {
-                                "enabled": false,
-                                "days": 0
-                            }
-                        }
-                    ],
-                    "logs": [],
-                    "logAnalyticsDestinationType": null
-                },
-                "ResourceGroupName": "rg-test",
-                "Type": "microsoft.keyvault/vaults",
-                "ResourceType": "microsoft.keyvault/vaults",
-                "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
-                "Sku": null,
-                "Tags": null,
-                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-            }
-        ]
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-F",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-F",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "keyvault-F",
+    "Name": "keyvault-F",
+    "Properties": {
+      "sku": {
+        "family": "A",
+        "name": "Premium"
+      },
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "accessPolicies": [],
+      "enabledForDeployment": true,
+      "enabledForDiskEncryption": true,
+      "enabledForTemplateDeployment": true,
+      "enableSoftDelete": true,
+      "enablePurgeProtection": true,
+      "vaultUri": "https://keyvault-F.vault.azure.net/",
+      "provisioningState": "Succeeded"
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-F",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-F",
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.KeyVault/vaults",
+    "ResourceType": "Microsoft.KeyVault/vaults",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-F/keys/key1",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-F/keys/key1",
         "Identity": null,
         "Kind": null,
-        "Location": "region",
+        "Location": "australiaeast",
         "ManagedBy": null,
-        "ResourceName": "keyvault-F",
-        "Name": "keyvault-F",
+        "ResourceName": "key1",
+        "Name": "key1",
+        "ExtensionResourceName": null,
+        "ParentResource": null,
+        "Plan": null,
         "Properties": {
-            "sku": {
-                "family": "A",
-                "name": "Premium"
-            },
-            "tenantId": "00000000-0000-0000-0000-000000000000",
-            "accessPolicies": [],
-            "enabledForDeployment": true,
-            "enabledForDiskEncryption": true,
-            "enabledForTemplateDeployment": true,
-            "enableSoftDelete": true,
-            "enablePurgeProtection": true,
-            "vaultUri": "https://keyvault-F.vault.azure.net/",
-            "provisioningState": "Succeeded"
+          "attributes": {
+            "enabled": true,
+            "created": 1644675924,
+            "updated": 1644675924,
+            "recoveryLevel": "Recoverable+Purgeable"
+          },
+          "rotationPolicy": {
+            "lifetimeActions": [
+              {
+                "trigger": {
+                  "timeAfterCreate": "P18D"
+                },
+                "action": {
+                  "type": "Rotate"
+                }
+              },
+              {
+                "trigger": {
+                  "timeBeforeExpiry": "P30D"
+                },
+                "action": {
+                  "type": "Notify"
+                }
+              }
+            ],
+            "attributes": {
+              "created": 1644675957,
+              "updated": 1644675957
+            }
+          },
+          "kty": "RSA",
+          "keyOps": [
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey",
+            "encrypt",
+            "decrypt"
+          ],
+          "keySize": 2048,
+          "keyUri": "https://keyvault-F.vault.azure.net/keys/key1",
+          "keyUriWithVersion": "https://keyvault-F.vault.azure.net/keys/key1/00000000000000000000000000000000"
         },
         "ResourceGroupName": "rg-test",
-        "Type": "Microsoft.KeyVault/vaults",
-        "ResourceType": "Microsoft.KeyVault/vaults",
+        "Type": "Microsoft.KeyVault/vaults/keys",
+        "ResourceType": "Microsoft.KeyVault/vaults/keys",
+        "ExtensionResourceType": null,
         "Sku": null,
+        "Tags": {},
+        "TagsTable": null,
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "resources": [
-            {
-                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-F/keys/key1",
-                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-F/keys/key1",
-                "Identity": null,
-                "Kind": null,
-                "Location": "australiaeast",
-                "ManagedBy": null,
-                "ResourceName": "key1",
-                "Name": "key1",
-                "ExtensionResourceName": null,
-                "ParentResource": null,
-                "Plan": null,
-                "Properties": {
-                    "attributes": {
-                        "enabled": true,
-                        "created": 1644675924,
-                        "updated": 1644675924,
-                        "recoveryLevel": "Recoverable+Purgeable"
-                    },
-                    "rotationPolicy": {
-                        "lifetimeActions": [
-                            {
-                                "trigger": {
-                                    "timeAfterCreate": "P18D"
-                                },
-                                "action": {
-                                    "type": "Rotate"
-                                }
-                            },
-                            {
-                                "trigger": {
-                                    "timeBeforeExpiry": "P30D"
-                                },
-                                "action": {
-                                    "type": "Notify"
-                                }
-                            }
-                        ],
-                        "attributes": {
-                            "created": 1644675957,
-                            "updated": 1644675957
-                        }
-                    },
-                    "kty": "RSA",
-                    "keyOps": [
-                        "sign",
-                        "verify",
-                        "wrapKey",
-                        "unwrapKey",
-                        "encrypt",
-                        "decrypt"
-                    ],
-                    "keySize": 2048,
-                    "keyUri": "https://keyvault-F.vault.azure.net/keys/key1",
-                    "keyUriWithVersion": "https://keyvault-F.vault.azure.net/keys/key1/00000000000000000000000000000000"
-                },
-                "ResourceGroupName": "rg-test",
-                "Type": "Microsoft.KeyVault/vaults/keys",
-                "ResourceType": "Microsoft.KeyVault/vaults/keys",
-                "ExtensionResourceType": null,
-                "Sku": null,
-                "Tags": {},
-                "TagsTable": null,
-                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-                "CreatedTime": null,
-                "ChangedTime": null,
-                "ETag": null
-            }
-        ]
-    },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-G",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-G",
+        "CreatedTime": null,
+        "ChangedTime": null,
+        "ETag": null
+      },
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-F/providers/microsoft.insights/diagnosticSettings/monitor",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-F/providers/microsoft.insights/diagnosticSettings/monitor",
         "Identity": null,
         "Kind": null,
-        "Location": "region",
+        "Location": null,
         "ManagedBy": null,
-        "ResourceName": "keyvault-G",
-        "Name": "keyvault-G",
+        "ResourceName": "monitor",
+        "Name": "monitor",
+        "ExtensionResourceName": "monitor",
         "Properties": {
-            "sku": {
-                "family": "A",
-                "name": "Premium"
-            },
-            "tenantId": "00000000-0000-0000-0000-000000000000",
-            "accessPolicies": [],
-            "enabledForDeployment": true,
-            "enabledForDiskEncryption": true,
-            "enabledForTemplateDeployment": true,
-            "enableSoftDelete": true,
-            "enablePurgeProtection": true,
-            "vaultUri": "https://keyvault-G.vault.azure.net/",
-            "provisioningState": "Succeeded"
+          "storageAccountId": null,
+          "serviceBusRuleId": null,
+          "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
+          "eventHubAuthorizationRuleId": null,
+          "eventHubName": null,
+          "metrics": [""],
+          "logs": [
+            {
+              "categoryGroup": "audit",
+              "enabled": true,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logAnalyticsDestinationType": null
         },
         "ResourceGroupName": "rg-test",
-        "Type": "Microsoft.KeyVault/vaults",
-        "ResourceType": "Microsoft.KeyVault/vaults",
+        "Type": "microsoft.keyvault/vaults",
+        "ResourceType": "microsoft.keyvault/vaults",
+        "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
         "Sku": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "resources": [
-            {
-                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-G/keys/key1",
-                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-G/keys/key1",
-                "Identity": null,
-                "Kind": null,
-                "Location": "australiaeast",
-                "ManagedBy": null,
-                "ResourceName": "key1",
-                "Name": "key1",
-                "ExtensionResourceName": null,
-                "ParentResource": null,
-                "Plan": null,
-                "Properties": {
-                    "attributes": {
-                        "enabled": true,
-                        "created": 1644675924,
-                        "updated": 1644675924,
-                        "recoveryLevel": "Recoverable+Purgeable"
-                    },
-                    "rotationPolicy": {
-                        "lifetimeActions": [
-                            {
-                                "trigger": {
-                                    "timeBeforeExpiry": "P30D"
-                                },
-                                "action": {
-                                    "type": "Notify"
-                                }
-                            }
-                        ],
-                        "attributes": {
-                            "created": 1644675957,
-                            "updated": 1644675957
-                        }
-                    },
-                    "kty": "RSA",
-                    "keyOps": [
-                        "sign",
-                        "verify",
-                        "wrapKey",
-                        "unwrapKey",
-                        "encrypt",
-                        "decrypt"
-                    ],
-                    "keySize": 2048,
-                    "keyUri": "https://keyvault-G.vault.azure.net/keys/key1",
-                    "keyUriWithVersion": "https://keyvault-G.vault.azure.net/keys/key1/00000000000000000000000000000000"
-                },
-                "ResourceGroupName": "rg-test",
-                "Type": "Microsoft.KeyVault/vaults/keys",
-                "ResourceType": "Microsoft.KeyVault/vaults/keys",
-                "ExtensionResourceType": null,
-                "Sku": null,
-                "Tags": {},
-                "TagsTable": null,
-                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-                "CreatedTime": null,
-                "ChangedTime": null,
-                "ETag": null
-            }
-        ]
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-G",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-G",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "keyvault-G",
+    "Name": "keyvault-G",
+    "Properties": {
+      "sku": {
+        "family": "A",
+        "name": "Premium"
+      },
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "accessPolicies": [],
+      "enabledForDeployment": true,
+      "enabledForDiskEncryption": true,
+      "enabledForTemplateDeployment": true,
+      "enableSoftDelete": true,
+      "enablePurgeProtection": true,
+      "vaultUri": "https://keyvault-G.vault.azure.net/",
+      "provisioningState": "Succeeded"
     },
-    {
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-H",
-        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-H",
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.KeyVault/vaults",
+    "ResourceType": "Microsoft.KeyVault/vaults",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-G/keys/key1",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-G/keys/key1",
         "Identity": null,
         "Kind": null,
-        "Location": "region",
+        "Location": "australiaeast",
         "ManagedBy": null,
-        "ResourceName": "keyvault-H",
-        "Name": "keyvault-H",
+        "ResourceName": "key1",
+        "Name": "key1",
+        "ExtensionResourceName": null,
+        "ParentResource": null,
+        "Plan": null,
         "Properties": {
-            "sku": {
-                "family": "A",
-                "name": "Premium"
-            },
-            "tenantId": "00000000-0000-0000-0000-000000000000",
-            "accessPolicies": [],
-            "enabledForDeployment": true,
-            "enabledForDiskEncryption": true,
-            "enabledForTemplateDeployment": true,
-            "enableSoftDelete": true,
-            "enablePurgeProtection": true,
-            "vaultUri": "https://keyvault-H.vault.azure.net/",
-            "provisioningState": "Succeeded"
+          "attributes": {
+            "enabled": true,
+            "created": 1644675924,
+            "updated": 1644675924,
+            "recoveryLevel": "Recoverable+Purgeable"
+          },
+          "rotationPolicy": {
+            "lifetimeActions": [
+              {
+                "trigger": {
+                  "timeBeforeExpiry": "P30D"
+                },
+                "action": {
+                  "type": "Notify"
+                }
+              }
+            ],
+            "attributes": {
+              "created": 1644675957,
+              "updated": 1644675957
+            }
+          },
+          "kty": "RSA",
+          "keyOps": [
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey",
+            "encrypt",
+            "decrypt"
+          ],
+          "keySize": 2048,
+          "keyUri": "https://keyvault-G.vault.azure.net/keys/key1",
+          "keyUriWithVersion": "https://keyvault-G.vault.azure.net/keys/key1/00000000000000000000000000000000"
         },
         "ResourceGroupName": "rg-test",
-        "Type": "Microsoft.KeyVault/vaults",
-        "ResourceType": "Microsoft.KeyVault/vaults",
+        "Type": "Microsoft.KeyVault/vaults/keys",
+        "ResourceType": "Microsoft.KeyVault/vaults/keys",
+        "ExtensionResourceType": null,
         "Sku": null,
+        "Tags": {},
+        "TagsTable": null,
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-        "resources": [
+        "CreatedTime": null,
+        "ChangedTime": null,
+        "ETag": null
+      },
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-G/providers/microsoft.insights/diagnosticSettings/monitor",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-G/providers/microsoft.insights/diagnosticSettings/monitor",
+        "Identity": null,
+        "Kind": null,
+        "Location": null,
+        "ManagedBy": null,
+        "ResourceName": "monitor",
+        "Name": "monitor",
+        "ExtensionResourceName": "monitor",
+        "Properties": {
+          "storageAccountId": null,
+          "serviceBusRuleId": null,
+          "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
+          "eventHubAuthorizationRuleId": null,
+          "eventHubName": null,
+          "metrics": [""],
+          "logs": [
             {
-                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-G/keys/key1",
-                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-G/keys/key1",
-                "Identity": null,
-                "Kind": null,
-                "Location": "australiaeast",
-                "ManagedBy": null,
-                "ResourceName": "key1",
-                "Name": "key1",
-                "ExtensionResourceName": null,
-                "ParentResource": null,
-                "Plan": null,
-                "Properties": {
-                    "attributes": {
-                        "enabled": true,
-                        "created": 1644675924,
-                        "updated": 1644675924,
-                        "recoveryLevel": "Recoverable+Purgeable"
-                    },
-                    "kty": "RSA",
-                    "keyOps": [
-                        "sign",
-                        "verify",
-                        "wrapKey",
-                        "unwrapKey",
-                        "encrypt",
-                        "decrypt"
-                    ],
-                    "keySize": 2048,
-                    "keyUri": "https://keyvault-H.vault.azure.net/keys/key1",
-                    "keyUriWithVersion": "https://keyvault-H.vault.azure.net/keys/key1/00000000000000000000000000000000"
-                },
-                "ResourceGroupName": "rg-test",
-                "Type": "Microsoft.KeyVault/vaults/keys",
-                "ResourceType": "Microsoft.KeyVault/vaults/keys",
-                "ExtensionResourceType": null,
-                "Sku": null,
-                "Tags": {},
-                "TagsTable": null,
-                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-                "CreatedTime": null,
-                "ChangedTime": null,
-                "ETag": null
+              "categoryGroup": "allLogs",
+              "enabled": false,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
             }
-        ]
-    }
+          ],
+          "logAnalyticsDestinationType": null
+        },
+        "ResourceGroupName": "rg-test",
+        "Type": "microsoft.keyvault/vaults",
+        "ResourceType": "microsoft.keyvault/vaults",
+        "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+      }
+    ]
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-H",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-H",
+    "Identity": null,
+    "Kind": null,
+    "Location": "region",
+    "ManagedBy": null,
+    "ResourceName": "keyvault-H",
+    "Name": "keyvault-H",
+    "Properties": {
+      "sku": {
+        "family": "A",
+        "name": "Premium"
+      },
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "accessPolicies": [],
+      "enabledForDeployment": true,
+      "enabledForDiskEncryption": true,
+      "enabledForTemplateDeployment": true,
+      "enableSoftDelete": true,
+      "enablePurgeProtection": true,
+      "vaultUri": "https://keyvault-H.vault.azure.net/",
+      "provisioningState": "Succeeded"
+    },
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.KeyVault/vaults",
+    "ResourceType": "Microsoft.KeyVault/vaults",
+    "Sku": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resources": [
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-G/keys/key1",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/keyvault-G/keys/key1",
+        "Identity": null,
+        "Kind": null,
+        "Location": "australiaeast",
+        "ManagedBy": null,
+        "ResourceName": "key1",
+        "Name": "key1",
+        "ExtensionResourceName": null,
+        "ParentResource": null,
+        "Plan": null,
+        "Properties": {
+          "attributes": {
+            "enabled": true,
+            "created": 1644675924,
+            "updated": 1644675924,
+            "recoveryLevel": "Recoverable+Purgeable"
+          },
+          "kty": "RSA",
+          "keyOps": [
+            "sign",
+            "verify",
+            "wrapKey",
+            "unwrapKey",
+            "encrypt",
+            "decrypt"
+          ],
+          "keySize": 2048,
+          "keyUri": "https://keyvault-H.vault.azure.net/keys/key1",
+          "keyUriWithVersion": "https://keyvault-H.vault.azure.net/keys/key1/00000000000000000000000000000000"
+        },
+        "ResourceGroupName": "rg-test",
+        "Type": "Microsoft.KeyVault/vaults/keys",
+        "ResourceType": "Microsoft.KeyVault/vaults/keys",
+        "ExtensionResourceType": null,
+        "Sku": null,
+        "Tags": {},
+        "TagsTable": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "CreatedTime": null,
+        "ChangedTime": null,
+        "ETag": null
+      },
+      {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-H/providers/microsoft.insights/diagnosticSettings/monitor",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.keyvault/vaults/keyvault-H/providers/microsoft.insights/diagnosticSettings/monitor",
+        "Identity": null,
+        "Kind": null,
+        "Location": null,
+        "ManagedBy": null,
+        "ResourceName": "monitor",
+        "Name": "monitor",
+        "ExtensionResourceName": "monitor",
+        "Properties": {
+          "storageAccountId": null,
+          "serviceBusRuleId": null,
+          "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/microsoft.operationalinsights/workspaces/workspace-A",
+          "eventHubAuthorizationRuleId": null,
+          "eventHubName": null,
+          "metrics": [""],
+          "logs": [
+            {
+              "categoryGroup": "allLogs",
+              "enabled": true,
+              "retentionPolicy": {
+                "enabled": false,
+                "days": 0
+              }
+            }
+          ],
+          "logAnalyticsDestinationType": null
+        },
+        "ResourceGroupName": "rg-test",
+        "Type": "microsoft.keyvault/vaults",
+        "ResourceType": "microsoft.keyvault/vaults",
+        "ExtensionResourceType": "microsoft.insights/diagnosticSettings",
+        "Sku": null,
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
## PR Summary

Fixes #1873 

Fixed missing support for category groups in Azure.KeyVault.Logs rule.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
