### PR TITLE
Fixes empty secure parameter #1826 #1886

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.22.0-B0106:
+
+- Bug fixes:
+  - Fixed managed identity flagged as secret by `Azure.Deployment.OutputSecretValue` by @BernieWhite.
+    [#1826](https://github.com/Azure/PSRule.Rules.Azure/issues/1826)
+    [#1886](https://github.com/Azure/PSRule.Rules.Azure/issues/1886)
+
 ## v1.22.0-B0106 (pre-release)
 
 What's changed since pre-release v1.22.0-B0062:

--- a/src/PSRule.Rules.Azure/Common/JsonExtensions.cs
+++ b/src/PSRule.Rules.Azure/Common/JsonExtensions.cs
@@ -366,5 +366,12 @@ namespace PSRule.Rules.Azure
             var value = token.Value<string>();
             return value != null && value.IsExpressionString();
         }
+
+        internal static bool IsEmpty(this JToken value)
+        {
+            return value.Type == JTokenType.None ||
+                value.Type == JTokenType.Null ||
+                (value.Type == JTokenType.String && string.IsNullOrEmpty(value.Value<string>()));
+        }
     }
 }

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -562,7 +562,8 @@ namespace PSRule.Rules.Azure.Data.Template
             /// </summary>
             internal void TrackSecureValue(string name, ParameterType type, object value)
             {
-                if (type != ParameterType.SecureString && type != ParameterType.SecureObject)
+                if (value == null || !(type == ParameterType.SecureString || type == ParameterType.SecureObject) ||
+                    (value is JValue jValue && jValue.IsEmpty()))
                     return;
 
                 _SecureValues.Add(value);

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.7.good.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.7.good.bicep
@@ -1,4 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+@secure()
+param empty string = ''
+
 output value string = 'testing123'
+output emptyOutput string = ''

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.7.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.7.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.6.18.56646",
-      "templateHash": "3587417424638621658"
+      "version": "0.12.40.16777",
+      "templateHash": "4463296209999688608"
     }
   },
   "parameters": {
@@ -62,8 +62,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.6.18.56646",
-              "templateHash": "16765444302131705333"
+              "version": "0.12.40.16777",
+              "templateHash": "7540507475036321031"
             }
           },
           "parameters": {
@@ -105,8 +105,14 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.6.18.56646",
-              "templateHash": "15751681190452431153"
+              "version": "0.12.40.16777",
+              "templateHash": "5419326011865364836"
+            }
+          },
+          "parameters": {
+            "empty": {
+              "type": "secureString",
+              "defaultValue": ""
             }
           },
           "resources": [],
@@ -114,6 +120,10 @@
             "value": {
               "type": "string",
               "value": "testing123"
+            },
+            "emptyOutput": {
+              "type": "string",
+              "value": ""
             }
           }
         }
@@ -127,7 +137,7 @@
     },
     "contentType": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.KeyVault/vaults/secrets', 'vault1', 'secret1')).contentType]"
+      "value": "[reference(resourceId('Microsoft.KeyVault/vaults/secrets', 'vault1', 'secret1'), '2021-10-01').contentType]"
     },
     "secret": {
       "type": "string",
@@ -139,7 +149,7 @@
     },
     "secretFromChild": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'child')).outputs.secretFromParameter.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'child'), '2020-10-01').outputs.secretFromParameter.value]"
     }
   }
 }


### PR DESCRIPTION
## PR Summary

- Fixed managed identity flagged as secret by `Azure.Deployment.OutputSecretValue`.

Fixes #1826 
Fixes #1886 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
