### PR TITLE
Added support for toObject #2014

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -26,6 +26,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v1.25.0-B0035:
 
+- General improvements:
+  - Added support for Bicep `toObject` function by @BernieWhite.
+    [#2014](https://github.com/Azure/PSRule.Rules.Azure/issues/2014)
 - Engineering:
   - Bump BenchmarkDotNet to v0.13.5.
     [#2052](https://github.com/Azure/PSRule.Rules.Azure/pull/2052)

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -159,6 +159,7 @@ namespace PSRule.Rules.Azure.Data.Template
             new FunctionDescriptor("map", Map, delayBinding: true),
             new FunctionDescriptor("reduce", Reduce, delayBinding: true),
             new FunctionDescriptor("sort", Sort, delayBinding: true),
+            new FunctionDescriptor("toObject", ToObject, delayBinding: true),
             new FunctionDescriptor("lambda", Lambda, delayBinding: true),
             new FunctionDescriptor("lambdaVariables", LambdaVariables, delayBinding: true),
         };
@@ -1901,6 +1902,32 @@ namespace PSRule.Rules.Azure.Data.Template
                 throw ArgumentFormatInvalid(nameof(Sort));
 
             return lambda.Sort(context, inputArray.OfType<object>().ToArray());
+        }
+
+        internal static object ToObject(ITemplateContext context, object[] args)
+        {
+            var count = CountArgs(args);
+            if (count < 2 || count > 3)
+                throw ArgumentsOutOfRange(nameof(ToObject), args);
+
+            args[0] = GetExpression(context, args[0]);
+            if (!ExpressionHelpers.TryArray(args[0], out var inputArray))
+                throw ArgumentFormatInvalid(nameof(ToObject));
+
+            args[1] = GetExpression(context, args[1]);
+            if (args[1] is not LambdaExpressionFn lambdaKeys)
+                throw ArgumentFormatInvalid(nameof(ToObject));
+
+            LambdaExpressionFn lambdaValues = null;
+            if (count == 3)
+            {
+                args[2] = GetExpression(context, args[2]);
+                if (args[2] is not LambdaExpressionFn)
+                    throw ArgumentFormatInvalid(nameof(ToObject));
+
+                lambdaValues = args[2] as LambdaExpressionFn;
+            }
+            return lambdaKeys.ToObject(context, inputArray.OfType<object>().ToArray(), lambdaValues);
         }
 
         /// <summary>

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -712,6 +712,26 @@ namespace PSRule.Rules.Azure
             Assert.Equal("Evie", dogsByAge["value"][1]["name"].Value<string>());
             Assert.Equal("Casper", dogsByAge["value"][2]["name"].Value<string>());
             Assert.Equal("Indy", dogsByAge["value"][3]["name"].Value<string>());
+
+            // ToObject
+            Assert.True(templateContext.RootDeployment.TryOutput("objectMap", out JObject objectMap));
+            Assert.Equal(123, objectMap["value"]["1"].Value<int>());
+            Assert.Equal(456, objectMap["value"]["4"].Value<int>());
+            Assert.Equal(789, objectMap["value"]["7"].Value<int>());
+            Assert.True(templateContext.RootDeployment.TryOutput("objectMap2", out JObject objectMap2));
+            Assert.True(objectMap2["value"]["0"]["isEven"].Value<bool>());
+            Assert.False(objectMap2["value"]["0"]["isGreaterThan2"].Value<bool>());
+            Assert.False(objectMap2["value"]["1"]["isEven"].Value<bool>());
+            Assert.False(objectMap2["value"]["1"]["isGreaterThan2"].Value<bool>());
+            Assert.True(objectMap2["value"]["2"]["isEven"].Value<bool>());
+            Assert.False(objectMap2["value"]["2"]["isGreaterThan2"].Value<bool>());
+            Assert.False(objectMap2["value"]["3"]["isEven"].Value<bool>());
+            Assert.True(objectMap2["value"]["3"]["isGreaterThan2"].Value<bool>());
+            Assert.True(templateContext.RootDeployment.TryOutput("objectMapNull", out JObject objectMapNull));
+            Assert.True(objectMapNull["value"][""].Type == JTokenType.Null);
+            Assert.Equal(123, objectMapNull["value"]["123"].Value<int>());
+            Assert.Equal(456, objectMapNull["value"]["456"].Value<int>());
+            Assert.Equal(789, objectMapNull["value"]["789"].Value<int>());
         }
 
         [Fact]

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.13.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.13.bicep
@@ -54,3 +54,12 @@ output totalAgeAdd1 int = reduce(ages, 1, (cur, next) => cur + next)
 
 // Sort
 output dogsByAge array = sort(dogs, (a, b) => a.age < b.age)
+
+// To Object
+param numbers array = [0, 1, 2, 3]
+output objectMap object = toObject([123, 456, 789], i => '${i / 100}')
+output objectMap2 object = toObject(numbers, i => '${i}', i => {
+  isEven: (i % 2) == 0
+  isGreaterThan2: (i > 2)
+})
+output objectMapNull object = toObject([123, 456, 789, null], i => '${i}')

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.13.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.13.json
@@ -1,11 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "1.9-experimental",
   "contentVersion": "1.0.0.0",
   "metadata": {
+    "_EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
     "_generator": {
       "name": "bicep",
-      "version": "0.13.1.58284",
-      "templateHash": "15169255149500185367"
+      "version": "0.14.85.62628",
+      "templateHash": "11595356597778450057"
     }
   },
   "parameters": {
@@ -23,6 +25,15 @@
           "four",
           "five"
         ]
+      ]
+    },
+    "numbers": {
+      "type": "array",
+      "defaultValue": [
+        0,
+        1,
+        2,
+        3
       ]
     }
   },
@@ -60,7 +71,7 @@
     ],
     "ages": "[map(variables('dogs'), lambda('dog', lambdaVariables('dog').age))]"
   },
-  "resources": [],
+  "resources": {},
   "outputs": {
     "arrayOutput": {
       "type": "array",
@@ -93,6 +104,18 @@
     "dogsByAge": {
       "type": "array",
       "value": "[sort(variables('dogs'), lambda('a', 'b', less(lambdaVariables('a').age, lambdaVariables('b').age)))]"
+    },
+    "objectMap": {
+      "type": "object",
+      "value": "[toObject(createArray(123, 456, 789), lambda('i', format('{0}', div(lambdaVariables('i'), 100))))]"
+    },
+    "objectMap2": {
+      "type": "object",
+      "value": "[toObject(parameters('numbers'), lambda('i', format('{0}', lambdaVariables('i'))), lambda('i', createObject('isEven', equals(mod(lambdaVariables('i'), 2), 0), 'isGreaterThan2', greater(lambdaVariables('i'), 2))))]"
+    },
+    "objectMapNull": {
+      "type": "object",
+      "value": "[toObject(createArray(123, 456, 789, null()), lambda('i', format('{0}', lambdaVariables('i'))))]"
     }
   }
 }


### PR DESCRIPTION
## PR Summary

- Added support for Bicep `toObject` function.

Fixes #2014 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
