### PR TITLE
Fixes SecureValue with reference function #1882

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,12 +24,18 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.22.1:
+
+- Bug fixes:
+  - Fixed `Azure.Deployment.SecureValue` with `reference` function expression by @BernieWhite.
+    [#1882](https://github.com/Azure/PSRule.Rules.Azure/issues/1882)
+
 ## v1.22.1
 
 What's changed since v1.22.0:
 
 - Bug fixes:
-  - Fixes template parameter does not use the required format by @BernieWhite.
+  - Fixed template parameter does not use the required format by @BernieWhite.
     [#1930](https://github.com/Azure/PSRule.Rules.Azure/issues/1930)
 
 ## v1.22.0

--- a/src/PSRule.Rules.Azure/Data/Template/TokenStreamValidator.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TokenStreamValidator.cs
@@ -16,6 +16,7 @@ namespace PSRule.Rules.Azure.Data.Template
         private const string FN_VARIABLES = "variables";
         private const string FN_IF = "if";
         private const string FN_LISTKEYS = "listKeys";
+        private const string FN_REFERNECE = "reference";
 
         /// <summary>
         /// Look for literal values or use of variables().
@@ -59,7 +60,7 @@ namespace PSRule.Rules.Azure.Data.Template
         }
 
         /// <summary>
-        /// Returns true if it contains a call to the function listKeys.
+        /// Returns true if an expression contains a call to the listKeys function.
         /// </summary>
         public static bool UsesListKeysFunction(TokenStream stream)
         {
@@ -72,11 +73,27 @@ namespace PSRule.Rules.Azure.Data.Template
                 }
 
                 if (IsFunction(token, FN_LISTKEYS))
-                {
                     return true;
-                }
             }
+            return false;
+        }
 
+        /// <summary>
+        /// Returns true if an expression contains a call to the reference function.
+        /// </summary>
+        public static bool UsesReferenceFunction(TokenStream stream)
+        {
+            while (stream.Count > 0)
+            {
+                if (!stream.TryTokenType(ExpressionTokenType.Element, out var token))
+                {
+                    stream.Pop();
+                    continue;
+                }
+
+                if (IsFunction(token, FN_REFERNECE))
+                    return true;
+            }
             return false;
         }
 
@@ -148,7 +165,8 @@ namespace PSRule.Rules.Azure.Data.Template
 
         private static bool IsFunction(ExpressionToken token, string name)
         {
-            return token.Type == ExpressionTokenType.Element && string.Equals(token.Content, name, StringComparison.OrdinalIgnoreCase);
+            return token.Type == ExpressionTokenType.Element &&
+                string.Equals(token.Content, name, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/PSRule.Rules.Azure/Runtime/Helper.cs
+++ b/src/PSRule.Rules.Azure/Runtime/Helper.cs
@@ -48,11 +48,21 @@ namespace PSRule.Rules.Azure.Runtime
         }
 
         /// <summary>
-        /// Returns true if it contains a call to the function listKeys.
+        /// Returns true if an expression contains a call to the listKeys function.
         /// </summary>
         internal static bool UsesListKeysFunction(string expression)
         {
-            return IsTemplateExpression(expression) && TokenStreamValidator.UsesListKeysFunction(ExpressionParser.Parse(expression));
+            return IsTemplateExpression(expression) &&
+                TokenStreamValidator.UsesListKeysFunction(ExpressionParser.Parse(expression));
+        }
+
+        /// <summary>
+        /// Returns true if an expression contains a call to the reference function.
+        /// </summary>
+        internal static bool UsesReferenceFunction(string expression)
+        {
+            return IsTemplateExpression(expression) &&
+                TokenStreamValidator.UsesReferenceFunction(ExpressionParser.Parse(expression));
         }
 
         /// <summary>
@@ -60,18 +70,16 @@ namespace PSRule.Rules.Azure.Runtime
         /// </summary>
         public static bool HasSecureValue(string expression, string[] secureParameters)
         {
-            if ((!string.IsNullOrEmpty(expression) && expression.StartsWith("{{Secret", StringComparison.OrdinalIgnoreCase)) || UsesListKeysFunction(expression))
-            {
+            if ((!string.IsNullOrEmpty(expression) && expression.StartsWith("{{Secret", StringComparison.OrdinalIgnoreCase)) ||
+                UsesListKeysFunction(expression) ||
+                UsesReferenceFunction(expression))
                 return true;
-            }
-            else
-            {
-                var parameterNamesInExpression = GetParameterTokenValue(expression);
 
-                return parameterNamesInExpression != null &&
-                parameterNamesInExpression.Length > 0 &&
-                parameterNamesInExpression.Intersect(secureParameters, StringComparer.OrdinalIgnoreCase).Count() == parameterNamesInExpression.Length;
-            }
+            var parameterNamesInExpression = GetParameterTokenValue(expression);
+
+            return parameterNamesInExpression != null &&
+            parameterNamesInExpression.Length > 0 &&
+            parameterNamesInExpression.Intersect(secureParameters, StringComparer.OrdinalIgnoreCase).Count() == parameterNamesInExpression.Length;
         }
 
         /// <summary>

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Deployment.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Deployment.Tests.ps1
@@ -71,9 +71,9 @@ Describe 'Azure.Deployment' -Tag 'Deployment' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
+            $ruleResult.Length | Should -Be 3;
             $targetNames = $ruleResult | ForEach-Object { $_.TargetObject.name };
-            $targetNames | Should -BeIn 'secret_good', 'streaming_jobs_good';
+            $targetNames | Should -BeIn 'secret_good', 'streaming_jobs_good', 'reference_good';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.9.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.9.bicep
@@ -33,3 +33,7 @@ module streaming_jobs_bad 'Tests.Bicep.9.badStreamingJobs.bicep' = {
     notSecret: ''
   }
 }
+
+module secret_goodreference 'Tests.Bicep.9.goodReference.bicep' = {
+  name: 'reference_good'
+}

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.9.goodReference.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.9.goodReference.bicep
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+param appInsightsName string = 'app-insights'
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+  name: appInsightsName
+}
+resource goodSecretReference 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: 'keyvault/good'
+  properties: {
+    value: appInsights.properties.InstrumentationKey
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.9.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.9.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.11.1.770",
-      "templateHash": "13697280230530537471"
+      "version": "0.13.1.58284",
+      "templateHash": "8685448171369407541"
     }
   },
   "resources": [
@@ -29,8 +29,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.11.1.770",
-              "templateHash": "16259778108278407670"
+              "version": "0.13.1.58284",
+              "templateHash": "3563517143203947158"
             }
           },
           "parameters": {
@@ -71,8 +71,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.11.1.770",
-              "templateHash": "17528568844097414113"
+              "version": "0.13.1.58284",
+              "templateHash": "13907904796621207265"
             }
           },
           "parameters": {
@@ -121,8 +121,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.11.1.770",
-              "templateHash": "12671604694843835576"
+              "version": "0.13.1.58284",
+              "templateHash": "1243191437263886583"
             }
           },
           "parameters": {
@@ -217,8 +217,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.11.1.770",
-              "templateHash": "10641783441846165654"
+              "version": "0.13.1.58284",
+              "templateHash": "14384591199981266606"
             }
           },
           "parameters": {
@@ -259,6 +259,44 @@
                     }
                   }
                 ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "reference_good",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.13.1.58284",
+              "templateHash": "9418583989023446705"
+            }
+          },
+          "parameters": {
+            "appInsightsName": {
+              "type": "string",
+              "defaultValue": "app-insights"
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2022-07-01",
+              "name": "keyvault/good",
+              "properties": {
+                "value": "[reference(resourceId('Microsoft.Insights/components', parameters('appInsightsName')), '2020-02-02').InstrumentationKey]"
               }
             }
           ]

--- a/tests/PSRule.Rules.Azure.Tests/TokenStreamValidatorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TokenStreamValidatorTests.cs
@@ -52,6 +52,7 @@ namespace PSRule.Rules.Azure
             Assert.False(Helper.HasSecureValue("[if(true(), parameters('notSecure'), parameters('adminPassword'))]", secureParameters));
             Assert.True(Helper.HasSecureValue("[listKeys(resourceId('Microsoft.Storage/storageAccounts', 'aStorageAccount'), '2021-09-01').keys[0].value]", secureParameters));
             Assert.True(Helper.HasSecureValue("{{SecretReference aName}}", secureParameters));
+            Assert.True(Helper.HasSecureValue("[reference(resourceId('Microsoft.Insights/components', parameters('appInsightsName')), '2020-02-02').InstrumentationKey]", secureParameters));
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.Deployment.SecureValue` with `reference` function expression.

Fixes #1882 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
