### PR TITLE
Added Azure Database for MariaDB resources names meet naming requirements

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -26,6 +26,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 - New rules:
   - Azure Database for MariaDB:
+    - Check Azure Database for MariaDB servers, databases, firewall rules and VNET rules names meet naming requirements by @BenjaminEngeset.
+      [#1854](https://github.com/Azure/PSRule.Rules.Azure/issues/1854)
     - Check Azure Database for MariaDB servers only accept encrypted connections by @bengeset96.
       [#1852](https://github.com/Azure/PSRule.Rules.Azure/issues/1852)
     - Check Azure Database for MariaDB servers have Microsoft Defender configured by @bengeset96.

--- a/docs/en/rules/Azure.MariaDB.DatabaseName.md
+++ b/docs/en/rules/Azure.MariaDB.DatabaseName.md
@@ -1,0 +1,36 @@
+---
+severity: Awareness
+pillar: Operational Excellence
+category: Repeatable infrastructure
+resource: Azure Database for MariaDB
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.MariaDB.DatabaseName/
+---
+
+# Use valid database names
+
+## SYNOPSIS
+
+Azure Database for MariaDB databases should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for Azure Database for MariaDB database names are:
+
+- Between 1 and 63 characters long.
+- Alphanumerics and hyphens.
+
+## RECOMMENDATION
+
+Consider using names that meet Azure Database for MariaDB database naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if Azure Database for MariaDB database names are unique.
+
+## LINKS
+
+- [Repeatable infrastructure](https://learn.microsoft.com/azure/architecture/framework/devops/automation-infrastructure)
+- [Naming rules and restrictions Azure Database for MariaDB resources](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb)
+- [Template reference](https://learn.microsoft.com/azure/templates/microsoft.dbformariadb/servers/databases)

--- a/docs/en/rules/Azure.MariaDB.FirewallRuleName.md
+++ b/docs/en/rules/Azure.MariaDB.FirewallRuleName.md
@@ -1,0 +1,36 @@
+---
+severity: Awareness
+pillar: Operational Excellence
+category: Repeatable infrastructure
+resource: Azure Database for MariaDB
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.MariaDB.FirewallRuleName/
+---
+
+# Use valid firewall rule names
+
+## SYNOPSIS
+
+Azure Database for MariaDB firewall rules should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for Azure Database for MariaDB firewall rule names are:
+
+- Between 1 and 128 characters long.
+- Alphanumerics, hyphens, and underscores.
+
+## RECOMMENDATION
+
+Consider using names that meet Azure Database for MariaDB firewall rule naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if Azure Database for MariaDB firewall rule names are unique.
+
+## LINKS
+
+- [Repeatable infrastructure](https://learn.microsoft.com/azure/architecture/framework/devops/automation-infrastructure)
+- [Naming rules and restrictions Azure Database for MariaDB resources](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb)
+- [Template reference](https://learn.microsoft.com/azure/templates/microsoft.dbformariadb/servers/firewallrules)

--- a/docs/en/rules/Azure.MariaDB.ServerName.md
+++ b/docs/en/rules/Azure.MariaDB.ServerName.md
@@ -1,0 +1,38 @@
+---
+severity: Awareness
+pillar: Operational Excellence
+category: Repeatable infrastructure
+resource: Azure Database for MariaDB
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.MariaDB.ServerName/
+---
+
+# Use valid server names
+
+## SYNOPSIS
+
+Azure Database for MariaDB servers should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for Azure Database for MariaDB server names are:
+
+- Between 3 and 63 characters long.
+- Lowercase letters, numbers, and hyphens.
+- Can't start or end with a hyphen.
+- MariaDB server names must be globally unique.
+
+## RECOMMENDATION
+
+Consider using names that meet Azure Database for MariaDB server naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if Azure Database for MariaDB server names are unique.
+
+## LINKS
+
+- [Repeatable infrastructure](https://learn.microsoft.com/azure/architecture/framework/devops/automation-infrastructure)
+- [Naming rules and restrictions Azure Database for MariaDB resources](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb)
+- [Template reference](https://learn.microsoft.com/azure/templates/microsoft.dbformariadb/servers)

--- a/docs/en/rules/Azure.MariaDB.VNETRuleName.md
+++ b/docs/en/rules/Azure.MariaDB.VNETRuleName.md
@@ -1,0 +1,36 @@
+---
+severity: Awareness
+pillar: Operational Excellence
+category: Repeatable infrastructure
+resource: Azure Database for MariaDB
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.MariaDB.VNETRuleName/
+---
+
+# Use valid VNET rule names
+
+## SYNOPSIS
+
+Azure Database for MariaDB VNET rules should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for Azure Database for MariaDB VNET rule names are:
+
+- Between 1 and 128 characters long.
+- Alphanumerics and hyphens.
+
+## RECOMMENDATION
+
+Consider using names that meet Azure Database for MariaDB VNET rule naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if Azure Database for MariaDB VNET rule names are unique.
+
+## LINKS
+
+- [Repeatable infrastructure](https://learn.microsoft.com/azure/architecture/framework/devops/automation-infrastructure)
+- [Naming rules and restrictions Azure Database for MariaDB resources](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb)
+- [Template reference](https://learn.microsoft.com/azure/templates/microsoft.dbformariadb/servers/virtualnetworkrules)

--- a/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.ps1
@@ -53,6 +53,10 @@ Rule 'Azure.MariaDB.DatabaseName' -Ref 'AZR-000337' -Type 'Microsoft.DBforMariaD
     # https://learn.microsoft.com/nb-no/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb
 
     $databases = @(GetMariaDBDatabaseName)
+    if ($databases.Length -eq 0) {
+        $Assert.Pass()
+    }
+
     foreach ($database in $databases) {
         # Between 1 and 63 characters long
         $Assert.GreaterOrEqual($database, '.', 1)
@@ -68,6 +72,10 @@ Rule 'Azure.MariaDB.FirewallRuleName' -Ref 'AZR-000338' -Type 'Microsoft.DBforMa
     # https://learn.microsoft.com/nb-no/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb
 
     $firewallRules = @(GetMariaDBFirewallRuleName)
+    if ($firewallRules.Length -eq 0) {
+        $Assert.Pass()
+    }
+
     foreach ($firewallRule in $firewallRules) {
         # Between 1 and 128 characters long
         $Assert.GreaterOrEqual($firewallRule, '.', 1)
@@ -83,6 +91,9 @@ Rule 'Azure.MariaDB.VNETRuleName' -Ref 'AZR-000339' -Type 'Microsoft.DBforMariaD
     # https://learn.microsoft.com/nb-no/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb
 
     $virtualNetworkRules = @(GetMariaDBVNETRuleName)
+    if ($virtualNetworkRules.Length -eq 0) {
+        $Assert.Pass()
+    }
 
     foreach ($virtualNetworkRule in $virtualNetworkRules) {
         # Between 1 and 128 characters long
@@ -114,10 +125,10 @@ function global:GetMariaDBDatabaseName {
     process {
         if ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers') {
             GetSubResources -ResourceType 'Microsoft.DBforMariaDB/servers/databases' |
-                ForEach-Object { $_.name }
+            ForEach-Object { $_.name }
         }
         elseif ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers/databases') {
-            $TargetObject.TargetName
+            $PSRule.TargetName
         }
     }
 }
@@ -129,10 +140,10 @@ function global:GetMariaDBFirewallRuleName {
     process {
         if ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers') {
             GetSubResources -ResourceType 'Microsoft.DBforMariaDB/servers/firewallRules' |
-                ForEach-Object { $_.name }
+            ForEach-Object { $_.name }
         }
         elseif ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers/firewallRules') {
-            $TargetObject.TargetName
+            $PSRule.TargetName
         }
     }
 }
@@ -144,10 +155,10 @@ function global:GetMariaDBVNETRuleName {
     process {
         if ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers') {
             GetSubResources -ResourceType 'Microsoft.DBforMariaDB/servers/virtualNetworkRules' |
-                ForEach-Object { $_.name }
+            ForEach-Object { $_.name }
         }
         elseif ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers/virtualNetworkRules') {
-            $TargetObject.TargetName
+            $PSRule.TargetName
         }
     }
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.ps1
@@ -35,6 +35,65 @@ Rule 'Azure.MariaDB.UseSSL' -Ref 'AZR-000334' -Type 'Microsoft.DBforMariaDB/serv
     $Assert.HasFieldValue($TargetObject, 'properties.sslEnforcement', 'Enabled').Reason($LocalizedData.MariaDBEncryptedConnection)
 }
 
+# Synopsis: Azure Database for MariaDB servers should meet naming requirements.
+Rule 'Azure.MariaDB.ServerName' -Ref 'AZR-000336' -Type 'Microsoft.DBforMariaDB/servers' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+    # https://learn.microsoft.com/nb-no/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb
+
+    # Between 3 and 63 characters long
+    $Assert.GreaterOrEqual($PSRule, 'TargetName', 3)
+    $Assert.LessOrEqual($PSRule, 'TargetName', 63)
+
+    # Lowercase letters, numbers, and hyphens
+    # Can't start or end with a hyphen
+    $Assert.Match($PSRule, 'TargetName', '^[a-z0-9]([a-z0-9-]*[a-z0-9]){2,62}$', $True)
+}
+
+# Synopsis: Azure Database for MariaDB databases should meet naming requirements.
+Rule 'Azure.MariaDB.DatabaseName' -Ref 'AZR-000337' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/databases' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+    # https://learn.microsoft.com/nb-no/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb
+
+    $databases = @(GetMariaDBDatabaseName)
+    foreach ($database in $databases) {
+        # Between 1 and 63 characters long
+        $Assert.GreaterOrEqual($database, '.', 1)
+        $Assert.LessOrEqual($database, '.', 63)
+
+        # Alphanumerics and hyphens
+        $Assert.Match($database, '.', '^[A-Za-z0-9-]{1,63}$', $True)
+    }
+}
+
+# Synopsis: Azure Database for MariaDB firewall rules should meet naming requirements.
+Rule 'Azure.MariaDB.FirewallRuleName' -Ref 'AZR-000338' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/firewallRules' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+    # https://learn.microsoft.com/nb-no/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb
+
+    $firewallRules = @(GetMariaDBFirewallRuleName)
+    foreach ($firewallRule in $firewallRules) {
+        # Between 1 and 128 characters long
+        $Assert.GreaterOrEqual($firewallRule, '.', 1)
+        $Assert.LessOrEqual($firewallRule, '.', 128)
+
+        # Alphanumerics, hyphens and underscores
+        $Assert.Match($firewallRule, '.', '^[A-Za-z0-9-_]{1,128}$', $True)
+    }
+}
+
+# Synopsis: Azure Database for MariaDB VNET rules should meet naming requirements.
+Rule 'Azure.MariaDB.VNETRuleName' -Ref 'AZR-000339' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/virtualNetworkRules' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+    # https://learn.microsoft.com/nb-no/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb
+
+    $virtualNetworkRules = @(global:GetMariaDBVNETRuleName)
+
+    foreach ($virtualNetworkRule in $virtualNetworkRules) {
+        # Between 1 and 128 characters long
+        $Assert.GreaterOrEqual($virtualNetworkRule, '.', 1)
+        $Assert.LessOrEqual($virtualNetworkRule, '.', 128)
+
+        # Alphanumerics and hyphens
+        $Assert.Match($virtualNetworkRule, '.', '^[A-Za-z0-9-]{1,128}$', $True)
+    }
+}
+
 #endregion Rules
 
 #region Helper functions
@@ -45,6 +104,51 @@ function global:HasMariaDBTierSupportingGeoRedundantBackup {
     param ()
     process {
         $Assert.in($TargetObject, 'sku.tier', @('GeneralPurpose', 'MemoryOptimized')).Result
+    }
+}
+
+function global:GetMariaDBDatabaseName {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param ()
+    process {
+        if ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers') {
+            Get-SubResources -ResourceType 'Microsoft.DBforMariaDB/servers/databases' |
+                ForEach-Object { $_.name }
+        }
+        elseif ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers/databases') {
+            $TargetObject.TargetName
+        }
+    }
+}
+
+function global:GetMariaDBFirewallRuleName {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param ()
+    process {
+        if ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers') {
+            Get-SubResources -ResourceType 'Microsoft.DBforMariaDB/servers/firewallRules' |
+                ForEach-Object { $_.name }
+        }
+        elseif ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers/firewallRules') {
+            $TargetObject.TargetName
+        }
+    }
+}
+
+function global:GetMariaDBVNETRuleName {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param ()
+    process {
+        if ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers') {
+            Get-SubResources -ResourceType 'Microsoft.DBforMariaDB/servers/virtualNetworkRules' |
+                ForEach-Object { $_.name }
+        }
+        elseif ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers/virtualNetworkRules') {
+            $TargetObject.TargetName
+        }
     }
 }
 

--- a/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.ps1
@@ -82,7 +82,7 @@ Rule 'Azure.MariaDB.FirewallRuleName' -Ref 'AZR-000338' -Type 'Microsoft.DBforMa
 Rule 'Azure.MariaDB.VNETRuleName' -Ref 'AZR-000339' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/virtualNetworkRules' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
     # https://learn.microsoft.com/nb-no/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb
 
-    $virtualNetworkRules = @(global:GetMariaDBVNETRuleName)
+    $virtualNetworkRules = @(GetMariaDBVNETRuleName)
 
     foreach ($virtualNetworkRule in $virtualNetworkRules) {
         # Between 1 and 128 characters long
@@ -113,7 +113,7 @@ function global:GetMariaDBDatabaseName {
     param ()
     process {
         if ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers') {
-            Get-SubResources -ResourceType 'Microsoft.DBforMariaDB/servers/databases' |
+            GetSubResources -ResourceType 'Microsoft.DBforMariaDB/servers/databases' |
                 ForEach-Object { $_.name }
         }
         elseif ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers/databases') {
@@ -128,7 +128,7 @@ function global:GetMariaDBFirewallRuleName {
     param ()
     process {
         if ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers') {
-            Get-SubResources -ResourceType 'Microsoft.DBforMariaDB/servers/firewallRules' |
+            GetSubResources -ResourceType 'Microsoft.DBforMariaDB/servers/firewallRules' |
                 ForEach-Object { $_.name }
         }
         elseif ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers/firewallRules') {
@@ -143,7 +143,7 @@ function global:GetMariaDBVNETRuleName {
     param ()
     process {
         if ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers') {
-            Get-SubResources -ResourceType 'Microsoft.DBforMariaDB/servers/virtualNetworkRules' |
+            GetSubResources -ResourceType 'Microsoft.DBforMariaDB/servers/virtualNetworkRules' |
                 ForEach-Object { $_.name }
         }
         elseif ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers/virtualNetworkRules') {

--- a/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.ps1
@@ -40,7 +40,7 @@ Rule 'Azure.MariaDB.MinTLS' -Ref 'AZR-000335' -Type 'Microsoft.DBforMariaDB/serv
     $Assert.HasFieldValue($TargetObject, 'properties.minimalTlsVersion', 'TLS1_2')
 }
 
-Synopsis: Azure Database for MariaDB servers should meet naming requirements.
+# Synopsis: Azure Database for MariaDB servers should meet naming requirements.
 Rule 'Azure.MariaDB.ServerName' -Ref 'AZR-000336' -Type 'Microsoft.DBforMariaDB/servers' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
     # https://learn.microsoft.com/nb-no/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.MariaDB.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.MariaDB.Tests.ps1
@@ -93,4 +93,197 @@ Describe 'Azure.MariaDB' -Tag 'MariaDB' {
             $ruleResult.TargetName | Should -BeIn 'server-C';
         }
     }
+
+    Context 'Resource name - Azure.MariaDB.ServerName' {
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+
+            $testObject = [PSCustomObject]@{
+                Name = ''
+                ResourceType = 'Microsoft.DBforMariaDB/servers'
+            }
+        }
+
+        BeforeDiscovery {
+            $validNames = @(
+                'mariadbserver1'
+                'mariadbserver-1'
+                'mariadbserver'
+            )
+
+            $invalidNames = @(
+                '-mariadbserver1'
+                'mariadbserver1-'
+                'mariadbserver.1'
+                'mariadbserver_1'
+                'MARIADBServer1'
+            )
+        }
+
+        # Pass
+        It '<_>' -ForEach $validNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.MariaDB.ServerName';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Pass';
+        }
+
+        # Fail
+        It '<_>' -ForEach $invalidNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.MariaDB.ServerName';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Fail';
+        }
+    }
+
+    Context 'Resource name - Azure.MariaDB.DatabaseName' {
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+
+            $testObject = [PSCustomObject]@{
+                Name = ''
+                ResourceType = 'Microsoft.DBforMariaDB/servers/databases'
+            }
+        }
+
+        BeforeDiscovery {
+            $validNames = @(
+                'mariadbdatabase1'
+                'MARIADBDATABASE1'
+                'mariadb-DATABASE1'
+                'MARIADB-DATABASE1'
+            )
+
+            $invalidNames = @(
+                '_mariadbdatabase1'
+                'mariadbdatabase1_'
+                'mariadbdatabase.1'
+                'MARIA.DB.DATABASE.1'
+            )
+        }
+
+        # Pass
+        It '<_>' -ForEach $validNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.MariaDB.DatabaseName';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Pass';
+        }
+
+        # Fail
+        It '<_>' -ForEach $invalidNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.MariaDB.DatabaseName';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Fail';
+        }
+    }
+
+    Context 'Resource name - Azure.MariaDB.FirewallRuleName' {
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+
+            $testObject = [PSCustomObject]@{
+                Name = ''
+                ResourceType = 'Microsoft.DBforMariaDB/servers/firewallRules'
+            }
+        }
+
+        BeforeDiscovery {
+            $validNames = @(
+                'rule1'
+                'default'
+                'allowed-developer'
+                'blocked-all'
+                'BLOCKED-ALL'
+            )
+
+            $invalidNames = @(
+                'rule.1'
+                'allowed.developer'
+                'blocked.all'
+                'BLOCKED.ALL'
+            )
+        }
+
+        # Pass
+        It '<_>' -ForEach $validNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.MariaDB.FirewallRuleName';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Pass';
+        }
+
+        # Fail
+        It '<_>' -ForEach $invalidNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.MariaDB.FirewallRuleName';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Fail';
+        }
+    }
+
+    Context 'Resource name - Azure.MariaDB.VNETRuleName' {
+        BeforeAll {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+
+            $testObject = [PSCustomObject]@{
+                Name = ''
+                ResourceType = 'Microsoft.DBforMariaDB/servers/virtualNetworkRules'
+            }
+        }
+
+        BeforeDiscovery {
+            $validNames = @(
+                'AllowSubnet'
+                'Out-Default'
+                'IN-DEFAULT'
+                'AllowPeeredSubnet'
+            )
+
+            $invalidNames = @(
+                'Allow_Subnet'
+                'Allow.Subnet'
+                'OUT_DEFAULT'
+                'Allow_All'
+            )
+        }
+
+        # Pass
+        It '<_>' -ForEach $validNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.MariaDB.VNETRuleName';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Pass';
+        }
+
+        # Fail
+        It '<_>' -ForEach $invalidNames {
+            $testObject.Name = $_;
+            $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.MariaDB.VNETRuleName';
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Outcome | Should -Be 'Fail';
+        }
+    }
 }


### PR DESCRIPTION
## PR Summary

Fixes #1854

Added `Azure.MariaDB.ServerName`, `Azure.MariaDB.DatabaseName`, `MariaDB.FirewallRuleName` and `Azure.MariaDB.VNETRuleName` rule.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
