### PR TITLE
Pre-release v1.25.0-B0138

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,10 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.25.0-B0138 (pre-release)
+
+What's changed since pre-release v1.25.0-B0100:
+
 - New rules:
   - Event Hub:
     - Check Event Hub namespaces only uses TLS 1.2 version by @BenjaminEngeset.


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.25.0-B0100:

- New rules:
  - Event Hub:
    - Check Event Hub namespaces only uses TLS 1.2 version by @BenjaminEngeset.
      [#1995](https://github.com/Azure/PSRule.Rules.Azure/issues/1995)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
