### PR TITLE
Add supports tag selector for indexed mode #1946

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -36,6 +36,9 @@ What's changed since pre-release v1.23.0-B0046:
     - Updated `Azure.AKS.Version` to use latest stable version `1.25.4` by @BernieWhite.
       [#1960](https://github.com/Azure/PSRule.Rules.Azure/issues/1960)
       - Use `AZURE_AKS_CLUSTER_MINIMUM_VERSION` to configure the minimum version of the cluster.
+- General improvements:
+  - Improves handling for policy definition modes by using support tags selector by @BernieWhite.
+    [#1946](https://github.com/Azure/PSRule.Rules.Azure/issues/1946)
 - Engineering:
   - Bump Microsoft.NET.Test.Sdk v17.4.1.
     [#1964](https://github.com/Azure/PSRule.Rules.Azure/pull/1964)

--- a/src/PSRule.Rules.Azure/Data/Policy/Models.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/Models.cs
@@ -108,6 +108,11 @@ namespace PSRule.Rules.Azure.Data.Policy
         public JObject Where { get; set; }
 
         /// <summary>
+        /// The spec with pre-condition for the rule.
+        /// </summary>
+        public string[] With { get; set; }
+
+        /// <summary>
         /// The spec type pre-condition for the rule.
         /// </summary>
         public List<string> Types { get; }

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyJsonRuleMapper.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyJsonRuleMapper.cs
@@ -22,6 +22,7 @@ namespace PSRule.Rules.Azure.Data.Policy
         private const string PROPERTY_SPEC = "spec";
         private const string PROPERTY_CONDITION = "condition";
         private const string PROPERTY_WHERE = "where";
+        private const string PROPERTY_WITH = "with";
         private const string PROPERTY_TYPE = "type";
         private const string PROPERTY_TAGS = "tags";
         private const string PROPERTY_ANNOTATIONS = "annotations";
@@ -57,6 +58,7 @@ namespace PSRule.Rules.Azure.Data.Policy
             writer.WritePropertyName(PROPERTY_SPEC);
             writer.WriteStartObject();
             WriteType(writer, serializer, definition);
+            WriteWith(writer, serializer, definition);
             WriteWhere(writer, serializer, definition);
             WriteCondition(writer, serializer, definition);
             writer.WriteEndObject();
@@ -87,6 +89,18 @@ namespace PSRule.Rules.Azure.Data.Policy
 
             writer.WritePropertyName(PROPERTY_WHERE);
             serializer.Serialize(writer, definition.Where);
+        }
+
+        /// <summary>
+        /// Emit selector pre-condition.
+        /// </summary>
+        private static void WriteWith(JsonWriter writer, JsonSerializer serializer, PolicyDefinition definition)
+        {
+            if (definition.With == null)
+                return;
+
+            writer.WritePropertyName(PROPERTY_WITH);
+            serializer.Serialize(writer, definition.With);
         }
 
         private static void WriteCondition(JsonWriter writer, JsonSerializer serializer, PolicyDefinition definition)

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyMode.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyMode.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Rules.Azure.Data.Policy
+{
+    /// <summary>
+    /// A list of supported policy modes.
+    /// </summary>
+    internal enum PolicyMode
+    {
+        None = 0,
+
+        All,
+
+        Indexed
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/PolicyAssignmentVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/PolicyAssignmentVisitorTests.cs
@@ -47,6 +47,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("Microsoft.Storage/storageAccounts", actual.Types[0]);
             Assert.Null(actual.Where);
             Assert.Equal("{\"allOf\":[{\"equals\":\"Microsoft.Storage/storageAccounts\",\"type\":\".\"},{\"field\":\"properties.networkAcls.defaultAction\",\"notEquals\":\"Deny\"}]}", actual.Condition.ToString(Formatting.None));
+            Assert.Equal(new string[] { "PSRule.Rules.Azure\\Azure.Resource.SupportsTags" }, actual.With);
         }
 
         [Fact]

--- a/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesData.jsonc
+++ b/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesData.jsonc
@@ -17,6 +17,9 @@
       "type": [
         "Microsoft.Storage/storageAccounts"
       ],
+      "with": [
+        "PSRule.Rules.Azure\\Azure.Resource.SupportsTags"
+      ],
       "condition": {
         "allOf": [
           {
@@ -48,6 +51,9 @@
     "spec": {
       "type": [
         "Microsoft.Compute/virtualMachines"
+      ],
+      "with": [
+        "PSRule.Rules.Azure\\Azure.Resource.SupportsTags"
       ],
       "where": {
         "allOf": [
@@ -350,6 +356,9 @@
     "spec": {
       "type": [
         "Microsoft.Web/sites"
+      ],
+      "with": [
+        "PSRule.Rules.Azure\\Azure.Resource.SupportsTags"
       ],
       "where": {
         "allOf": [

--- a/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesPrefixData.jsonc
+++ b/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesPrefixData.jsonc
@@ -14,6 +14,9 @@
       }
     },
     "spec": {
+      "with": [
+        "PSRule.Rules.Azure\\Azure.Resource.SupportsTags"
+      ],
       "condition": {
         "allOf": [
           {


### PR DESCRIPTION
## PR Summary

- Improves handling for policy definition modes by using support tags selector.

Fixes #1946 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
