### PR TITLE
Azure SQL Transparent Encryption: ensure proper result on exported resources

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -36,6 +36,9 @@ What's changed since pre-release v1.25.0-B0035:
     [#2052](https://github.com/Azure/PSRule.Rules.Azure/pull/2052)
   - Bump Microsoft.NET.Test.Sdk to v17.5.0.
     [#2055](https://github.com/Azure/PSRule.Rules.Azure/pull/2055)
+- Bug fixes:
+  - SQL transparent data Encryption (TDE) works properly on all resources including exported resources
+    [#2059](https://github.com/Azure/PSRule.Rules.Azure/issues/2059)
 
 ## v1.25.0-B0035 (pre-release)
 

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -37,7 +37,7 @@ What's changed since pre-release v1.25.0-B0035:
   - Bump Microsoft.NET.Test.Sdk to v17.5.0.
     [#2055](https://github.com/Azure/PSRule.Rules.Azure/pull/2055)
 - Bug fixes:
-  - SQL transparent data Encryption (TDE) works properly on all resources including exported resources
+  - Fixed SQL transparent data Encryption (TDE) works properly on all resources including exported resources by @zilberd.
     [#2059](https://github.com/Azure/PSRule.Rules.Azure/issues/2059)
 
 ## v1.25.0-B0035 (pre-release)

--- a/src/PSRule.Rules.Azure/rules/Azure.SQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.SQL.Rule.ps1
@@ -108,7 +108,7 @@ Rule 'Azure.SQL.TDE' -Ref 'AZR-000191' -Type 'Microsoft.Sql/servers/databases', 
         return $Assert.Fail($LocalizedData.SubResourceNotFound, 'Microsoft.Sql/servers/databases/transparentDataEncryption');
     }
     foreach ($config in $configs) {
-        if ($Assert.HasFieldValue($config, 'apiVersion', '2014-04-01').Result) {
+        if ($Assert.HasField($config, 'Properties.status').Result) {
             $Assert.HasFieldValue($config, 'Properties.status', 'Enabled');
         }
         else {


### PR DESCRIPTION
## PR Summary

This fixes #2059 where exported resources are sometime flaged as failed with TDE.

I have simplified the check in order so it would verifiy the precense of the two potential fields.

## PR Checklist

- [X] PR has a meaningful title
- [X] Summarized changes
- [X] Change is not breaking
- [X] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [ ] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [X] Link to a filed issue
  - [X] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
