### PR TITLE
Release v1.24.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -31,7 +31,7 @@ Steps to reproduce the issue:
 **Module in use and version:**
 
 - Module: PSRule.Rules.Azure
-- Version: **[e.g. 1.22.0]**
+- Version: **[e.g. 1.24.0]**
 
 Captured output from `$PSVersionTable`:
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ jobs:
 
     # STEP 2: Run analysis against exported data
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.6.0
+      uses: microsoft/ps-rule@v2.7.0
       with:
         modules: 'PSRule.Rules.Azure'  # Analyze objects using the rules within the PSRule.Rules.Azure PowerShell module.
 ```

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,47 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.24.0
+
+What's changed since v1.23.0:
+
+- General improvements:
+  - Updated `Export-AzRuleData` to improve export performance by @BernieWhite.
+    [#1341](https://github.com/Azure/PSRule.Rules.Azure/issues/1341)
+    - Removed `Az.Resources` dependency.
+    - Added async threading for export concurrency.
+    - Improved performance by using automatic look up of API versions by using provider cache.
+  - Added support for Bicep lambda functions by @BernieWhite.
+    [#1536](https://github.com/Azure/PSRule.Rules.Azure/issues/1536)
+    - Bicep `filter`, `map`, `reduce`, and `sort` are supported.
+    - Support for `flatten` was previously added in v1.23.0.
+  - Added optimization for policy type conditions by @BernieWhite.
+    [#1966](https://github.com/Azure/PSRule.Rules.Azure/issues/1966)
+- Engineering:
+  - Bump PSRule to v2.7.0.
+    [#1973](https://github.com/Azure/PSRule.Rules.Azure/pull/1973)
+  - Updated resource providers and policy aliases.
+    [#1736](https://github.com/Azure/PSRule.Rules.Azure/pull/1736)
+  - Bump Az.Resources to v6.5.1.
+    [#1973](https://github.com/Azure/PSRule.Rules.Azure/pull/1973)
+  - Bump Newtonsoft.Json to v13.0.2.
+    [#1903](https://github.com/Azure/PSRule.Rules.Azure/pull/1903)
+  - Bump Pester to v5.4.0.
+    [#1994](https://github.com/Azure/PSRule.Rules.Azure/pull/1994)
+- Bug fixes:
+  - Fixed `Export-AzRuleData` may not export all data if throttled by @BernieWhite.
+    [#1341](https://github.com/Azure/PSRule.Rules.Azure/issues/1341)
+  - Fixed failed to expand nested deployment with runtime shallow parameter by @BernieWhite.
+    [#2004](https://github.com/Azure/PSRule.Rules.Azure/issues/2004)
+  - Fixed `apiVersion` comparison of `requestContext` by @BernieWhite.
+    [#1654](https://github.com/Azure/PSRule.Rules.Azure/issues/1654)
+  - Fixed simple cases for field type expressions by @BernieWhite.
+    [#1323](https://github.com/Azure/PSRule.Rules.Azure/issues/1323)
+
+What's changed since pre-release v1.24.0-B0035:
+
+- No additional changes.
+
 ## v1.24.0-B0035 (pre-release)
 
 What's changed since pre-release v1.24.0-B0013:

--- a/docs/creating-your-pipeline.md
+++ b/docs/creating-your-pipeline.md
@@ -32,7 +32,7 @@ Within the root directory of your infrastructure as code repository:
 
         # Analyze Azure resources using PSRule for Azure
         - name: Analyze Azure template files
-          uses: microsoft/ps-rule@v2.6.0
+          uses: microsoft/ps-rule@v2.7.0
           with:
             modules: 'PSRule.Rules.Azure'
     ```
@@ -95,7 +95,7 @@ You can use the `inputPath` parameter to limit the analysis to a specific path.
     ```yaml hl_lines="6"
     # Analyze Azure resources using PSRule for Azure
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.6.0
+      uses: microsoft/ps-rule@v2.7.0
       with:
         modules: 'PSRule.Rules.Azure'
         inputPath: azure/modules/
@@ -135,7 +135,7 @@ See [working with baselines][8] for more information.
     ```yaml hl_lines="6"
     # Analyze Azure resources using PSRule for Azure
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.6.0
+      uses: microsoft/ps-rule@v2.7.0
       with:
         modules: 'PSRule.Rules.Azure'
         baseline: Azure.GA_2022_12
@@ -175,7 +175,7 @@ To do this, configure the PSRule for Azure step to _continue on error_.
     ```yaml hl_lines="4"
     # Analyze Azure resources using PSRule for Azure
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.6.0
+      uses: microsoft/ps-rule@v2.7.0
       continue-on-error: true
       with:
         modules: 'PSRule.Rules.Azure'
@@ -214,7 +214,7 @@ You can add additional modules to the `modules` parameter by using comma (`,`) s
     ```yaml hl_lines="5"
     # Analyze Azure resources using PSRule for Azure
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.6.0
+      uses: microsoft/ps-rule@v2.7.0
       with:
         modules: 'PSRule.Rules.Azure,PSRule.Monitor'
     ```
@@ -248,7 +248,7 @@ For details on the formats that are supported see [analysis output][9].
     ```yaml hl_lines="6-7"
     # Analyze Azure resources using PSRule for Azure
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.6.0
+      uses: microsoft/ps-rule@v2.7.0
       with:
         modules: 'PSRule.Rules.Azure'
         outputFormat: Sarif

--- a/docs/install-instructions.md
+++ b/docs/install-instructions.md
@@ -24,7 +24,7 @@ Install and use PSRule for Azure with GitHub Actions by referencing the `microso
 
     ```yaml
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.6.0
+      uses: microsoft/ps-rule@v2.7.0
       with:
         modules: 'PSRule.Rules.Azure'
     ```
@@ -35,7 +35,7 @@ Install and use PSRule for Azure with GitHub Actions by referencing the `microso
 
     ```yaml
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.6.0
+      uses: microsoft/ps-rule@v2.7.0
       with:
         modules: 'PSRule.Rules.Azure'
         prerelease: true

--- a/docs/setup/setup-azure-monitor-logs.md
+++ b/docs/setup/setup-azure-monitor-logs.md
@@ -70,7 +70,7 @@ Import analysis results into Azure Monitor with GitHub Actions by:
 
     ```yaml
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.6.0
+      uses: microsoft/ps-rule@v2.7.0
       with:
         modules: PSRule.Rules.Azure,PSRule.Monitor
         conventions: Monitor.LogAnalytics.Import
@@ -86,7 +86,7 @@ Import analysis results into Azure Monitor with GitHub Actions by:
 
     ```yaml
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.6.0
+      uses: microsoft/ps-rule@v2.7.0
       with:
         modules: PSRule.Rules.Azure,PSRule.Monitor
         conventions: Monitor.LogAnalytics.Import

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -156,5 +156,5 @@ For the PSRule GitHub Action, use **>=1.4.0**.
 
 ```yaml
 - name: Run PSRule analysis
-  uses: microsoft/ps-rule@v2.6.0
+  uses: microsoft/ps-rule@v2.7.0
 ```

--- a/docs/using-bicep.md
+++ b/docs/using-bicep.md
@@ -149,7 +149,7 @@ You may need to [configure credentials][4] to access the private registry from a
 
     ```yaml
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.6.0
+      uses: microsoft/ps-rule@v2.7.0
       with:
         modules: PSRule.Rules.Azure,PSRule.Monitor
         conventions: Monitor.LogAnalytics.Import

--- a/docs/working-with-baselines.md
+++ b/docs/working-with-baselines.md
@@ -77,7 +77,7 @@ See [reference][1] for a list baselines shipped with PSRule for Azure.
     ```yaml
     # Analyze Azure resources using PSRule for Azure
     - name: Analyze Azure template files
-      uses: microsoft/ps-rule@v2.6.0
+      uses: microsoft/ps-rule@v2.7.0
       with:
         modules: 'PSRule.Rules.Azure'
         baseline: 'Azure.GA_2022_12'


### PR DESCRIPTION
## PR Summary

What's changed since v1.23.0:

- General improvements:
  - Updated `Export-AzRuleData` to improve export performance by @BernieWhite.
    [#1341](https://github.com/Azure/PSRule.Rules.Azure/issues/1341)
    - Removed `Az.Resources` dependency.
    - Added async threading for export concurrency.
    - Improved performance by using automatic look up of API versions by using provider cache.
  - Added support for Bicep lambda functions by @BernieWhite.
    [#1536](https://github.com/Azure/PSRule.Rules.Azure/issues/1536)
    - Bicep `filter`, `map`, `reduce`, and `sort` are supported.
    - Support for `flatten` was previously added in v1.23.0.
  - Added optimization for policy type conditions by @BernieWhite.
    [#1966](https://github.com/Azure/PSRule.Rules.Azure/issues/1966)
- Engineering:
  - Bump PSRule to v2.7.0.
    [#1973](https://github.com/Azure/PSRule.Rules.Azure/pull/1973)
  - Updated resource providers and policy aliases.
    [#1736](https://github.com/Azure/PSRule.Rules.Azure/pull/1736)
  - Bump Az.Resources to v6.5.1.
    [#1973](https://github.com/Azure/PSRule.Rules.Azure/pull/1973)
  - Bump Newtonsoft.Json to v13.0.2.
    [#1903](https://github.com/Azure/PSRule.Rules.Azure/pull/1903)
  - Bump Pester to v5.4.0.
    [#1994](https://github.com/Azure/PSRule.Rules.Azure/pull/1994)
- Bug fixes:
  - Fixed `Export-AzRuleData` may not export all data if throttled by @BernieWhite.
    [#1341](https://github.com/Azure/PSRule.Rules.Azure/issues/1341)
  - Fixed failed to expand nested deployment with runtime shallow parameter by @BernieWhite.
    [#2004](https://github.com/Azure/PSRule.Rules.Azure/issues/2004)
  - Fixed `apiVersion` comparison of `requestContext` by @BernieWhite.
    [#1654](https://github.com/Azure/PSRule.Rules.Azure/issues/1654)
  - Fixed simple cases for field type expressions by @BernieWhite.
    [#1323](https://github.com/Azure/PSRule.Rules.Azure/issues/1323)

What's changed since pre-release v1.24.0-B0035:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
