### PR TITLE
Added support for Bicep lambda functions #1536

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -26,6 +26,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v1.24.0-B0013:
 
+- General improvements:
+  - Added support for Bicep lambda functions by @BernieWhite.
+    [#1536](https://github.com/Azure/PSRule.Rules.Azure/issues/1536)
+    - Bicep `filter`, `map`, `reduce`, and `sort` are supported.
+    - Support for `flatten` was previously added in v1.23.0.
 - Engineering:
   - Updated resource providers and policy aliases.
     [#1736](https://github.com/Azure/PSRule.Rules.Azure/pull/1736)

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
@@ -638,6 +638,12 @@ namespace PSRule.Rules.Azure.Data.Policy
             {
                 return _PolicyIgnore.Contains(definitionId);
             }
+
+            /// <inheritdoc/>
+            public bool TryLambdaVariable(string variableName, out object value)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         internal void Visit(PolicyAssignmentContext context, JObject assignment)

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -153,6 +153,14 @@ namespace PSRule.Rules.Azure.Data.Template
             new FunctionDescriptor("uri", Uri),
             new FunctionDescriptor("uriComponent", UriComponent),
             new FunctionDescriptor("uriComponentToString", UriComponentToString),
+
+            // Lambda
+            new FunctionDescriptor("filter", Filter, delayBinding: true),
+            new FunctionDescriptor("map", Map, delayBinding: true),
+            new FunctionDescriptor("reduce", Reduce, delayBinding: true),
+            new FunctionDescriptor("sort", Sort, delayBinding: true),
+            new FunctionDescriptor("lambda", Lambda, delayBinding: true),
+            new FunctionDescriptor("lambdaVariables", LambdaVariables, delayBinding: true),
         };
 
         /// <summary>
@@ -359,7 +367,7 @@ namespace PSRule.Rules.Azure.Data.Template
         /// flatten(arrayToFlatten)
         /// </summary>
         /// <remarks>
-        /// https://learn.microsoft.com/azure/azure-resource-manager/bicep/bicep-functions-array#flatten
+        /// See <seealso href="https://learn.microsoft.com/azure/azure-resource-manager/bicep/bicep-functions-array#flatten"/>.
         /// </remarks>
         internal static object Flatten(ITemplateContext context, object[] args)
         {
@@ -1786,6 +1794,126 @@ namespace PSRule.Rules.Azure.Data.Template
         }
 
         #endregion String
+
+        #region Lambda
+
+        /// <summary>
+        /// filter(inputArray, lambda expression)
+        /// </summary>
+        /// <remarks>
+        /// See <seealso href="https://learn.microsoft.com/azure/azure-resource-manager/bicep/bicep-functions-lambda#filter"/>.
+        /// </remarks>
+        internal static object Filter(ITemplateContext context, object[] args)
+        {
+            if (CountArgs(args) != 2)
+                throw ArgumentsOutOfRange(nameof(Filter), args);
+
+            args[0] = GetExpression(context, args[0]);
+            if (!ExpressionHelpers.TryArray(args[0], out var inputArray))
+                throw ArgumentFormatInvalid(nameof(Filter));
+
+            args[1] = GetExpression(context, args[1]);
+            if (args[1] is not LambdaExpressionFn lambda)
+                throw ArgumentFormatInvalid(nameof(Filter));
+
+            return lambda.Filter(context, inputArray.OfType<object>().ToArray());
+        }
+
+        /// <summary>
+        /// map(inputArray, lambda expression)
+        /// </summary>
+        /// <remarks>
+        /// See <seealso href="https://learn.microsoft.com/azure/azure-resource-manager/bicep/bicep-functions-lambda#map"/>.
+        /// </remarks>
+        internal static object Map(ITemplateContext context, object[] args)
+        {
+            if (CountArgs(args) != 2)
+                throw ArgumentsOutOfRange(nameof(Map), args);
+
+            args[0] = GetExpression(context, args[0]);
+            if (!ExpressionHelpers.TryArray(args[0], out var inputArray))
+                throw ArgumentFormatInvalid(nameof(Map));
+
+            args[1] = GetExpression(context, args[1]);
+            if (args[1] is not LambdaExpressionFn lambda)
+                throw ArgumentFormatInvalid(nameof(Map));
+
+            return lambda.Map(context, inputArray.OfType<object>().ToArray());
+        }
+
+        /// <summary>
+        /// reduce(inputArray, initialValue, lambda expression)
+        /// </summary>
+        /// <remarks>
+        /// See <seealso href="https://learn.microsoft.com/azure/azure-resource-manager/bicep/bicep-functions-lambda#reduce"/>.
+        /// </remarks>
+        internal static object Reduce(ITemplateContext context, object[] args)
+        {
+            if (CountArgs(args) != 3)
+                throw ArgumentsOutOfRange(nameof(Reduce), args);
+
+            args[0] = GetExpression(context, args[0]);
+            if (!ExpressionHelpers.TryArray(args[0], out var inputArray))
+                throw ArgumentFormatInvalid(nameof(Reduce));
+
+            var initialValue = GetExpression(context, args[1]);
+            args[2] = GetExpression(context, args[2]);
+            if (args[2] is not LambdaExpressionFn lambda)
+                throw ArgumentFormatInvalid(nameof(Reduce));
+
+            return lambda.Reduce(context, inputArray.OfType<object>().ToArray(), initialValue);
+        }
+
+        /// <summary>
+        /// sort(inputArray, lambda expression)
+        /// </summary>
+        /// <remarks>
+        /// See <seealso href="https://learn.microsoft.com/azure/azure-resource-manager/bicep/bicep-functions-lambda#sort"/>.
+        /// </remarks>
+        internal static object Sort(ITemplateContext context, object[] args)
+        {
+            if (CountArgs(args) != 2)
+                throw ArgumentsOutOfRange(nameof(Sort), args);
+
+            args[0] = GetExpression(context, args[0]);
+            if (!ExpressionHelpers.TryArray(args[0], out var inputArray))
+                throw ArgumentFormatInvalid(nameof(Sort));
+
+            args[1] = GetExpression(context, args[1]);
+            if (args[1] is not LambdaExpressionFn lambda)
+                throw ArgumentFormatInvalid(nameof(Sort));
+
+            return lambda.Sort(context, inputArray.OfType<object>().ToArray());
+        }
+
+        /// <summary>
+        /// Evaluate a lambda expression.
+        /// </summary>
+        internal static object Lambda(ITemplateContext context, object[] args)
+        {
+            var count = CountArgs(args);
+            if (count < 2 || count > 3)
+                throw ArgumentsOutOfRange(nameof(Lambda), args);
+
+            return new LambdaExpressionFn(args);
+        }
+
+        /// <summary>
+        /// Get a lambda variable.
+        /// </summary>
+        internal static object LambdaVariables(ITemplateContext context, object[] args)
+        {
+            if (CountArgs(args) != 1)
+                throw ArgumentsOutOfRange(nameof(LambdaVariables), args);
+
+            args[0] = GetExpression(context, args[0]);
+            if (!ExpressionHelpers.TryString(args[0], out var variableName))
+                throw ArgumentInvalidString(nameof(LambdaVariables), nameof(args));
+
+            return context.TryLambdaVariable(variableName, out var value) ? value : null;
+        }
+
+        #endregion Lambda
 
         #region Helper functions
 

--- a/src/PSRule.Rules.Azure/Data/Template/ITemplateContext.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ITemplateContext.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using PSRule.Rules.Azure.Configuration;
+using static PSRule.Rules.Azure.Data.Template.TemplateVisitor;
+
+namespace PSRule.Rules.Azure.Data.Template
+{
+    internal static class TemplateContextExtensions
+    {
+        /// <summary>
+        /// Get a lambda variable from the current context scope.
+        /// This will throw an exception if the current context is not within a lambda expression.
+        /// </summary>
+        /// <param name="context">An instance of a <see cref="ITemplateContext"/>.</param>
+        /// <param name="variableName">The name of the variable. Variable names are case-insensitive.</param>
+        /// <param name="value">The returned value of the variable.</param>
+        /// <returns>Returns <c>true</c> if the variable exists or <c>false</c> if a variable with the specified name could not be found.</returns>
+        /// <exception cref="NotImplementedException">A lambda variable can not be evaluated outside a lambda expression.</exception>
+        public static bool TryLambdaVariable<TValue>(this ITemplateContext context, string variableName, out TValue value)
+        {
+            value = default;
+            if (!context.TryLambdaVariable(variableName, out var v))
+                return false;
+
+            value = (TValue)v;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// An interface for a template context.
+    /// </summary>
+    internal interface ITemplateContext : IValidationContext
+    {
+        TemplateContext.CopyIndexStore CopyIndex { get; }
+
+        /// <summary>
+        /// The current deployment.
+        /// </summary>
+        DeploymentValue Deployment { get; }
+
+        string TemplateFile { get; }
+
+        string ParameterFile { get; }
+
+        ResourceGroupOption ResourceGroup { get; }
+
+        SubscriptionOption Subscription { get; }
+
+        TenantOption Tenant { get; }
+
+        ManagementGroupOption ManagementGroup { get; }
+
+        ExpressionFnOuter BuildExpression(string s);
+
+        CloudEnvironment GetEnvironment();
+
+        /// <summary>
+        /// Get a parameter from the current context.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter. Parameter names are case-insensitive.</param>
+        /// <param name="value">The returned value of the parameter.</param>
+        /// <returns>Returns <c>true</c> if the parameter exists or <c>false</c> if a parameter with the specified name could not be found.</returns>
+        bool TryParameter(string parameterName, out object value);
+
+        /// <summary>
+        /// Get a variable from the current context.
+        /// </summary>
+        /// <param name="variableName">The name of the variable. Variable names are case-insensitive.</param>
+        /// <param name="value">The returned value of the variable.</param>
+        /// <returns>Returns <c>true</c> if the variable exists or <c>false</c> if a variable with the specified name could not be found.</returns>
+        bool TryVariable(string variableName, out object value);
+
+        bool TryGetResource(string resourceId, out IResourceValue resource);
+
+        void WriteDebug(string message, params object[] args);
+
+        /// <summary>
+        /// Get a lambda variable from the current context scope.
+        /// This will throw an exception if the current context is not within a lambda expression.
+        /// </summary>
+        /// <param name="variableName">The name of the variable. Variable names are case-insensitive.</param>
+        /// <param name="value">The returned value of the variable.</param>
+        /// <returns>Returns <c>true</c> if the variable exists or <c>false</c> if a variable with the specified name could not be found.</returns>
+        /// <exception cref="NotImplementedException">A lambda variable can not be evaluated outside a lambda expression.</exception>
+        bool TryLambdaVariable(string variableName, out object value);
+    }
+
+    /// <summary>
+    /// A base implementation of a template context.
+    /// </summary>
+    internal abstract class BaseTemplateContext : ITemplateContext
+    {
+        protected readonly ITemplateContext _Inner;
+
+        public BaseTemplateContext(ITemplateContext context)
+        {
+            _Inner = context;
+        }
+
+        public TemplateContext.CopyIndexStore CopyIndex => _Inner.CopyIndex;
+
+        public DeploymentValue Deployment => throw new NotImplementedException();
+
+        public string TemplateFile => _Inner.TemplateFile;
+
+        public string ParameterFile => _Inner.ParameterFile;
+
+        public ResourceGroupOption ResourceGroup => _Inner.ResourceGroup;
+
+        public SubscriptionOption Subscription => _Inner.Subscription;
+
+        public TenantOption Tenant => _Inner.Tenant;
+
+        public ManagementGroupOption ManagementGroup => _Inner.ManagementGroup;
+
+        public ExpressionFnOuter BuildExpression(string s)
+        {
+            return _Inner.BuildExpression(s);
+        }
+
+        public CloudEnvironment GetEnvironment()
+        {
+            return _Inner.GetEnvironment();
+        }
+
+        /// <inheritdoc/>
+        public virtual bool TryParameter(string parameterName, out object value)
+        {
+            return _Inner.TryParameter(parameterName, out value);
+        }
+
+        /// <inheritdoc/>
+        public virtual bool TryVariable(string variableName, out object value)
+        {
+            return _Inner.TryVariable(variableName, out value);
+        }
+
+        public bool TryGetResource(string resourceId, out IResourceValue resource)
+        {
+            return _Inner.TryGetResource(resourceId, out resource);
+        }
+
+        public void WriteDebug(string message, params object[] args)
+        {
+            _Inner.WriteDebug(message, args);
+        }
+
+        /// <inheritdoc/>
+        public virtual bool TryLambdaVariable(string variableName, out object value)
+        {
+            return _Inner.TryLambdaVariable(variableName, out value);
+        }
+
+        #region IValidationContext
+
+        /// <inheritdoc/>
+        public void AddValidationIssue(string issueId, string name, string path, string message, params object[] args)
+        {
+            _Inner.AddValidationIssue(issueId, name, path, message, args);
+        }
+
+        /// <inheritdoc/>
+        public ResourceProviderType[] GetResourceType(string providerNamespace, string resourceType)
+        {
+            return _Inner.GetResourceType(providerNamespace, resourceType);
+        }
+
+        /// <inheritdoc/>
+        public bool IsSecureValue(object value)
+        {
+            return _Inner.IsSecureValue(value);
+        }
+
+        #endregion IValidationContext
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Template/IValidationContext.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/IValidationContext.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Rules.Azure.Data.Template
+{
+    /// <summary>
+    /// An interface for a validation context.
+    /// </summary>
+    internal interface IValidationContext
+    {
+        /// <summary>
+        /// Track a validation issue.
+        /// </summary>
+        void AddValidationIssue(string issueId, string name, string path, string message, params object[] args);
+
+        /// <summary>
+        /// Lookup a resource type.
+        /// </summary>
+        ResourceProviderType[] GetResourceType(string providerNamespace, string resourceType);
+
+        /// <summary>
+        /// Determines if the value is a previously identified secure value.
+        /// </summary>
+        bool IsSecureValue(object value);
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Template/LambdaExpressionFn.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/LambdaExpressionFn.cs
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace PSRule.Rules.Azure.Data.Template
+{
+    /// <summary>
+    /// An expression for resolving lambda functions.
+    /// </summary>
+    internal sealed class LambdaExpressionFn
+    {
+        private readonly object[] _Args;
+
+        /// <summary>
+        /// Create an instance of a lambda function with the specified arguments for the function.
+        /// </summary>
+        /// <param name="args">An array of arguments for the function.</param>
+        public LambdaExpressionFn(params object[] args)
+        {
+            _Args = args;
+        }
+
+        private sealed class LambdaContext : BaseTemplateContext
+        {
+            private readonly Dictionary<string, object> _Variables;
+
+            public LambdaContext(ITemplateContext context)
+                : base(context)
+            {
+                _Variables = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            public override bool TryLambdaVariable(string variableName, out object value)
+            {
+                return _Variables.TryGetValue(variableName, out value);
+            }
+
+            internal void LambdaVariable(string variableName, object value)
+            {
+                if (string.IsNullOrEmpty(variableName))
+                    return;
+
+                _Variables[variableName] = value;
+            }
+        }
+
+        private sealed class LambdaSort : IComparer<object>
+        {
+            private readonly LambdaContext _LambdaContext;
+            private readonly ExpressionFnOuter _Comparer;
+            private readonly string _VarName1;
+            private readonly string _VarName2;
+
+            public LambdaSort(LambdaContext lambdaContext, ExpressionFnOuter comparer, string varName1, string varName2)
+            {
+                _LambdaContext = lambdaContext;
+                _Comparer = comparer;
+                _VarName1 = varName1;
+                _VarName2 = varName2;
+            }
+
+            public int Compare(object x, object y)
+            {
+                _LambdaContext.LambdaVariable(_VarName1, x);
+                _LambdaContext.LambdaVariable(_VarName2, y);
+                return AsBoolean(_LambdaContext, _Comparer) ? 1 : -1;
+            }
+        }
+
+        #region Lambda functions
+
+        /// <summary>
+        /// Call the <c>filter</c> function to filter the input array to items that meet the condition.
+        /// </summary>
+        /// <param name="context">The current context.</param>
+        /// <param name="inputArray">An array of inputs.</param>
+        /// <returns>An array of items that meet the condition. If not items meet the condition an empty array will be returned.</returns>
+        internal object Filter(ITemplateContext context, object[] inputArray)
+        {
+            var lambdaContext = GetArgs2(context, out var varName, out var filter);
+            if (lambdaContext == null)
+                return null;
+
+            var result = new List<object>(inputArray.Length);
+            for (var i = 0; i < inputArray.Length; i++)
+            {
+                lambdaContext.LambdaVariable(varName, inputArray[i]);
+                if (AsBoolean(lambdaContext, filter))
+                    result.Add(inputArray[i]);
+            }
+            return result.ToArray();
+        }
+
+        /// <summary>
+        /// Call the <c>map</c> function to transform the input array into items based on the input elements based on a custom function.
+        /// </summary>
+        /// <param name="context">The current context.</param>
+        /// <param name="inputArray">An array of inputs.</param>
+        /// <returns>An array of transformed items.</returns>
+        internal object Map(ITemplateContext context, object[] inputArray)
+        {
+            var lambdaContext = GetArgs2(context, out var varName, out var mapper);
+            if (lambdaContext == null)
+                return null;
+
+            var result = new object[inputArray.Length];
+            for (var i = 0; i < inputArray.Length; i++)
+            {
+                lambdaContext.LambdaVariable(varName, inputArray[i]);
+                result[i] = mapper(lambdaContext);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Call the <c>reduce</c> function to combine the input array using a custom combining function.
+        /// </summary>
+        /// <param name="context">The current context.</param>
+        /// <param name="inputArray">An array of inputs.</param>
+        /// <param name="initialValue"></param>
+        /// <returns>A combined output result from the custom function.</returns>
+        internal object Reduce(ITemplateContext context, object[] inputArray, object initialValue)
+        {
+            var lambdaContext = GetArgs3(context, out var varName1, out var varName2, out var reducer);
+            if (lambdaContext == null)
+                return null;
+
+            var result = initialValue;
+            for (var i = 0; i < inputArray.Length; i++)
+            {
+                lambdaContext.LambdaVariable(varName1, result);
+                lambdaContext.LambdaVariable(varName2, inputArray[i]);
+                result = reducer(lambdaContext);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Call the <c>sort</c> function to reorder the input array elements using a custom sorting function.
+        /// </summary>
+        /// <param name="context">The current context.</param>
+        /// <param name="inputArray">An array of inputs.</param>
+        /// <returns>An array of reordered items.</returns>
+        internal object Sort(ITemplateContext context, object[] inputArray)
+        {
+            var lambdaContext = GetArgs3(context, out var varName1, out var varName2, out var comparer);
+            if (lambdaContext == null)
+                return null;
+
+            var result = new object[inputArray.Length];
+            inputArray.CopyTo(result, 0);
+            Array.Sort(result, new LambdaSort(lambdaContext, comparer, varName1, varName2));
+            return result;
+        }
+
+        #endregion Lambda functions
+
+        #region Helper methods
+
+        private static bool AsBoolean(ITemplateContext context, ExpressionFnOuter fn)
+        {
+            var result = fn(context);
+            return result is bool b && b;
+        }
+
+        private static object GetExpression(ITemplateContext context, object o)
+        {
+            return o is ExpressionFnOuter fn ? fn(context) : o;
+        }
+
+        private LambdaContext GetArgs2(ITemplateContext context, out string varName1, out ExpressionFnOuter fn)
+        {
+            fn = null;
+            var arg0 = GetExpression(context, _Args[0]);
+            if (!ExpressionHelpers.TryString(arg0, out varName1) || _Args[1] is not ExpressionFnOuter arg1)
+                return null;
+
+            fn = arg1;
+            return new LambdaContext(context);
+        }
+
+        private LambdaContext GetArgs3(ITemplateContext context, out string varName1, out string varName2, out ExpressionFnOuter fn)
+        {
+            fn = null;
+            varName2 = null;
+            var arg0 = GetExpression(context, _Args[0]);
+            var arg1 = GetExpression(context, _Args[1]);
+            if (!ExpressionHelpers.TryString(arg0, out varName1) ||
+                !ExpressionHelpers.TryString(arg1, out varName2) ||
+                _Args[2] is not ExpressionFnOuter arg2)
+                return null;
+
+            fn = arg2;
+            return new LambdaContext(context);
+        }
+
+        #endregion Helper methods
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Template/ResourceValue.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ResourceValue.cs
@@ -35,6 +35,17 @@ namespace PSRule.Rules.Azure.Data.Template
         {
             return string.Equals(resource.Type, type, StringComparison.OrdinalIgnoreCase);
         }
+
+        internal static bool TryOutput<TValue>(this DeploymentValue resource, string name, out TValue value)
+        {
+            value = default;
+            if (resource.TryOutput(name, out var o) && o is TValue v)
+            {
+                value = v;
+                return true;
+            }
+            return false;
+        }
     }
 
     internal abstract class BaseResourceValue
@@ -161,6 +172,16 @@ namespace PSRule.Rules.Azure.Data.Template
         public void AddOutput(string name, ILazyValue output)
         {
             _Outputs.Add(name, output);
+        }
+
+        internal bool TryOutput(string name, out object value)
+        {
+            value = null;
+            if (!_Outputs.TryGetValue(name, out var lazy))
+                return false;
+
+            value = lazy.GetValue();
+            return true;
         }
 
         public bool TryProperty(string propertyName, out object value)

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PSRule.Rules.Azure.Configuration;
@@ -28,6 +29,7 @@ namespace PSRule.Rules.Azure
         private const string TRAIT_STRING = "String";
         private const string TRAIT_RESOURCE = "Resource";
         private const string TRAIT_SCOPE = "Scope";
+        private const string TRAIT_LAMBDA = "Lambda";
 
         #region Array and object
 
@@ -1831,6 +1833,73 @@ namespace PSRule.Rules.Azure
         }
 
         #endregion String
+
+        #region Lambda
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_LAMBDA)]
+        public void Filter()
+        {
+            var context = GetContext();
+            var dogs = JArray.Parse(@"[{""name"":""Evie"",""age"":5,""interests"":[""Ball"",""Frisbee""]},{""name"":""Casper"",""age"":3,""interests"":[""Other dogs""]},{""name"":""Indy"",""age"":2,""interests"":[""Butter""]},{""name"":""Kira"",""age"":8,""interests"":[""Rubs""]}]");
+            var i = 0;
+
+            ExpressionFnOuter comparer = c => dogs[i++]["age"].Value<int>() >= 5;
+            var actual = Functions.Filter(context, new object[] { dogs, new LambdaExpressionFn("dog", comparer) }) as object[];
+            Assert.Equal(2, actual.Length);
+        }
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_LAMBDA)]
+        public void Map()
+        {
+            var context = GetContext();
+            var dogs = JArray.Parse(@"[{""name"":""Evie"",""age"":5,""interests"":[""Ball"",""Frisbee""]},{""name"":""Casper"",""age"":3,""interests"":[""Other dogs""]},{""name"":""Indy"",""age"":2,""interests"":[""Butter""]},{""name"":""Kira"",""age"":8,""interests"":[""Rubs""]}]");
+            var i = 0;
+
+            ExpressionFnOuter mapper = c => dogs[i++]["name"].Value<string>();
+            var actual = Functions.Map(context, new object[] { dogs, new LambdaExpressionFn("dog", mapper) }) as object[];
+            Assert.Equal(4, actual.Length);
+            Assert.Equal("Evie", actual.OfType<string>().First());
+        }
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_LAMBDA)]
+        public void Reduce()
+        {
+            var context = GetContext();
+            var dogs = JArray.Parse(@"[{""name"":""Evie"",""age"":5,""interests"":[""Ball"",""Frisbee""]},{""name"":""Casper"",""age"":3,""interests"":[""Other dogs""]},{""name"":""Indy"",""age"":2,""interests"":[""Butter""]},{""name"":""Kira"",""age"":8,""interests"":[""Rubs""]}]");
+
+            ExpressionFnOuter reducer = c =>
+            {
+                c.TryLambdaVariable("cur", out int cur);
+                c.TryLambdaVariable("next", out JObject next);
+                cur += next["age"].Value<int>();
+                return cur;
+            };
+            var actual = (int)Functions.Reduce(context, new object[] { dogs, 0, new LambdaExpressionFn("cur", "next", reducer) });
+            Assert.Equal(18, actual);
+        }
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_LAMBDA)]
+        public void Sort()
+        {
+            var context = GetContext();
+            var dogs = JArray.Parse(@"[{""name"":""Evie"",""age"":5,""interests"":[""Ball"",""Frisbee""]},{""name"":""Casper"",""age"":3,""interests"":[""Other dogs""]},{""name"":""Indy"",""age"":2,""interests"":[""Butter""]},{""name"":""Kira"",""age"":8,""interests"":[""Rubs""]}]");
+
+            ExpressionFnOuter sorter = c =>
+            {
+                c.TryLambdaVariable("a", out JObject a);
+                c.TryLambdaVariable("b", out JObject b);
+                return a["age"].Value<int>() < b["age"].Value<int>();
+            };
+            var actual = Functions.Sort(context, new object[] { dogs, new LambdaExpressionFn("a", "b", sorter) }) as object[];
+            Assert.Equal(4, actual.Length);
+            Assert.Equal("Kira", actual.OfType<JObject>().First()["name"].Value<string>());
+        }
+
+        #endregion Lambda
 
         #region Complex scenarios
 

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -145,6 +145,9 @@
     <None Update="Tests.Bicep.12.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Tests.Bicep.13.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Tests.Bicep.2.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.13.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.13.bicep
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Tests for lambda expressions
+
+param arrayToTest array = [
+  ['one', 'two']
+  ['three']
+  ['four', 'five']
+]
+
+var dogs = [
+  {
+    name: 'Evie'
+    age: 5
+    interests: ['Ball', 'Frisbee']
+  }
+  {
+    name: 'Casper'
+    age: 3
+    interests: ['Other dogs']
+  }
+  {
+    name: 'Indy'
+    age: 2
+    interests: ['Butter']
+  }
+  {
+    name: 'Kira'
+    age: 8
+    interests: ['Rubs']
+  }
+]
+
+// Flatten
+output arrayOutput array = flatten(arrayToTest)
+
+// Filter
+output oldDogs array = filter(dogs, dog => dog.age >= 5)
+
+// Map
+output dogNames array = map(dogs, dog => dog.name)
+output sayHi array = map(dogs, dog => 'Hello ${dog.name}!')
+output mapObject array = map(range(0, length(dogs)), i => {
+  i: i
+  dog: dogs[i].name
+  greeting: 'Ahoy, ${dogs[i].name}!'
+})
+
+// Reduce
+var ages = map(dogs, dog => dog.age)
+output totalAge int = reduce(ages, 0, (cur, next) => cur + next)
+output totalAgeAdd1 int = reduce(ages, 1, (cur, next) => cur + next)
+
+// Sort
+output dogsByAge array = sort(dogs, (a, b) => a.age < b.age)

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.13.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.13.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.13.1.58284",
+      "templateHash": "15169255149500185367"
+    }
+  },
+  "parameters": {
+    "arrayToTest": {
+      "type": "array",
+      "defaultValue": [
+        [
+          "one",
+          "two"
+        ],
+        [
+          "three"
+        ],
+        [
+          "four",
+          "five"
+        ]
+      ]
+    }
+  },
+  "variables": {
+    "dogs": [
+      {
+        "name": "Evie",
+        "age": 5,
+        "interests": [
+          "Ball",
+          "Frisbee"
+        ]
+      },
+      {
+        "name": "Casper",
+        "age": 3,
+        "interests": [
+          "Other dogs"
+        ]
+      },
+      {
+        "name": "Indy",
+        "age": 2,
+        "interests": [
+          "Butter"
+        ]
+      },
+      {
+        "name": "Kira",
+        "age": 8,
+        "interests": [
+          "Rubs"
+        ]
+      }
+    ],
+    "ages": "[map(variables('dogs'), lambda('dog', lambdaVariables('dog').age))]"
+  },
+  "resources": [],
+  "outputs": {
+    "arrayOutput": {
+      "type": "array",
+      "value": "[flatten(parameters('arrayToTest'))]"
+    },
+    "oldDogs": {
+      "type": "array",
+      "value": "[filter(variables('dogs'), lambda('dog', greaterOrEquals(lambdaVariables('dog').age, 5)))]"
+    },
+    "dogNames": {
+      "type": "array",
+      "value": "[map(variables('dogs'), lambda('dog', lambdaVariables('dog').name))]"
+    },
+    "sayHi": {
+      "type": "array",
+      "value": "[map(variables('dogs'), lambda('dog', format('Hello {0}!', lambdaVariables('dog').name)))]"
+    },
+    "mapObject": {
+      "type": "array",
+      "value": "[map(range(0, length(variables('dogs'))), lambda('i', createObject('i', lambdaVariables('i'), 'dog', variables('dogs')[lambdaVariables('i')].name, 'greeting', format('Ahoy, {0}!', variables('dogs')[lambdaVariables('i')].name))))]"
+    },
+    "totalAge": {
+      "type": "int",
+      "value": "[reduce(variables('ages'), 0, lambda('cur', 'next', add(lambdaVariables('cur'), lambdaVariables('next'))))]"
+    },
+    "totalAgeAdd1": {
+      "type": "int",
+      "value": "[reduce(variables('ages'), 1, lambda('cur', 'next', add(lambdaVariables('cur'), lambdaVariables('next'))))]"
+    },
+    "dogsByAge": {
+      "type": "array",
+      "value": "[sort(variables('dogs'), lambda('a', 'b', less(lambdaVariables('a').age, lambdaVariables('b').age)))]"
+    }
+  }
+}


### PR DESCRIPTION
## PR Summary

- Added support for Bicep lambda functions.
  - Bicep `filter`, `map`, `reduce`, and `sort` are supported.
  - Support for `flatten` was previously added in v1.23.0.

Fixes #1536 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
