### PR TITLE
Pre-release v1.24.0-B0013

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.24.0-B0013 (pre-release)
+
 What's changed since v1.23.0:
 
 - General improvements:


### PR DESCRIPTION
## PR Summary

What's changed since v1.23.0:

- General improvements:
  - Updated `Export-AzRuleData` to improve export performance by @BernieWhite.
    [#1341](https://github.com/Azure/PSRule.Rules.Azure/issues/1341)
    - Removed `Az.Resources` dependency.
    - Added async threading for export concurrency.
    - Improved performance by using automatic look up of API versions by using provider cache.
- Engineering:
  - Bump PSRule to v2.7.0.
    [#1973](https://github.com/Azure/PSRule.Rules.Azure/pull/1973)
  - Bump Az.Resources to v6.5.1.
    [#1973](https://github.com/Azure/PSRule.Rules.Azure/pull/1973)
  - Bump Newtonsoft.Json to v13.0.2.
    [#1903](https://github.com/Azure/PSRule.Rules.Azure/pull/1903)
  - Bump Pester to v5.4.0.
    [#1994](https://github.com/Azure/PSRule.Rules.Azure/pull/1994)
- Bug fixes:
  - Fixed `Export-AzRuleData` may not export all data if throttled by @BernieWhite.
    [#1341](https://github.com/Azure/PSRule.Rules.Azure/issues/1341)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
