### PR TITLE
Added Bicep minimum version warning #1935

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -84,6 +84,7 @@
         "POLICYDEFINITIONID",
         "POLICYRULE",
         "psarm",
+        "PSRULE",
         "PUBLICIP",
         "pwsh",
         "Qualys",

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -36,7 +36,7 @@ What's changed since pre-release v1.25.0-B0013:
       [#1632](https://github.com/Azure/PSRule.Rules.Azure/issues/1632)
 - General improvements:
   - Added support for configuring a minimum version of Bicep by @BernieWhite.
-    [#1953](https://github.com/Azure/PSRule.Rules.Azure/issues/1935)
+    [#1935](https://github.com/Azure/PSRule.Rules.Azure/issues/1935)
     - Configure this option to increase the visibility of the version of the Bicep CLI used by PSRule for Azure.
     - Set `AZURE_BICEP_MINIMUM_VERSION` to configure the minimum version.
     - By default, this option default to `0.4.451`.

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -34,6 +34,12 @@ What's changed since pre-release v1.25.0-B0013:
       [#1632](https://github.com/Azure/PSRule.Rules.Azure/issues/1632)
     - Check Microsoft Defender for ARM is enabled by @BernieWhite.
       [#1632](https://github.com/Azure/PSRule.Rules.Azure/issues/1632)
+- General improvements:
+  - Added support for configuring a minimum version of Bicep by @BernieWhite.
+    [#1953](https://github.com/Azure/PSRule.Rules.Azure/issues/1935)
+    - Configure this option to increase the visibility of the version of the Bicep CLI used by PSRule for Azure.
+    - Set `AZURE_BICEP_MINIMUM_VERSION` to configure the minimum version.
+    - By default, this option default to `0.4.451`.
 - Engineering:
   - Bump Az.Resources to v6.5.2.
     [#2037](https://github.com/Azure/PSRule.Rules.Azure/pull/2037)

--- a/docs/setup/setup-bicep.md
+++ b/docs/setup/setup-bicep.md
@@ -13,6 +13,7 @@ The Bicep CLI is already installed on hosted runners and agents used by GitHub A
 ## Installing Bicep CLI
 
 PSRule for Azure requires a minimum of Bicep CLI version **0.4.451**.
+However the features you use within Bicep may require a newer version of the Bicep CLI.
 
 You may need to install or upgrade the Bicep CLI in the following scenarios:
 
@@ -139,7 +140,7 @@ This can occur if your Bicep deployments are:
 - Use nested modules.
 - Use modules restored from a registry.
 
-If you are experincing timeout errors you can increase the default timeout of 5 seconds.
+If you are experiencing timeout errors you can increase the default timeout of 5 seconds.
 To configure the timeout, set `Configuration.AZURE_BICEP_FILE_EXPANSION_TIMEOUT` to the timeout in seconds.
 
 ```yaml title="ps-rule.yaml"
@@ -152,6 +153,32 @@ configuration:
 ```
 
   [7]: configuring-expansion.md#bicep-compilation-timeout
+
+### Configuring minimum version
+
+:octicons-milestone-24: v1.25.0
+
+The Azure Bicep CLI is updated regularly, with new features and bug fixes.
+You must use a version of the Bicep CLI that supports the features you are using.
+If you attempt to use a feature that is not supported by the Bicep CLI, expansion will fail with a _BCP_ error.
+
+It may not always be clear which version of Bicep CLI PSRule for Azure is using if you have multiple versions installed.
+Using the Bicep CLI via `az bicep` is not the default, and you may need to [set additional options to use it](#using-azure-cli).
+
+To ensure you are using the correct version of the Bicep CLI, you can configure the minimum version required.
+If an earlier version is detected, PSRule for Azure will generate a warning.
+To configure the minimum version, set the `Configuration.AZURE_BICEP_MINIMUM_VERSION` option.
+
+```yaml title="ps-rule.yaml"
+configuration:
+  # Configure the minimum version of the Bicep CLI.
+  AZURE_BICEP_MINIMUM_VERSION: '0.13.0'
+```
+
+!!! Tip
+    For troubleshooting Bicep compilation errors see [Bicep compile errors][8].
+
+  [8]: ../troubleshooting.md#bicep-compile-errors
 
 ## Recommended content
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,36 +7,30 @@ discussion: false
 
 This article provides troubleshooting instructions for common errors.
 
-## An earlier version of Az.Accounts is imported
+## Bicep compile errors
 
-When running PSRule for Azure in Azure DevOps within the `AzurePowerShell@5` task,
-you may see the following error.
+When expanding Bicep source files you may get an error including a _BCPnnn_ code similar to the following:
 
 !!! Error
 
-    This module requires Az.Accounts version 2.8.0. An earlier version of
-    Az.Accounts is imported in the current PowerShell session. Please open a new
-    session before importing this module. This error could indicate that multiple
-    incompatible versions of the Azure PowerShell cmdlets are installed on your
-    system. Please see https://aka.ms/azps-version-error for troubleshooting
-    information.
+    Exception calling "GetResources" with "3" argument(s): "Bicep (0.14.46) compilation of '<file>' failed with: Error BCP057: The name "storageAccountName" does not exist in the current context.
 
-This error is raised by a chained dependency failure importing a newer version of `Az.Accounts`.
-To avoid this issue attempt to install the exact versions of `Az.Resources`.
-In the `AzurePowerShell@5` task before installing PSRule.
+This error is raised when Bicep fails to compile a source file.
+To resolve this issue:
 
-```powershell
-Install-Module Az.Resources -RequiredVersion '5.6.0' -Force -Scope CurrentUser
-```
+- You may need to update your Bicep source file before PSRule can expand it.
+  Use guidance from the Bicep error message to help resolve the issue.
+- Check that you are using a version of Bicep that supports the Bicep features you are using.
+  It may not always be clear which version of Bicep CLI PSRule for Azure is using if you have multiple versions installed.
+  Using the Bicep CLI via `az bicep` is not the default, and you may need to [set additional options to use it][7].
 
-From PSRule for Azure v1.16.0, `Az.Accounts` and `Az.Resources` are no longer installed as dependencies.
-When using export commands from PSRule, you may need to install these modules.
+!!! Tip
+    From PSRule for Azure v1.25.0 you can configure the minimum version of Bicep CLI required.
+    If an earlier version is detected, PSRule for Azure will generate a warning.
+    See [Configuring minimum version][8] for details on how to configure this option.
 
-To install these modules, use the following PowerShell command:
-
-```powershell
-Install-Module Az.Resources -Force -Scope CurrentUser
-```
+  [7]: setup/setup-bicep.md#using-azure-cli
+  [8]: setup/setup-bicep.md#configuring-minimum-version
 
 ## Bicep compilation timeout
 
@@ -95,7 +89,7 @@ There is a few common causes of this issue including:
   On case-sensitive file systems such as Linux, this directory name is case-sensitive.
   See [Storing and naming rules][5] for more information.
 - **Check file name suffix** &mdash; PSRule only looks for files with the `.Rule.ps1`, `.Rule.yaml`, or `.Rule.jsonc` suffix.
-  On case-sensitive file systems such as Linux, this file siffix is case-sensitive.
+  On case-sensitive file systems such as Linux, this file suffix is case-sensitive.
   See [Storing and naming rules][5] for more information.
 - **Check binding configuration** &mdash; PSRule uses _binding_ to work out which property to use for a resource type.
   To be able to use the `-Type` parameter or `type` properties in rules definitions, binding must be set.
@@ -107,7 +101,7 @@ There is a few common causes of this issue including:
   See [using templates][2] and [using Bicep source][3] for details on how to enable expansion.
 
 !!! Tip
-    You may be able to use `git mv` to change the case of a file if it is commited to the repository inorrectly.
+    You may be able to use `git mv` to change the case of a file if it is committed to the repository incorrectly.
 
   [5]: https://aka.ms/ps-rule/naming
   [6]: customization/enforce-custom-tags.md#binding-type
@@ -135,6 +129,37 @@ You may find while editing a `.json` parameter file the root `metadata` property
 This doesn't affect the workings of the parameter file or deployment.
 The reason for the warning is that the `metadata` property has not been added to the parameter file JSON schema.
 However, the top level `metadata` property is ignored by Azure Resource Manager when deploying a template.
+
+## An earlier version of Az.Accounts is imported
+
+When running PSRule for Azure in Azure DevOps within the `AzurePowerShell@5` task,
+you may see the following error.
+
+!!! Error
+
+    This module requires Az.Accounts version 2.8.0. An earlier version of
+    Az.Accounts is imported in the current PowerShell session. Please open a new
+    session before importing this module. This error could indicate that multiple
+    incompatible versions of the Azure PowerShell cmdlets are installed on your
+    system. Please see https://aka.ms/azps-version-error for troubleshooting
+    information.
+
+This error is raised by a chained dependency failure importing a newer version of `Az.Accounts`.
+To avoid this issue attempt to install the exact versions of `Az.Resources`.
+In the `AzurePowerShell@5` task before installing PSRule.
+
+```powershell
+Install-Module Az.Resources -RequiredVersion '5.6.0' -Force -Scope CurrentUser
+```
+
+From PSRule for Azure v1.16.0, `Az.Accounts` and `Az.Resources` are no longer installed as dependencies.
+When using export commands from PSRule, you may need to install these modules.
+
+To install these modules, use the following PowerShell command:
+
+```powershell
+Install-Module Az.Resources -Force -Scope CurrentUser
+```
 
 ## Could not load file or assembly YamlDotNet
 

--- a/src/PSRule.Rules.Azure/Runtime/IService.cs
+++ b/src/PSRule.Rules.Azure/Runtime/IService.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace PSRule.Rules.Azure.Runtime
+{
+    /// <summary>
+    /// A context when running within PSRule.
+    /// </summary>
+    public interface IService : IDisposable
+    {
+
+    }
+}

--- a/src/PSRule.Rules.Azure/Runtime/RuntimeService.cs
+++ b/src/PSRule.Rules.Azure/Runtime/RuntimeService.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Rules.Azure.Data.Bicep;
+
+namespace PSRule.Rules.Azure.Runtime
+{
+    /// <summary>
+    /// A singleton context when running is PSRule.
+    /// </summary>
+    internal sealed class RuntimeService : IService
+    {
+        private bool _Disposed;
+
+        public RuntimeService()
+        {
+
+        }
+
+        public BicepHelper.BicepInfo Bicep { get; internal set; }
+
+        #region IDisposable
+
+        private void Dispose(bool disposing)
+        {
+            if (!_Disposed)
+            {
+                if (disposing)
+                {
+                    Bicep = null;
+                }
+                _Disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            System.GC.SuppressFinalize(this);
+        }
+
+        #endregion IDisposable
+    }
+}

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -93,4 +93,5 @@
     VMAzureMonitorAgent = "The virtual machine should have Azure Monitor Agent installed."
     VMSSAzureMonitorAgent = "The virtual machine scale set should have Azure Monitor Agent installed."
     AzureCacheRedisVersion = "The Azure Cache for Redis should use the latest supported version of Redis."
+    BicepCLIVersion = "The Bicep version is '{0}' however the configured minimum version is '{1}'."
 }

--- a/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
@@ -28,6 +28,7 @@ spec:
     AZURE_PARAMETER_FILE_EXPANSION: false
     AZURE_PARAMETER_FILE_METADATA_LINK: false
     AZURE_BICEP_FILE_EXPANSION: false
+    AZURE_BICEP_MINIMUM_VERSION: '0.4.451'
 
     # Configure minimum AKS cluster version
     AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.25.4'
@@ -38,6 +39,7 @@ spec:
 
   convention:
     include:
+    - 'Azure.Context'
     - 'Azure.DeprecatedOptions'
     - 'Azure.ExpandTemplate'
     - 'Azure.BicepInstall'

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -154,6 +154,9 @@
     <None Update="Tests.Bicep.15.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Tests.Bicep.16.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Tests.Bicep.2.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -728,6 +728,25 @@ namespace PSRule.Rules.Azure
             Assert.NotNull(resources);
         }
 
+        [Fact]
+        public void BatchSize()
+        {
+            var resources = ProcessTemplate(GetSourcePath("Tests.Bicep.16.json"), null, out _);
+            Assert.NotNull(resources);
+            Assert.Equal(3, resources.Length);
+
+            var actual = resources[0];
+            Assert.Equal("Microsoft.Resources/deployments", actual["type"].Value<string>());
+
+            actual = resources[1];
+            Assert.Equal("Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments", actual["type"].Value<string>());
+            Assert.Equal("cosmos-repro/a", actual["name"].Value<string>());
+
+            actual = resources[2];
+            Assert.Equal("Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments", actual["type"].Value<string>());
+            Assert.Equal("cosmos-repro/b", actual["name"].Value<string>());
+        }
+
         #region Helper methods
 
         private static string GetSourcePath(string fileName)

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.16.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.16.bicep
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+param resourceName string = 'cosmos-repro'
+param servicePrincipalIds array = [
+  'a'
+  'b'
+]
+var dataContributorRoleId = '00000000-0000-0000-0000-000000000002'
+
+resource databaseAccount 'Microsoft.DocumentDB/databaseAccounts@2021-01-15' existing = {
+  name: resourceName
+}
+
+@batchSize(1)
+resource repro 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2021-10-15' = [ for servicePrincipalId in servicePrincipalIds: {
+  name: 'repo/${servicePrincipalId}'
+  properties: {
+    roleDefinitionId: '${subscription().id}/resourceGroups/${resourceGroup().name}/providers/Microsoft.DocumentDB/databaseAccounts/${resourceName}/sqlRoleDefinitions/${dataContributorRoleId}'
+    principalId: servicePrincipalId
+    scope: databaseAccount.id
+  }
+}]

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.16.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.16.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.14.46.61228",
+      "templateHash": "7216837688353806863"
+    }
+  },
+  "parameters": {
+    "resourceName": {
+      "type": "string",
+      "defaultValue": "cosmos-repro"
+    },
+    "servicePrincipalIds": {
+      "type": "array",
+      "defaultValue": [
+        "a",
+        "b"
+      ]
+    }
+  },
+  "variables": {
+    "dataContributorRoleId": "00000000-0000-0000-0000-000000000002"
+  },
+  "resources": [
+    {
+      "copy": {
+        "name": "repro",
+        "count": "[length(parameters('servicePrincipalIds'))]",
+        "mode": "serial",
+        "batchSize": 1
+      },
+      "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+      "apiVersion": "2021-10-15",
+      "name": "[format('{0}/{1}', parameters('resourceName'), format('{0}', parameters('servicePrincipalIds')[copyIndex()]))]",
+      "properties": {
+        "roleDefinitionId": "[format('{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}/sqlRoleDefinitions/{3}', subscription().id, resourceGroup().name, parameters('resourceName'), variables('dataContributorRoleId'))]",
+        "principalId": "[parameters('servicePrincipalIds')[copyIndex()]]",
+        "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('resourceName'))]"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## PR Summary

- Added warning for minimum Bicep version.
- Configure this option to increase the visibility of the version of the Bicep CLI used by PSRule for Azure.
- Set `AZURE_BICEP_MINIMUM_VERSION` to configure the minimum version.
- By default, this option default to `0.4.451`.

Related to #1935.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
