### PR TITLE
Pre-release v1.23.0-B0072

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.23.0-B0072 (pre-release)
+
 What's changed since pre-release v1.23.0-B0046:
 
 - New features:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.23.0-B0046:

- New features:
  - Added December 2022 baselines `Azure.GA_2022_12` and `Azure.Preview_2022_12` by @BernieWhite.
    [#1961](https://github.com/Azure/PSRule.Rules.Azure/issues/1961)
    - Includes rules released before or during December 2022.
    - Marked `Azure.GA_2022_09` and `Azure.Preview_2022_09` baselines as obsolete.
- Updated rules:
  - Azure Kubernetes Service:
    - Updated `Azure.AKS.Version` to use latest stable version `1.25.4` by @BernieWhite.
      [#1960](https://github.com/Azure/PSRule.Rules.Azure/issues/1960)
      - Use `AZURE_AKS_CLUSTER_MINIMUM_VERSION` to configure the minimum version of the cluster.
- General improvements:
  - Improves handling for policy definition modes by using support tags selector by @BernieWhite.
    [#1946](https://github.com/Azure/PSRule.Rules.Azure/issues/1946)
- Engineering:
  - Bump Microsoft.NET.Test.Sdk v17.4.1.
    [#1964](https://github.com/Azure/PSRule.Rules.Azure/pull/1964)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
