### PR TITLE
Fixes for policy function handling #1654 #1323

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.22.0-B0062:
+
 - New rules:
   - API Management:
     - Check API management instances uses multi-region deployment by @BenjaminEngeset.
@@ -41,6 +43,10 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
     [#1876](https://github.com/Azure/PSRule.Rules.Azure/issues/1876)
   - Fixed an item with the same key for parameters by @BernieWhite
     [#1871](https://github.com/Azure/PSRule.Rules.Azure/issues/1871)
+  - Fixed policy parse of `requestContext` function by @BernieWhite.
+    [#1654](https://github.com/Azure/PSRule.Rules.Azure/issues/1654)
+  - Fixed handling of policy type field by @BernieWhite.
+    [#1323](https://github.com/Azure/PSRule.Rules.Azure/issues/1323)
 
 ## v1.22.0-B0062 (pre-release)
 

--- a/src/PSRule.Rules.Azure/Common/StringExtensions.cs
+++ b/src/PSRule.Rules.Azure/Common/StringExtensions.cs
@@ -36,6 +36,10 @@ namespace PSRule.Rules.Azure
             return str.Substring(lastSubstringIndex + 1);
         }
 
+        /// <summary>
+        /// Check if the string is an Azure Resource Manager expression.
+        /// Expression use the <c>[function()]</c> syntax.
+        /// </summary>
         internal static bool IsExpressionString(this string str)
         {
             return str != null &&

--- a/src/PSRule.Rules.Azure/Data/ResourceManagerVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/ResourceManagerVisitor.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Rules.Azure.Data
+{
+    /// <summary>
+    /// A base class for all Azure Resource Manager visitors that implement common methods.
+    /// </summary>
+    internal abstract class ResourceManagerVisitor
+    {
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
@@ -222,11 +222,18 @@ namespace PSRule.Rules.Azure.Data.Template
     {
         private readonly Dictionary<string, IFunctionDescriptor> _Descriptors;
 
-        public ExpressionFactory()
+        public ExpressionFactory(bool policy = false)
         {
             _Descriptors = new Dictionary<string, IFunctionDescriptor>(StringComparer.OrdinalIgnoreCase);
-            foreach (var d in Functions.Builtin)
+            foreach (var d in Functions.Common)
                 With(d);
+
+            // Azure policy specific functions should be added
+            if (policy)
+            {
+                foreach (var d in Functions.Policy)
+                    With(d);
+            }
         }
 
         public bool TryDescriptor(string name, out IFunctionDescriptor descriptor)

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -36,7 +36,7 @@ namespace PSRule.Rules.Azure.Data.Template
         private const char SINGLE_QUOTE = '\'';
         private const char DOUBLE_QUOTE = '"';
 
-        internal readonly static IFunctionDescriptor[] Builtin = new IFunctionDescriptor[]
+        internal readonly static IFunctionDescriptor[] Common = new IFunctionDescriptor[]
         {
             // Array and object
             new FunctionDescriptor("array", Array),
@@ -152,6 +152,18 @@ namespace PSRule.Rules.Azure.Data.Template
             new FunctionDescriptor("uri", Uri),
             new FunctionDescriptor("uriComponent", UriComponent),
             new FunctionDescriptor("uriComponentToString", UriComponentToString),
+        };
+
+        /// <summary>
+        /// Functions specific to Azure Policy.
+        /// See <seealso href="https://learn.microsoft.com/azure/governance/policy/concepts/definition-structure#policy-functions">Policy Functions</seealso>.
+        /// </summary>
+        internal readonly static IFunctionDescriptor[] Policy = new IFunctionDescriptor[]
+        {
+            //new FunctionDescriptor("addDays", AddDays),
+            //new FunctionDescriptor("field", Field),
+            //new FunctionDescriptor("requestContext", RequestContext),
+            //new FunctionDescriptor("policy", Policy),
         };
 
         private static readonly CultureInfo AzureCulture = new("en-US");

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -15,6 +15,9 @@ using static PSRule.Rules.Azure.Data.Template.TemplateVisitor;
 
 namespace PSRule.Rules.Azure.Data.Template
 {
+    /// <summary>
+    /// A string expression.
+    /// </summary>
     public delegate T StringExpression<T>();
 
     internal interface IValidationContext
@@ -60,7 +63,7 @@ namespace PSRule.Rules.Azure.Data.Template
     /// <summary>
     /// The base class for a template visitor.
     /// </summary>
-    internal abstract class TemplateVisitor
+    internal abstract class TemplateVisitor : ResourceManagerVisitor
     {
         private const string RESOURCETYPE_DEPLOYMENT = "Microsoft.Resources/deployments";
         private const string DEPLOYMENTSCOPE_INNER = "inner";

--- a/src/PSRule.Rules.Azure/Data/Template/TokenStream.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TokenStream.cs
@@ -1,15 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
 namespace PSRule.Rules.Azure.Data.Template
 {
+    /// <summary>
+    /// The available token types used for Azure Resource Manager expressions.
+    /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "Represents standard type.")]
     public enum ExpressionTokenType : byte
     {
+        /// <summary>
+        /// Null token.
+        /// </summary>
         None,
 
         /// <summary>
@@ -18,7 +25,7 @@ namespace PSRule.Rules.Azure.Data.Template
         Element,
 
         /// <summary>
-        /// A property '.property_name'.
+        /// A property <c>.property_name</c>.
         /// </summary>
         Property,
 
@@ -33,22 +40,22 @@ namespace PSRule.Rules.Azure.Data.Template
         Numeric,
 
         /// <summary>
-        /// Start a grouping '('.
+        /// Start a grouping <c>'('</c>.
         /// </summary>
         GroupStart,
 
         /// <summary>
-        /// End a grouping ')'.
+        /// End a grouping <c>')'</c>.
         /// </summary>
         GroupEnd,
 
         /// <summary>
-        /// Start an index '['.
+        /// Start an index <c>'['</c>.
         /// </summary>
         IndexStart,
 
         /// <summary>
-        /// End an index ']'.
+        /// End an index <c>']'</c>.
         /// </summary>
         IndexEnd
     }
@@ -119,6 +126,53 @@ namespace PSRule.Rules.Azure.Data.Template
         internal static void IndexEnd(this TokenStream stream)
         {
             stream.Add(new ExpressionToken(ExpressionTokenType.IndexEnd, null));
+        }
+
+        internal static bool ConsumeFunction(this TokenStream stream, string name)
+        {
+            if (stream == null ||
+                stream.Count == 0 ||
+                stream.Current.Type != ExpressionTokenType.Element ||
+                !string.Equals(stream.Current.Content, name, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            stream.Pop();
+            return true;
+        }
+
+        internal static bool ConsumePropertyName(this TokenStream stream, string propertyName)
+        {
+            if (stream == null ||
+                stream.Count == 0 ||
+                stream.Current.Type != ExpressionTokenType.Property ||
+                !string.Equals(stream.Current.Content, propertyName, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            stream.Pop();
+            return true;
+        }
+
+        internal static bool ConsumeString(this TokenStream stream, string s)
+        {
+            if (stream == null ||
+                stream.Count == 0 ||
+                stream.Current.Type != ExpressionTokenType.Property ||
+                !string.Equals(stream.Current.Content, s, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            stream.Pop();
+            return true;
+        }
+
+        internal static bool ConsumeGroup(this TokenStream stream)
+        {
+            if (stream == null ||
+                stream.Count == 0 ||
+                stream.Current.Type != ExpressionTokenType.GroupStart)
+                return false;
+
+            stream.SkipGroup();
+            return true;
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Policy.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/Policy.assignment.json
@@ -17496,5 +17496,130 @@
         "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e56962a6-4747-49cd-b67b-bf8b01975c4c"
       }
     ]
+  },
+  {
+    "Identity": null,
+    "Location": null,
+    "Name": "RequestContext",
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/RequestContext",
+    "ResourceName": "CustomAllowedLocations-australiaeast",
+    "ResourceGroupName": null,
+    "ResourceType": "Microsoft.Authorization/policyAssignments",
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "Sku": null,
+    "PolicyAssignmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/RequestContext",
+    "Properties": {
+      "Scope": "/subscriptions/00000000-0000-0000-0000-000000000000",
+      "NotScopes": [],
+      "DisplayName": "RequestContext",
+      "Description": null,
+      "Metadata": {
+        "assignedBy": "Bernie White",
+        "parameterScopes": {
+          "listOfAllowedLocations": "/subscriptions/00000000-0000-0000-0000-000000000000"
+        },
+        "updatedBy": null,
+        "updatedOn": null
+      },
+      "EnforcementMode": 1,
+      "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
+      "Parameters": {
+        "listOfAllowedLocations": {
+          "value": [
+            "australiaeast"
+          ]
+        }
+      }
+    },
+    "PolicyDefinitions": [
+      {
+        "Name": "1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d",
+        "ResourceId": "/providers/Microsoft.Authorization/policyDefinitions/1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d",
+        "ResourceName": "1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d",
+        "ResourceType": "Microsoft.Authorization/policyDefinitions",
+        "SubscriptionId": null,
+        "Properties": {
+          "Description": "Deleting a key vault without soft delete enabled permanently deletes all secrets, keys, and certificates stored in the key vault. Accidental deletion of a key vault can lead to permanent data loss. Soft delete allows you to recover an accidentally deleted key vault for a configurable retention period.",
+          "DisplayName": "Key vaults should have soft delete enabled",
+          "Metadata": {
+            "version": "3.0.0",
+            "category": "Key Vault"
+          },
+          "Mode": "Indexed",
+          "Parameters": {
+            "effect": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Effect",
+                "description": "Enable or disable the execution of the policy"
+              },
+              "allowedValues": [
+                "Audit",
+                "Deny",
+                "Disabled"
+              ],
+              "defaultValue": "Audit"
+            }
+          },
+          "PolicyRule": {
+            "if": {
+              "allOf": [
+                {
+                  "field": "type",
+                  "equals": "Microsoft.KeyVault/vaults"
+                },
+                {
+                  "not": {
+                    "field": "Microsoft.KeyVault/vaults/createMode",
+                    "equals": "recover"
+                  }
+                },
+                {
+                  "anyOf": [
+                    {
+                      "allOf": [
+                        {
+                          "value": "[requestContext().apiVersion]",
+                          "less": "2019-09-01"
+                        },
+                        {
+                          "anyOf": [
+                            {
+                              "field": "Microsoft.KeyVault/vaults/enableSoftDelete",
+                              "equals": "false"
+                            },
+                            {
+                              "field": "Microsoft.KeyVault/vaults/enableSoftDelete",
+                              "exists": "false"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "value": "[requestContext().apiVersion]",
+                          "greaterOrEquals": "2019-09-01"
+                        },
+                        {
+                          "field": "Microsoft.KeyVault/vaults/enableSoftDelete",
+                          "equals": "false"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "then": {
+              "effect": "[parameters('effect')]"
+            }
+          },
+          "PolicyType": 2
+        },
+        "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d"
+      }
+    ]
   }
 ]

--- a/tests/PSRule.Rules.Azure.Tests/PolicyAssignmentVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/PolicyAssignmentVisitorTests.cs
@@ -35,7 +35,7 @@ namespace PSRule.Rules.Azure
 
             var definitions = context.GetDefinitions();
             Assert.NotNull(definitions);
-            Assert.Equal(103, definitions.Length);
+            Assert.Equal(105, definitions.Length);
 
             // Check category and version
             var actual = definitions.FirstOrDefault(definition => definition.DefinitionId == "/providers/Microsoft.Authorization/policyDefinitions/34c877ad-507e-4c82-993e-3452a6e0ad3c");
@@ -73,7 +73,7 @@ namespace PSRule.Rules.Azure
 
             var definitions = context.GetDefinitions();
             Assert.NotNull(definitions);
-            Assert.Equal(102, definitions.Length);
+            Assert.Equal(104, definitions.Length);
 
             // Check category and version
             var actual = definitions.FirstOrDefault(definition => definition.DefinitionId == "/providers/Microsoft.Authorization/policyDefinitions/34c877ad-507e-4c82-993e-3452a6e0ad3c");
@@ -100,6 +100,19 @@ namespace PSRule.Rules.Azure
             var definitions = context.GetDefinitions();
             Assert.NotNull(definitions);
             Assert.Equal(2, definitions.Length);
+        }
+
+        [Fact]
+        public void ConvertRequestContext()
+        {
+            var context = new PolicyAssignmentContext(GetContext());
+            var visitor = new PolicyAssignmentDataExportVisitor();
+            foreach (var assignment in GetAssignmentData().Where(a => a["Name"].Value<string>() == "RequestContext"))
+                visitor.Visit(context, assignment);
+
+            var definitions = context.GetDefinitions();
+            Assert.NotNull(definitions);
+            Assert.Single(definitions);
         }
 
         #region Helper methods


### PR DESCRIPTION
## PR Summary

- Fixed policy parse of `requestContext` function. Working towards #1654, some upstream updates are required for completion.
- Fixed handling of policy type field. Working towards #1323, some upstream updates are required for completion.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
