### PR TITLE
Release v1.24.2

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,15 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.24.2
+
+This is republished v1.24.1 to fix a release issue.
+What's changed since v1.24.0:
+
+- Bug fixes:
+  - Fixes Bicep expand object or null by @BernieWhite.
+    [#2021](https://github.com/Azure/PSRule.Rules.Azure/issues/2021)
+
 ## v1.24.1
 
 What's changed since v1.24.0:


### PR DESCRIPTION
## PR Summary

This is republished v1.24.1 to fix a release issue.
What's changed since v1.24.0:

- Bug fixes:
  - Fixes Bicep expand object or null by @BernieWhite.
    [#2021](https://github.com/Azure/PSRule.Rules.Azure/issues/2021)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
