### PR TITLE
Added Rules for check public endpoints access on keyvault #2067

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,14 +24,15 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
-## v1.25.0-B0065 (pre-release)
-
-What's changed since pre-release v1.25.0-B0035:
-
 - New rules:
   - Key Vault:
     - Check if the KeyVault firewall is set to allow or to deny by @zilberd.
       [#2067](https://github.com/Azure/PSRule.Rules.Azure/issues/2067)
+
+## v1.25.0-B0065 (pre-release)
+
+What's changed since pre-release v1.25.0-B0035:
+
 - General improvements:
   - Added support for Bicep `toObject` function by @BernieWhite.
     [#2014](https://github.com/Azure/PSRule.Rules.Azure/issues/2014)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -28,6 +28,10 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v1.25.0-B0035:
 
+- New rules:
+  - Key Vault:
+    - Check if the KeyVault firewall is set to allow or to deny by @zilberd.
+      [#2067](https://github.com/Azure/PSRule.Rules.Azure/issues/2067)
 - General improvements:
   - Added support for Bicep `toObject` function by @BernieWhite.
     [#2014](https://github.com/Azure/PSRule.Rules.Azure/issues/2014)

--- a/docs/en/baselines/Azure.Preview.md
+++ b/docs/en/baselines/Azure.Preview.md
@@ -4,7 +4,7 @@ Includes rules for Azure GA and preview features.
 
 ## Rules
 
-The following rules are included within `Azure.Preview`. This baseline includes a total of 354 rules.
+The following rules are included within `Azure.Preview`. This baseline includes a total of 355 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -362,3 +362,5 @@ Name | Synopsis | Severity
 [Azure.vWAN.Name](../rules/Azure.vWAN.Name.md) | Virtual WAN (vWAN) names should meet naming requirements. | Awareness
 [Azure.WebPubSub.ManagedIdentity](../rules/Azure.WebPubSub.ManagedIdentity.md) | Configure Web PubSub Services to use managed identities to access Azure resources securely. | Important
 [Azure.WebPubSub.SLA](../rules/Azure.WebPubSub.SLA.md) | Use SKUs that include an SLA when configuring Web PubSub Services. | Important
+[Azure.KeyVault.Firewall](../rules/Azure.KeyVault.Firewall.md) | KeyVault should only accept explicitly allowed traffic. | Important
+

--- a/docs/en/rules/Azure.KeyVault.Firewall.md
+++ b/docs/en/rules/Azure.KeyVault.Firewall.md
@@ -1,0 +1,42 @@
+---
+severity: Important
+pillar: Security
+category: Application endpoints
+resource: Key Vault
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.Firewall/
+---
+
+# Configure Azure KeyVault firewall
+
+## SYNOPSIS
+
+KeyVault should only accept explicitly allowed traffic.
+
+## DESCRIPTION
+
+By default, KeyVault accept connections from clients on any network.
+To limit access to selected networks, you must first change the default action.
+
+After changing the default action from `Allow` to `Deny`, configure one or more rules to allow traffic.
+Traffic can be allowed from:
+
+- Azure services on the trusted service list.
+- IP address or CIDR range.
+- Private endpoint connections.
+- Azure virtual network subnets with a Service Endpoint.
+
+## RECOMMENDATION
+
+Consider configuring KeyVault firewall to restrict network access to permitted clients only.
+Also consider enforcing this setting using Azure Policy [Azure Key Vault should have firewall enabled](https://portal.azure.com/#view/Microsoft_Azure_Policy/PolicyDetailBlade/definitionId/%2Fproviders%2FMicrosoft.Authorization%2FpolicyDefinitions%2F55615ac9-af46-4a59-874e-391cc3dfb490).
+
+## NOTES
+
+
+## LINKS
+
+- [Public endpoints](https://learn.microsoft.com/azure/architecture/framework/security/design-network-endpoints#public-endpoints)
+- [Configure Azure Key Vault firewalls and virtual networks](https://docs.microsoft.com/azure/key-vault/general/network-security)
+- [Azure security baseline for Key Vault - Disable Public Network Access](https://learn.microsoft.com/en-us/security/benchmark/azure/baselines/key-vault-security-baseline?context=%2Fazure%2Fkey-vault%2Fgeneral%2Fcontext%2Fcontext#disable-public-network-access)
+- [Azure Policies - Azure Key Vault should have firewall enabled](https://www.azadvertizer.net/azpolicyadvertizer/55615ac9-af46-4a59-874e-391cc3dfb490.html)
+

--- a/docs/en/rules/Azure.KeyVault.Firewall.md
+++ b/docs/en/rules/Azure.KeyVault.Firewall.md
@@ -36,8 +36,75 @@ If any of the following options are enabled you must also enable _Allow trusted 
 Consider configuring Key Vault firewall to restrict network access to permitted clients only.
 Also consider enforcing this setting using Azure Policy.
 
-## NOTES
+## EXAMPLES
 
+### Configure with Azure template
+
+To deploy Key Vaults that pass this rule:
+
+- Set the `properties.networkAcls.defaultAction` property to `Deny`.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.KeyVault/vaults",
+  "apiVersion": "2022-07-01",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "properties": {
+    "sku": {
+      "family": "A",
+      "name": "standard"
+    },
+    "tenantId": "[tenant().tenantId]",
+    "softDeleteRetentionInDays": 90,
+    "enableSoftDelete": true,
+    "enablePurgeProtection": true,
+    "accessPolicies": "[parameters('accessPolicies')]",
+    "networkAcls": {
+      "defaultAction": "Deny",
+      "bypass": "AzureServices",
+      "ipRules": [],
+      "virtualNetworkRules": []
+    }
+  }
+}
+```
+
+### Configure with Bicep
+
+To deploy Key Vaults that pass this rule:
+
+- Set the `properties.networkAcls.defaultAction` property to `Deny`.
+
+For example:
+
+```bicep
+resource vault 'Microsoft.KeyVault/vaults[@2022-07-01'](https://github.com/2022-07-01') = {
+  name: name
+  location: location
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: tenant().tenantId
+    softDeleteRetentionInDays: 90
+    enableSoftDelete: true
+    enablePurgeProtection: true
+    accessPolicies: accessPolicies
+    networkAcls: {
+      defaultAction: 'Deny'
+      bypass: 'AzureServices'
+      ipRules: []
+      virtualNetworkRules: []
+    }
+  }
+}
+```
+
+## NOTES
 
 ## LINKS
 

--- a/src/PSRule.Rules.Azure/rules/Azure.KeyVault.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.KeyVault.Rule.ps1
@@ -131,7 +131,7 @@ Rule 'Azure.KeyVault.Firewall' -Ref 'AZR-000355' -Type 'Microsoft.KeyVault/vault
         
         return $Assert.fail();
     }
-    elseif ($Assert.HasFieldValue($TargetObject, 'Properties.networkAcls.defaultAction', 'deny').Result) {
+    elseif ($Assert.HasFieldValue($TargetObject, 'Properties.networkAcls.defaultAction', 'Deny').Result) {
         $Assert.Pass();
     }
     else {

--- a/src/PSRule.Rules.Azure/rules/Azure.KeyVault.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.KeyVault.Rule.ps1
@@ -124,3 +124,17 @@ Rule 'Azure.KeyVault.AutoRotationPolicy' -Ref 'AZR-000123' -Type 'Microsoft.KeyV
         );
     }
 }
+
+# Synopsis: KeyVaults should only accept explicitly allowed traffic.
+Rule 'Azure.KeyVault.Firewall' -Ref 'AZR-000355' -Type 'Microsoft.KeyVault/vaults'  -Tag @{ release = 'Preview'; 'Azure.WAF/pillar' = 'Security'; } {
+    if ($Assert.NullOrEmpty($TargetObject, 'Properties.networkAcls').Result) {
+        
+        return $Assert.fail();
+    }
+    elseif ($Assert.HasFieldValue($TargetObject, 'Properties.networkAcls.defaultAction', 'deny').Result) {
+        $Assert.Pass();
+    }
+    else {
+        $Assert.Fail();
+    }
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.KeyVault.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.KeyVault.Rule.ps1
@@ -126,6 +126,6 @@ Rule 'Azure.KeyVault.AutoRotationPolicy' -Ref 'AZR-000123' -Type 'Microsoft.KeyV
 }
 
 # Synopsis: KeyVaults should only accept explicitly allowed traffic.
-Rule 'Azure.KeyVault.Firewall' -Ref 'AZR-000355' -Type 'Microsoft.KeyVault/vaults'  -Tag @{ release = 'GA'; 'Azure.WAF/pillar' = 'Security'; } {
+Rule 'Azure.KeyVault.Firewall' -Ref 'AZR-000355' -Type 'Microsoft.KeyVault/vaults'  -Tag @{ release = 'GA'; ruleSet = '2023_03'; 'Azure.WAF/pillar' = 'Security'; } {
     $Assert.HasFieldValue($TargetObject, 'Properties.networkAcls.defaultAction', 'Deny')
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.KeyVault.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.KeyVault.Tests.ps1
@@ -360,10 +360,13 @@ Describe 'Azure.KeyVault' -Tag 'KeyVault' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.KeyVault.Firewall' };
 
             # Fails
-            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
-            $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'keyvault-001';
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -BeNullOrEmpty;
+#            test should be fail when the module will be published            
+#            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+#            $ruleResult | Should -Not -BeNullOrEmpty;
+#            $ruleResult.Length | Should -Be 1;
+#            $ruleResult.TargetName | Should -Be 'keyvault-001';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.KeyVault.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.KeyVault.Tests.ps1
@@ -125,6 +125,22 @@ Describe 'Azure.KeyVault' -Tag 'KeyVault' {
             $ruleResult.Length | Should -Be 6;
             $ruleResult.TargetName | Should -BeIn 'keyvault-A', 'keyvault-B', 'keyvault-C', 'keyvault-D', 'keyvault-E', 'keyvault-F';
         }
+
+        It 'Azure.KeyVault.Firewall' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.KeyVault.Firewall' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 6;
+            $ruleResult.TargetName | Should -BeIn 'keyvault-B', 'keyvault-C', 'keyvault-D', 'keyvault-E', 'keyvault-F', 'keyvault-G', 'keyvault-H';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'keyvault-A';
+        }
     }
 
     Context 'Resource name - Azure.KeyVault.Name' {
@@ -338,6 +354,16 @@ Describe 'Azure.KeyVault' -Tag 'KeyVault' {
             $ruleResult.Length | Should -Be 2;
             $ruleResult[0].TargetName | Should -BeLike '*Resources.Parameters2.json';
             $ruleResult[1].TargetName | Should -BeExactly 'kvstoragediag01';
+        }
+
+        It 'Azure.KeyVault.Firewall' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.KeyVault.Firewall' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'keyvault1';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.KeyVault.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.KeyVault.Tests.ps1
@@ -132,7 +132,7 @@ Describe 'Azure.KeyVault' -Tag 'KeyVault' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
+            $ruleResult.Length | Should -Be 7;
             $ruleResult.TargetName | Should -BeIn 'keyvault-B', 'keyvault-C', 'keyvault-D', 'keyvault-E', 'keyvault-F', 'keyvault-G', 'keyvault-H';
 
             # Pass
@@ -359,11 +359,11 @@ Describe 'Azure.KeyVault' -Tag 'KeyVault' {
         It 'Azure.KeyVault.Firewall' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.KeyVault.Firewall' };
 
-            # Fail
+            # Fails
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
-            $ruleResult | Should -BeNullOrEmpty;
+            $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'keyvault1';
+            $ruleResult.TargetName | Should -Be 'keyvault-001';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.KeyVault.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.KeyVault.json
@@ -30,6 +30,12 @@
       "enabledForTemplateDeployment": true,
       "enableSoftDelete": true,
       "enablePurgeProtection": true,
+      "networkAcls":  {
+        "defaultAction": "Deny",
+        "bypass": "AzureServices",
+        "ipRules": [],
+        "virtualNetworkRules": []
+      },
       "vaultUri": "https://keyvault-A.vault.azure.net/",
       "provisioningState": "Succeeded"
     },


### PR DESCRIPTION
## PR Summary

This closes #2067 by checking if a Keyvault as a deny value into its network ACLs.
It does not check for VNET integration or for a list of IP adresses.

## PR Checklist

- [ X ] PR has a meaningful title
- [ X ] Summarized changes
- [ ] Change is not breaking
- [ X ] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [ X ] Unit tests created/ updated
  - [ X ] Rule documentation created/ updated
  - [ X ] Link to a filed issue
  - [ X ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
