### PR TITLE
Update AKS version to 1.25.6 #2136

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -45,6 +45,11 @@ What's changed since pre-release v1.26.0-B0011:
       [#2120](https://github.com/Azure/PSRule.Rules.Azure/issues/2120)
     - Check that Azure AD-only authentication is enabled by @BenjaminEngeset.
       [#2118](https://github.com/Azure/PSRule.Rules.Azure/issues/2118)
+- Updated rules:
+  - Azure Kubernetes Service:
+    - Updated `Azure.AKS.Version` to use latest stable version `1.25.6` by @BernieWhite.
+      [#2136](https://github.com/Azure/PSRule.Rules.Azure/issues/2136)
+      - Use `AZURE_AKS_CLUSTER_MINIMUM_VERSION` to configure the minimum version of the cluster.
 - Bug fixes:
   - Fixed dependency issue of deployments across resource group scopes by @BernieWhite.
     [#2111](https://github.com/Azure/PSRule.Rules.Azure/issues/2111)

--- a/docs/en/rules/Azure.AKS.Version.md
+++ b/docs/en/rules/Azure.AKS.Version.md
@@ -45,7 +45,7 @@ For example:
         }
     },
     "properties": {
-        "kubernetesVersion": "1.25.4",
+        "kubernetesVersion": "1.25.6",
         "enableRBAC": true,
         "dnsPrefix": "[parameters('dnsPrefix')]",
         "agentPoolProfiles": "[variables('allPools')]",
@@ -122,7 +122,7 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2021-10-01' = {
     }
   }
   properties: {
-    kubernetesVersion: '1.25.4'
+    kubernetesVersion: '1.25.6'
     enableRBAC: true
     dnsPrefix: dnsPrefix
     agentPoolProfiles: allPools
@@ -184,13 +184,13 @@ az aks update -n '<name>' -g '<resource_group>' --auto-upgrade-channel 'stable'
 ```
 
 ```bash
-az aks upgrade -n '<name>' -g '<resource_group>' --kubernetes-version '1.25.4'
+az aks upgrade -n '<name>' -g '<resource_group>' --kubernetes-version '1.25.6'
 ```
 
 ### Configure with Azure PowerShell
 
 ```powershell
-Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -KubernetesVersion '1.25.4'
+Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -KubernetesVersion '1.25.6'
 ```
 
 ## NOTES

--- a/docs/examples-aks.bicep
+++ b/docs/examples-aks.bicep
@@ -46,7 +46,7 @@ param systemPoolMin int
 param systemPoolMax int = 3
 
 @description('The version of Kubernetes.')
-param kubernetesVersion string = '1.25.4'
+param kubernetesVersion string = '1.25.6'
 
 @description('Maximum number of pods that can run on nodes in the system pool.')
 @minValue(30)

--- a/docs/setup/configuring-options.md
+++ b/docs/setup/configuring-options.md
@@ -46,7 +46,7 @@ Use comments to add context.
       AZURE_BICEP_FILE_EXPANSION_TIMEOUT: 15
 
       # Configure the minimum AKS cluster version.
-      AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.25.4
+      AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.25.6
 
     rule:
       # Enable custom rules that don't exist in the baseline

--- a/docs/setup/configuring-rules.md
+++ b/docs/setup/configuring-rules.md
@@ -34,7 +34,7 @@ Default:
 ```yaml
 # YAML: The default AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option
 configuration:
-  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.25.4
+  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.25.6
 ```
 
 Example:

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -43,9 +43,9 @@ To update your configuration, use the new name instead.
     Set the `AZURE_AKS_CLUSTER_MINIMUM_VERSION` option in `ps-rule.yaml`.
 
     ```yaml
-    # YAML: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.25.4
+    # YAML: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.25.6
     configuration:
-      AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.25.4
+      AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.25.6
     ```
 
 === "Bash"
@@ -53,8 +53,8 @@ To update your configuration, use the new name instead.
     Set the `PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION` environment variable.
 
     ```bash
-    # Bash: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.25.4
-    export PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION=1.25.4
+    # Bash: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.25.6
+    export PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION=1.25.6
     ```
 
 === "GitHub Actions"
@@ -62,9 +62,9 @@ To update your configuration, use the new name instead.
     Set the `PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION` environment variable.
 
     ```yaml
-    # GitHub Actions: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.25.4
+    # GitHub Actions: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.25.6
     env:
-      PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.25.4'
+      PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.25.6'
     ```
 
 === "Azure Pipelines"
@@ -72,10 +72,10 @@ To update your configuration, use the new name instead.
     Set the `PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION` environment variable.
 
     ```yaml
-    # Azure Pipelines: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.25.4
+    # Azure Pipelines: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.25.6
     variables:
     - name: PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION
-      value: '1.25.4'
+      value: '1.25.6'
     ```
 
 ### Removal of SupportsTags function

--- a/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
@@ -32,7 +32,7 @@ spec:
     AZURE_BICEP_CHECK_TOOL: false 
 
     # Configure minimum AKS cluster version
-    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.25.4'
+    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.25.6'
     AZURE_DEPLOYMENT_SENSITIVE_PROPERTY_NAMES:
     - adminUsername
     - administratorLogin

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -62,7 +62,7 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult.TargetName | Should -BeIn 'cluster-B';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[0].Reason | Should -BeExactly "Path Properties.kubernetesVersion: The version '1.13.8' does not match the constraint '>=1.25.4'.";
+            $ruleResult[0].Reason | Should -BeExactly "Path Properties.kubernetesVersion: The version '1.13.8' does not match the constraint '>=1.25.6'.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -50,7 +50,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.25.4",
+                "kubernetesVersion": "1.25.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -210,7 +210,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.25.4",
+                "kubernetesVersion": "1.25.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -395,7 +395,7 @@
                 "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-03')]",
                 "maxPods": 50,
                 "type": "VirtualMachineScaleSets",
-                "orchestratorVersion": "1.25.4",
+                "orchestratorVersion": "1.25.6",
                 "osType": "Linux",
                 "enableAutoScaling": false
             }
@@ -427,7 +427,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.25.4",
+                "kubernetesVersion": "1.25.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -628,7 +628,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.25.4",
+                "kubernetesVersion": "1.25.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName5'))]",
                 "agentPoolProfiles": [
                     {
@@ -831,7 +831,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.25.4",
+                "kubernetesVersion": "1.25.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName6'))]",
                 "agentPoolProfiles": [
                     {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -6,7 +6,7 @@
     "ResourceName": "cluster-A",
     "Name": "cluster-A",
     "Properties": {
-      "kubernetesVersion": "1.25.4",
+      "kubernetesVersion": "1.25.6",
       "dnsPrefix": "cluster-A",
       "fqdn": "cluster-A-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -18,7 +18,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "AvailabilitySet",
-          "orchestratorVersion": "1.25.4",
+          "orchestratorVersion": "1.25.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -164,7 +164,7 @@
     "ParentResource": null,
     "Properties": {
       "provisioningState": "Succeeded",
-      "kubernetesVersion": "1.25.4",
+      "kubernetesVersion": "1.25.6",
       "dnsPrefix": "cluster-C",
       "fqdn": "cluster-C-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -178,7 +178,7 @@
           "maxPods": 50,
           "type": "VirtualMachineScaleSets",
           "provisioningState": "Succeeded",
-          "orchestratorVersion": "1.25.4",
+          "orchestratorVersion": "1.25.6",
           "osType": "Linux",
           "enableAutoScaling": false
         }
@@ -284,7 +284,7 @@
     "Plan": null,
     "Properties": {
       "provisioningState": "Succeeded",
-      "kubernetesVersion": "1.25.4",
+      "kubernetesVersion": "1.25.6",
       "dnsPrefix": "cluster-D",
       "fqdn": "cluster-D-nnnnnnnn.hcp.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -297,7 +297,7 @@
           "maxPods": 50,
           "type": "VirtualMachineScaleSets",
           "provisioningState": "Succeeded",
-          "orchestratorVersion": "1.25.4",
+          "orchestratorVersion": "1.25.6",
           "nodeLabels": {},
           "mode": "System",
           "osType": "Linux",
@@ -471,7 +471,7 @@
       "powerState": {
         "code": "Running"
       },
-      "orchestratorVersion": "1.25.4",
+      "orchestratorVersion": "1.25.6",
       "nodeLabels": {},
       "mode": "System",
       "osType": "Linux",
@@ -541,7 +541,7 @@
       "powerState": {
         "code": "Running"
       },
-      "kubernetesVersion": "1.25.4",
+      "kubernetesVersion": "1.25.6",
       "dnsPrefix": "cluster-F",
       "fqdn": "cluster-F-00000000.hcp.region.azmk8s.io",
       "azurePortalFQDN": "cluster-F-00000000.portal.hcp.region.azmk8s.io",
@@ -562,7 +562,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.25.4",
+          "orchestratorVersion": "1.25.6",
           "nodeLabels": {},
           "mode": "System",
           "osType": "Linux",
@@ -769,7 +769,7 @@
     "ResourceName": "cluster-G",
     "Name": "cluster-G",
     "Properties": {
-      "kubernetesVersion": "1.25.4",
+      "kubernetesVersion": "1.25.6",
       "dnsPrefix": "cluster-G",
       "fqdn": "cluster-G-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -781,7 +781,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.25.4",
+          "orchestratorVersion": "1.25.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -943,7 +943,7 @@
     "ResourceName": "cluster-H",
     "Name": "cluster-H",
     "Properties": {
-      "kubernetesVersion": "1.25.4",
+      "kubernetesVersion": "1.25.6",
       "dnsPrefix": "cluster-H",
       "fqdn": "cluster-H-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -955,7 +955,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.25.4",
+          "orchestratorVersion": "1.25.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": []
@@ -1117,7 +1117,7 @@
     "ResourceName": "cluster-I",
     "Name": "cluster-I",
     "Properties": {
-      "kubernetesVersion": "1.25.4",
+      "kubernetesVersion": "1.25.6",
       "dnsPrefix": "cluster-I",
       "fqdn": "cluster-I-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1129,7 +1129,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.25.4",
+          "orchestratorVersion": "1.25.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -1291,7 +1291,7 @@
     "ResourceName": "cluster-J",
     "Name": "cluster-J",
     "Properties": {
-      "kubernetesVersion": "1.25.4",
+      "kubernetesVersion": "1.25.6",
       "dnsPrefix": "cluster-J",
       "fqdn": "cluster-J-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1303,7 +1303,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.25.4",
+          "orchestratorVersion": "1.25.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -1463,7 +1463,7 @@
       "powerState": {
         "code": "Running"
       },
-      "kubernetesVersion": "1.25.4",
+      "kubernetesVersion": "1.25.6",
       "dnsPrefix": "cluster-K",
       "fqdn": "cluster-K-00000000.hcp.eastus.azmk8s.io",
       "azurePortalFQDN": "cluster-K-00000000.portal.hcp.eastus.azmk8s.io",
@@ -1485,7 +1485,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.25.4",
+          "orchestratorVersion": "1.25.6",
           "mode": "System",
           "osType": "Linux",
           "osSKU": "Ubuntu",


### PR DESCRIPTION
## PR Summary

- Updated `Azure.AKS.Version` to use latest stable version `1.25.6`.

Fixes #2136 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
