### PR TITLE
Fixes Azure.Deployment.Name false positive #2109

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.26.0-B0011:
+
 - New rules:
   - Container App:
     - Check that internal-only ingress for container apps are configured by @BenjaminEngeset.
@@ -38,12 +40,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
       [#2120](https://github.com/Azure/PSRule.Rules.Azure/issues/2120)
     - Check that Azure AD-only authentication is enabled by @BenjaminEngeset.
       [#2118](https://github.com/Azure/PSRule.Rules.Azure/issues/2118)
-
-What's changed since pre-release v1.26.0-B0011:
-
 - Bug fixes:
   - Fixed dependency issue of deployments across resource group scopes by @BernieWhite.
     [#2111](https://github.com/Azure/PSRule.Rules.Azure/issues/2111)
+  - Fixed false positive with `Azure.Deployment.Name` by @BernieWhite.
+    [#2109](https://github.com/Azure/PSRule.Rules.Azure/issues/2109)
 
 ## v1.26.0-B0011 (pre-release)
 

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -65,6 +65,7 @@ namespace PSRule.Rules.Azure.Data.Template
         private const string PROPERTY_DEPENDSON = "dependsOn";
         private const string PROPERTY_DEFINITIONS = "definitions";
         private const string PROPERTY_REF = "$ref";
+        private const string PROPERTY_ROOTDEPLOYMENT = "rootDeployment";
 
         internal sealed class TemplateContext : ITemplateContext
         {
@@ -482,13 +483,17 @@ namespace PSRule.Rules.Azure.Data.Template
 
                 var deployment = new JObject
                 {
-                    { PROPERTY_RESOURCENAME, ParameterFile ?? TemplateFile },
+                    { PROPERTY_RESOURCENAME, isNested ? deploymentName : ParameterFile ?? TemplateFile },
                     { PROPERTY_NAME, deploymentName },
                     { PROPERTY_PROPERTIES, properties },
                     { PROPERTY_LOCATION, ResourceGroup.Location },
                     { PROPERTY_TYPE, RESOURCETYPE_DEPLOYMENT },
-                    { PROPERTY_METADATA, metadata }
+                    { PROPERTY_METADATA, metadata },
+
+                    // Add a property to allow rules to detect root deployment. Related to: https://github.com/Azure/PSRule.Rules.Azure/issues/2109
+                    { PROPERTY_ROOTDEPLOYMENT, !isNested }
                 };
+
                 var path = template.GetResourcePath(parentLevel: 2);
                 deployment.SetTargetInfo(TemplateFile, ParameterFile, path);
                 var deploymentValue = new DeploymentValue(string.Concat(ResourceGroup.Id, "/providers/", RESOURCETYPE_DEPLOYMENT, "/", deploymentName), deploymentName, deployment, null, null);

--- a/src/PSRule.Rules.Azure/rules/Azure.Deployment.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.Deployment.Rule.yaml
@@ -21,6 +21,9 @@ metadata:
 spec:
   type:
     - Microsoft.Resources/deployments
+  where:
+    field: rootDeployment
+    notEquals: true
   condition:
     allOf:
       - name: '.'
@@ -29,4 +32,5 @@ spec:
         lessOrEquals: 64
       - name: '.'
         match: '^[A-Za-z0-9-._()]{1,64}$'
+
 #endregion Rules

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Deployment.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Deployment.Tests.ps1
@@ -127,6 +127,19 @@ Describe 'Azure.Deployment.AdminUsername' -Tag 'Deployment' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+        }
+
+        It 'Azure.Deployment.Name' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Deployment.Name' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 3;
         }
     }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Deployment.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Deployment.Tests.ps1
@@ -127,7 +127,7 @@ Describe 'Azure.Deployment.AdminUsername' -Tag 'Deployment' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
+            $ruleResult.Length | Should -Be 3;
         }
 
         It 'Azure.Deployment.Name' {
@@ -140,7 +140,7 @@ Describe 'Azure.Deployment.AdminUsername' -Tag 'Deployment' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
+            $ruleResult.Length | Should -Be 2;
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -22,7 +22,10 @@ namespace PSRule.Rules.Azure
             Assert.NotNull(resources);
             Assert.Equal(8, resources.Length);
 
-            var actual = resources[1];
+            var actual = resources[0];
+            Assert.True(actual["rootDeployment"].Value<bool>());
+
+            actual = resources[1];
             Assert.Equal("vnet-001", actual["name"].Value<string>());
             Assert.Equal("10.1.0.0/24", actual["properties"]["addressSpace"]["addressPrefixes"][0].Value<string>());
             Assert.Equal(3, actual["properties"]["subnets"].Value<JArray>().Count);
@@ -39,6 +42,7 @@ namespace PSRule.Rules.Azure
             Assert.Equal("vnet-001/subnet2/Microsoft.Authorization/c7db2a25-b75f-d22b-f692-bbb38c83d9d0", actual["name"].Value<string>());
 
             actual = resources[2];
+            Assert.False(actual["rootDeployment"].Value<bool>());
             Assert.Equal("vnetDelegation", actual["name"].Value<string>());
             Assert.Equal("Microsoft.Resources/deployments", actual["type"].Value<string>());
 


### PR DESCRIPTION
## PR Summary

- Fixed false positive with `Azure.Deployment.Name`.

Fixes #2109 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section

