### PR TITLE
Release v1.22.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -31,7 +31,7 @@ Steps to reproduce the issue:
 **Module in use and version:**
 
 - Module: PSRule.Rules.Azure
-- Version: **[e.g. 1.21.2]**
+- Version: **[e.g. 1.22.0]**
 
 Captured output from `$PSVersionTable`:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A suite of rules to validate Azure resources and infrastructure as code (IaC) us
 
 Features of PSRule for Azure include:
 
-- [Ready to go][2] - Leverage over 310 pre-built rules to validate Azure resources.
+- [Ready to go][2] - Leverage over 330 pre-built rules to validate Azure resources.
 - [DevOps][3] - Validate resources and infrastructure code pre or post-deployment.
 - [Cross-platform][4] - Run on MacOS, Linux, and Windows.
 
@@ -97,7 +97,7 @@ jobs:
 
     # STEP 2: Run analysis against exported data
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.5.2
+      uses: microsoft/ps-rule@v2.6.0
       with:
         modules: 'PSRule.Rules.Azure'  # Analyze objects using the rules within the PSRule.Rules.Azure PowerShell module.
 ```

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,91 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.22.0
+
+What's changed since v1.21.2:
+
+- New rules:
+  - API Management:
+    - Check API management instances uses multi-region deployment by @BenjaminEngeset.
+      [#1030](https://github.com/Azure/PSRule.Rules.Azure/issues/1030)
+    - Check api management instances limits control plane API calls to apim with version `'2021-08-01'` or newer by @BenjaminEngeset.
+      [#1819](https://github.com/Azure/PSRule.Rules.Azure/issues/1819)
+  - App Service Environment:
+    - Check app service environments uses version 3 (ASEv3) instead of classic version 1 (ASEv1) and version 2 (ASEv2) by @BenjaminEngeset.
+      [#1805](https://github.com/Azure/PSRule.Rules.Azure/issues/1805)
+  - Azure Database for MariaDB:
+    - Check Azure Database for MariaDB servers, databases, firewall rules and VNET rules names meet naming requirements by @BenjaminEngeset.
+      [#1854](https://github.com/Azure/PSRule.Rules.Azure/issues/1854)
+    - Check Azure Database for MariaDB servers only uses TLS 1.2 version by @BenjaminEngeset.
+      [#1853](https://github.com/Azure/PSRule.Rules.Azure/issues/1853)
+    - Check Azure Database for MariaDB servers only accept encrypted connections by @BenjaminEngeset.
+      [#1852](https://github.com/Azure/PSRule.Rules.Azure/issues/1852)
+    - Check Azure Database for MariaDB servers have Microsoft Defender configured by @BenjaminEngeset.
+      [#1850](https://github.com/Azure/PSRule.Rules.Azure/issues/1850)
+    - Check Azure Database for MariaDB servers have geo-redundant backup configured by @BenjaminEngeset.
+      [#1848](https://github.com/Azure/PSRule.Rules.Azure/issues/1848)
+  - Azure Database for PostgreSQL:
+    - Check Azure Database for PostgreSQL servers have Microsoft Defender configured by @BenjaminEngeset.
+      [#286](https://github.com/Azure/PSRule.Rules.Azure/issues/286)
+    - Check Azure Database for PostgreSQL servers have geo-redundant backup configured by @BenjaminEngeset.
+      [#285](https://github.com/Azure/PSRule.Rules.Azure/issues/285)
+  - Azure Database for MySQL:
+    - Check Azure Database for MySQL servers have Microsoft Defender configured by @BenjaminEngeset.
+      [#287](https://github.com/Azure/PSRule.Rules.Azure/issues/287)
+    - Check Azure Database for MySQL servers uses the flexible deployment model by @BenjaminEngeset.
+      [#1841](https://github.com/Azure/PSRule.Rules.Azure/issues/1841)
+    - Check Azure Database for MySQL Flexible Servers have geo-redundant backup configured by @BenjaminEngeset.
+      [#1840](https://github.com/Azure/PSRule.Rules.Azure/issues/1840)
+    - Check Azure Database for MySQL servers have geo-redundant backup configured by @BenjaminEngeset.
+      [#284](https://github.com/Azure/PSRule.Rules.Azure/issues/284)
+  - Azure Resource Deployments:
+    - Check for nested deployment that are scoped to `outer` and passing secure values by @ms-sambell.
+      [#1475](https://github.com/Azure/PSRule.Rules.Azure/issues/1475)
+    - Check custom script extension uses protected settings for secure values by @ms-sambell.
+      [#1478](https://github.com/Azure/PSRule.Rules.Azure/issues/1478)
+  - Front Door:
+    - Check front door uses caching by @BenjaminEngeset.
+      [#548](https://github.com/Azure/PSRule.Rules.Azure/issues/548)
+  - Virtual Machine:
+    - Check virtual machines running SQL Server uses Premium disks or above by @BenjaminEngeset.
+      [#9](https://github.com/Azure/PSRule.Rules.Azure/issues/9)
+  - Virtual Network:
+    - Check VNETs with a GatewaySubnet also has an AzureFirewallSubnet by @BernieWhite.
+      [#875](https://github.com/Azure/PSRule.Rules.Azure/issues/875)
+- General improvements:
+  - Added debug logging improvements for Bicep expansion by @BernieWhite.
+    [#1901](https://github.com/Azure/PSRule.Rules.Azure/issues/1901)
+- Engineering:
+  - Bump PSRule to v2.6.0.
+    [#1883](https://github.com/Azure/PSRule.Rules.Azure/pull/1883)
+  - Bump Az.Resources to v6.4.1.
+    [#1883](https://github.com/Azure/PSRule.Rules.Azure/pull/1883)
+  - Bump Microsoft.NET.Test.Sdk to v17.4.0
+    [#1838](https://github.com/Azure/PSRule.Rules.Azure/pull/1838)
+  - Bump coverlet.collector to v3.2.0.
+    [#1814](https://github.com/Azure/PSRule.Rules.Azure/pull/1814)
+- Bug fixes:
+  - Fixed ref and name duplicated by @BernieWhite.
+    [#1876](https://github.com/Azure/PSRule.Rules.Azure/issues/1876)
+  - Fixed an item with the same key for parameters by @BernieWhite
+    [#1871](https://github.com/Azure/PSRule.Rules.Azure/issues/1871)
+  - Fixed policy parse of `requestContext` function by @BernieWhite.
+    [#1654](https://github.com/Azure/PSRule.Rules.Azure/issues/1654)
+  - Fixed handling of policy type field by @BernieWhite.
+    [#1323](https://github.com/Azure/PSRule.Rules.Azure/issues/1323)
+  - Fixed `Azure.AppService.WebProbe` with non-boolean value set by @BernieWhite.
+    [#1906](https://github.com/Azure/PSRule.Rules.Azure/issues/1906)
+  - Fixed managed identity flagged as secret by `Azure.Deployment.OutputSecretValue` by @BernieWhite.
+    [#1826](https://github.com/Azure/PSRule.Rules.Azure/issues/1826)
+    [#1886](https://github.com/Azure/PSRule.Rules.Azure/issues/1886)
+  - Fixed missing support for diagnostic settings category groups by @BenjaminEngeset.
+    [#1873](https://github.com/Azure/PSRule.Rules.Azure/issues/1873)
+
+What's changed since pre-release v1.22.0-B0203:
+
+- No additional changes.
+
 ## v1.22.0-B0203 (pre-release)
 
 What's changed since pre-release v1.22.0-B0153:

--- a/docs/creating-your-pipeline.md
+++ b/docs/creating-your-pipeline.md
@@ -32,7 +32,7 @@ Within the root directory of your infrastructure as code repository:
 
         # Analyze Azure resources using PSRule for Azure
         - name: Analyze Azure template files
-          uses: microsoft/ps-rule@v2.5.2
+          uses: microsoft/ps-rule@v2.6.0
           with:
             modules: 'PSRule.Rules.Azure'
     ```
@@ -79,7 +79,7 @@ You can use the `inputPath` parameter to limit the analysis to a specific path.
     ```yaml hl_lines="6"
     # Analyze Azure resources using PSRule for Azure
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.5.2
+      uses: microsoft/ps-rule@v2.6.0
       with:
         modules: 'PSRule.Rules.Azure'
         inputPath: azure/modules/
@@ -110,7 +110,7 @@ See [working with baselines][8] for more information.
     ```yaml hl_lines="6"
     # Analyze Azure resources using PSRule for Azure
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.5.2
+      uses: microsoft/ps-rule@v2.6.0
       with:
         modules: 'PSRule.Rules.Azure'
         baseline: Azure.GA_2022_09
@@ -136,7 +136,7 @@ You can add additional modules to the `modules` parameter by using comma (`,`) s
     ```yaml hl_lines="5"
     # Analyze Azure resources using PSRule for Azure
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.5.2
+      uses: microsoft/ps-rule@v2.6.0
       with:
         modules: 'PSRule.Rules.Azure,PSRule.Monitor'
     ```
@@ -161,7 +161,7 @@ For details on the formats that are supported see [analysis output][9].
     ```yaml hl_lines="6-7"
     # Analyze Azure resources using PSRule for Azure
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.5.2
+      uses: microsoft/ps-rule@v2.6.0
       with:
         modules: 'PSRule.Rules.Azure'
         outputFormat: Sarif

--- a/docs/features.md
+++ b/docs/features.md
@@ -25,7 +25,7 @@ This allows you to explore and learn the context of each WAF principle.
 
 ## Ready to go
 
-PSRule for Azure includes over 310 rules for validating resources against configuration recommendations.
+PSRule for Azure includes over 330 rules for validating resources against configuration recommendations.
 Rules automatically detect and analyze resources from Azure IaC artifacts.
 This allows you to quickly light up unit testing of Azure resources from templates and Bicep deployments.
 

--- a/docs/install-instructions.md
+++ b/docs/install-instructions.md
@@ -24,7 +24,7 @@ Install and use PSRule for Azure with GitHub Actions by referencing the `microso
 
     ```yaml
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.5.2
+      uses: microsoft/ps-rule@v2.6.0
       with:
         modules: 'PSRule.Rules.Azure'
     ```
@@ -35,7 +35,7 @@ Install and use PSRule for Azure with GitHub Actions by referencing the `microso
 
     ```yaml
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.5.2
+      uses: microsoft/ps-rule@v2.6.0
       with:
         modules: 'PSRule.Rules.Azure'
         prerelease: true

--- a/docs/setup/setup-azure-monitor-logs.md
+++ b/docs/setup/setup-azure-monitor-logs.md
@@ -70,7 +70,7 @@ Import analysis results into Azure Monitor with GitHub Actions by:
 
     ```yaml
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.5.2
+      uses: microsoft/ps-rule@v2.6.0
       with:
         modules: PSRule.Rules.Azure,PSRule.Monitor
         conventions: Monitor.LogAnalytics.Import
@@ -86,7 +86,7 @@ Import analysis results into Azure Monitor with GitHub Actions by:
 
     ```yaml
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.5.2
+      uses: microsoft/ps-rule@v2.6.0
       with:
         modules: PSRule.Rules.Azure,PSRule.Monitor
         conventions: Monitor.LogAnalytics.Import

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -156,5 +156,5 @@ For the PSRule GitHub Action, use **>=1.4.0**.
 
 ```yaml
 - name: Run PSRule analysis
-  uses: microsoft/ps-rule@v2.5.2
+  uses: microsoft/ps-rule@v2.6.0
 ```

--- a/docs/using-bicep.md
+++ b/docs/using-bicep.md
@@ -149,7 +149,7 @@ You may need to [configure credentials][4] to access the private registry from a
 
     ```yaml
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.5.2
+      uses: microsoft/ps-rule@v2.6.0
       with:
         modules: PSRule.Rules.Azure,PSRule.Monitor
         conventions: Monitor.LogAnalytics.Import

--- a/docs/working-with-baselines.md
+++ b/docs/working-with-baselines.md
@@ -77,7 +77,7 @@ See [reference][1] for a list baselines shipped with PSRule for Azure.
     ```yaml
     # Analyze Azure resources using PSRule for Azure
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.5.2
+      uses: microsoft/ps-rule@v2.6.0
       with:
         modules: 'PSRule.Rules.Azure'
         baseline: 'Azure.GA_2022_06'

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -316,7 +316,7 @@
                 <div>
                     {% include ".icons/octicons/rocket-24.svg" %}
                     <h3 class="h4 text-brand font-weight-600 mb-3">Ready to go</h3>
-                    <p>Leverage over 310 pre-built rules to test Azure resources.</p>
+                    <p>Leverage over 330 pre-built rules to test Azure resources.</p>
                 </div>
             </a>
             <a class="tile" href="{{ page.next_page.url | url }}#devops" target="_self" rel="noopener">


### PR DESCRIPTION
## PR Summary

What's changed since v1.21.2:

- New rules:
  - API Management:
    - Check API management instances uses multi-region deployment by @BenjaminEngeset.
      [#1030](https://github.com/Azure/PSRule.Rules.Azure/issues/1030)
    - Check api management instances limits control plane API calls to apim with version `'2021-08-01'` or newer by @BenjaminEngeset.
      [#1819](https://github.com/Azure/PSRule.Rules.Azure/issues/1819)
  - App Service Environment:
    - Check app service environments uses version 3 (ASEv3) instead of classic version 1 (ASEv1) and version 2 (ASEv2) by @BenjaminEngeset.
      [#1805](https://github.com/Azure/PSRule.Rules.Azure/issues/1805)
  - Azure Database for MariaDB:
    - Check Azure Database for MariaDB servers, databases, firewall rules and VNET rules names meet naming requirements by @BenjaminEngeset.
      [#1854](https://github.com/Azure/PSRule.Rules.Azure/issues/1854)
    - Check Azure Database for MariaDB servers only uses TLS 1.2 version by @BenjaminEngeset.
      [#1853](https://github.com/Azure/PSRule.Rules.Azure/issues/1853)
    - Check Azure Database for MariaDB servers only accept encrypted connections by @BenjaminEngeset.
      [#1852](https://github.com/Azure/PSRule.Rules.Azure/issues/1852)
    - Check Azure Database for MariaDB servers have Microsoft Defender configured by @BenjaminEngeset.
      [#1850](https://github.com/Azure/PSRule.Rules.Azure/issues/1850)
    - Check Azure Database for MariaDB servers have geo-redundant backup configured by @BenjaminEngeset.
      [#1848](https://github.com/Azure/PSRule.Rules.Azure/issues/1848)
  - Azure Database for PostgreSQL:
    - Check Azure Database for PostgreSQL servers have Microsoft Defender configured by @BenjaminEngeset.
      [#286](https://github.com/Azure/PSRule.Rules.Azure/issues/286)
    - Check Azure Database for PostgreSQL servers have geo-redundant backup configured by @BenjaminEngeset.
      [#285](https://github.com/Azure/PSRule.Rules.Azure/issues/285)
  - Azure Database for MySQL:
    - Check Azure Database for MySQL servers have Microsoft Defender configured by @BenjaminEngeset.
      [#287](https://github.com/Azure/PSRule.Rules.Azure/issues/287)
    - Check Azure Database for MySQL servers uses the flexible deployment model by @BenjaminEngeset.
      [#1841](https://github.com/Azure/PSRule.Rules.Azure/issues/1841)
    - Check Azure Database for MySQL Flexible Servers have geo-redundant backup configured by @BenjaminEngeset.
      [#1840](https://github.com/Azure/PSRule.Rules.Azure/issues/1840)
    - Check Azure Database for MySQL servers have geo-redundant backup configured by @BenjaminEngeset.
      [#284](https://github.com/Azure/PSRule.Rules.Azure/issues/284)
  - Azure Resource Deployments:
    - Check for nested deployment that are scoped to `outer` and passing secure values by @ms-sambell.
      [#1475](https://github.com/Azure/PSRule.Rules.Azure/issues/1475)
    - Check custom script extension uses protected settings for secure values by @ms-sambell.
      [#1478](https://github.com/Azure/PSRule.Rules.Azure/issues/1478)
  - Front Door:
    - Check front door uses caching by @BenjaminEngeset.
      [#548](https://github.com/Azure/PSRule.Rules.Azure/issues/548)
  - Virtual Machine:
    - Check virtual machines running SQL Server uses Premium disks or above by @BenjaminEngeset.
      [#9](https://github.com/Azure/PSRule.Rules.Azure/issues/9)
  - Virtual Network:
    - Check VNETs with a GatewaySubnet also has an AzureFirewallSubnet by @BernieWhite.
      [#875](https://github.com/Azure/PSRule.Rules.Azure/issues/875)
- General improvements:
  - Added debug logging improvements for Bicep expansion by @BernieWhite.
    [#1901](https://github.com/Azure/PSRule.Rules.Azure/issues/1901)
- Engineering:
  - Bump PSRule to v2.6.0.
    [#1883](https://github.com/Azure/PSRule.Rules.Azure/pull/1883)
  - Bump Az.Resources to v6.4.1.
    [#1883](https://github.com/Azure/PSRule.Rules.Azure/pull/1883)
  - Bump Microsoft.NET.Test.Sdk to v17.4.0
    [#1838](https://github.com/Azure/PSRule.Rules.Azure/pull/1838)
  - Bump coverlet.collector to v3.2.0.
    [#1814](https://github.com/Azure/PSRule.Rules.Azure/pull/1814)
- Bug fixes:
  - Fixed ref and name duplicated by @BernieWhite.
    [#1876](https://github.com/Azure/PSRule.Rules.Azure/issues/1876)
  - Fixed an item with the same key for parameters by @BernieWhite
    [#1871](https://github.com/Azure/PSRule.Rules.Azure/issues/1871)
  - Fixed policy parse of `requestContext` function by @BernieWhite.
    [#1654](https://github.com/Azure/PSRule.Rules.Azure/issues/1654)
  - Fixed handling of policy type field by @BernieWhite.
    [#1323](https://github.com/Azure/PSRule.Rules.Azure/issues/1323)
  - Fixed `Azure.AppService.WebProbe` with non-boolean value set by @BernieWhite.
    [#1906](https://github.com/Azure/PSRule.Rules.Azure/issues/1906)
  - Fixed managed identity flagged as secret by `Azure.Deployment.OutputSecretValue` by @BernieWhite.
    [#1826](https://github.com/Azure/PSRule.Rules.Azure/issues/1826)
    [#1886](https://github.com/Azure/PSRule.Rules.Azure/issues/1886)
  - Fixed missing support for diagnostic settings category groups by @BenjaminEngeset.
    [#1873](https://github.com/Azure/PSRule.Rules.Azure/issues/1873)

What's changed since pre-release v1.22.0-B0203:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
