### PR TITLE
Fixes non-taggable resources #2129

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,8 @@ What's changed since v1.26.0:
 - Bug fixes:
   - Fixed null union with first value being null by @BernieWhite.
     [#2075](https://github.com/Azure/PSRule.Rules.Azure/issues/2075)
+  - Fixed `Azure.Resource.UseTags` for additional resources that don't support tags by @BernieWhite.
+    [#2129](https://github.com/Azure/PSRule.Rules.Azure/issues/2129)
 
 ## v1.26.0
 

--- a/docs/en/rules/Azure.Resource.UseTags.md
+++ b/docs/en/rules/Azure.Resource.UseTags.md
@@ -1,7 +1,8 @@
 ---
+reviewed: 2023-04-20
 severity: Awareness
-pillar: Operational Excellence
-category: Tagging and resource naming
+pillar: Cost Optimization
+category: Governance
 resource: All resources
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Resource.UseTags/
 ms-content-id: d8480c0d-e41c-441a-9b03-0dc9c340c149
@@ -20,7 +21,7 @@ Tags are additional metadata that improves identification of resources and aids 
 
 Azure stores tags as name/ value pairs such as `environment = production` or `costCode = 349921`.
 
-A well defined tagging approach improves the management, billing and automation operations of resources.
+A well defined tagging approach improves the management, billing, and automation operations of resources.
 When planning tags, identify information that is meaningful to business and technical staff.
 
 Azure provides several built-in policies to managed tags.
@@ -34,14 +35,70 @@ Identify mandatory and optional tags then tag all resources and resource groups 
 
 Also consider using Azure Policy to enforce mandatory tags.
 
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy resource that pass this rule:
+
+- Set the `tags` property tags that align to your tagging standard.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.Resources/resourceGroups",
+  "apiVersion": "2022-09-01",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "tags": {
+    "environment": "production",
+    "costCode": "349921"
+  }
+}
+```
+
+### Configure with Bicep
+
+To deploy resource that pass this rule:
+
+- Set the `tags` property tags that align to your tagging standard.
+
+For example:
+
+```bicep
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: name
+  location: location
+  tags: {
+    environment: 'production'
+    costCode: '349921'
+  }
+}
+```
+
 ## NOTES
 
-Azure Policy includes the following built-in policies to enforce tagging:
+Azure Policy includes several built-in policies to enforce tagging such as:
 
-- Require a tag on resources
-- Require a tag on resource groups
+- _Add a tag to resources_
+- _Add a tag to resource groups_
+- _Require a tag on resources_
+- _Require a tag on resource groups_
+- _Inherit a tag from the resource group_
+- _Inherit a tag from the resource group if missing_
+- _Inherit a tag from the subscription_
+
+If you find resources that incorrectly report they should be tagged, please let us know by [opening an issue][1].
+
+  [1]: https://github.com/Azure/PSRule.Rules.Azure/issues/new/choose
 
 ## LINKS
 
-- [Tag support for Azure resources](https://docs.microsoft.com/azure/azure-resource-manager/management/tag-support)
-- [Recommended naming and tagging conventions](https://docs.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging#metadata-tags)
+- [Enforce resource tagging](https://learn.microsoft.com/azure/architecture/framework/cost/design-governance#enforce-resource-tagging)
+- [Tag support for Azure resources](https://learn.microsoft.com/azure/azure-resource-manager/management/tag-support)
+- [Develop your naming and tagging strategy for Azure resources](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging)
+- [Define your tagging strategy](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-tagging)
+- [Resource naming and tagging decision guide](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming-and-tagging-decision-guide)
+- [Assign policy definitions for tag compliance](https://learn.microsoft.com/azure/azure-resource-manager/management/tag-policies)
+- [Enforcing custom tags](https://azure.github.io/PSRule.Rules.Azure/customization/enforce-custom-tags/)

--- a/docs/examples-rg.bicep
+++ b/docs/examples-rg.bicep
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Bicep documentation examples
+
+targetScope = 'subscription'
+
+@description('The name of the resource group.')
+param name string
+
+@description('The location resource group will be deployed.')
+param location string = 'eastus'
+
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: name
+  location: location
+  tags: {
+    environment: 'production'
+    costCode: '349921'
+  }
+}

--- a/docs/examples-rg.json
+++ b/docs/examples-rg.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.16.2.56959",
+      "templateHash": "14150843793582590973"
+    }
+  },
+  "parameters": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the resource group."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "eastus",
+      "metadata": {
+        "description": "The location resource group will be deployed."
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2022-09-01",
+      "name": "[parameters('name')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "environment": "production",
+        "costCode": "349921"
+      }
+    }
+  ]
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -260,10 +260,13 @@ function global:SupportsTags {
             ($TargetType -eq 'Microsoft.Subscription') -or
             ($TargetType -eq 'Microsoft.Resources/deployments') -or
             ($TargetType -eq 'Microsoft.AzureActiveDirectory/b2ctenants') -or
+            ($TargetType -eq 'Microsoft.OperationsManagement/solutions') -or
+            # ($TargetType -eq 'Microsoft.AAD/domainServices/oucontainer') -or
+            ($TargetType -eq 'Microsoft.Kubernetes/registeredSubscriptions') -or
+            ($TargetType -eq 'Microsoft.Network/privateDnsZonesInternal') -or
             ($TargetType -notLike 'Microsoft.*/*') -or
             ($TargetType -like 'Microsoft.Addons/*') -or
             ($TargetType -like 'Microsoft.Advisor/*') -or
-            ($TargetType -like 'Microsoft.Authorization/*') -or
             ($TargetType -like 'Microsoft.Billing/*') -or
             ($TargetType -like 'Microsoft.Blueprint/*') -or
             ($TargetType -like 'Microsoft.Capacity/*') -or
@@ -273,6 +276,9 @@ function global:SupportsTags {
             ($TargetType -like 'Microsoft.Security/*') -or
             ($TargetType -like 'microsoft.support/*') -or
             ($TargetType -like 'Microsoft.WorkloadMonitor/*') -or
+            ($TargetType -like 'Microsoft.ManagedServices/*') -or
+            ($TargetType -like 'Microsoft.Management/*') -or
+            ($TargetType -like 'Microsoft.PolicyInsights/*') -or
             ($TargetType -like '*/providers/roleAssignments') -or
             ($TargetType -like '*/providers/diagnosticSettings') -or
 
@@ -318,6 +324,18 @@ function global:SupportsTags {
             # Some exceptions to resources (https://docs.microsoft.com/azure/azure-resource-manager/management/tag-support#microsoftcostmanagement)
             ($TargetType -like 'Microsoft.CostManagement/*' -and !(
                 $TargetType -eq 'Microsoft.CostManagement/Connectors'
+            )) -or
+
+            ($TargetType -like 'Microsoft.KubernetesConfiguration/*' -and !(
+                $TargetType -eq 'Microsoft.KubernetesConfiguration/privateLinkScopes'
+            )) -or
+
+            ($TargetType -like 'Microsoft.ManagedIdentity/*' -and !(
+                $TargetType -eq 'Microsoft.ManagedIdentity/userAssignedIdentities'
+            )) -or
+
+            ($TargetType -like 'Microsoft.Authorization/*' -and !(
+                $TargetType -eq 'Microsoft.Authorization/resourceManagementPrivateLinks'
             ))
         ) {
             return $False;

--- a/src/PSRule.Rules.Azure/rules/Azure.Resource.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Resource.Rule.ps1
@@ -5,15 +5,15 @@
 # Validation rules for Azure resources
 #
 
-# Synopsis: Resources should be tagged
-Rule 'Azure.Resource.UseTags' -Ref 'AZR-000166' -With 'Azure.Resource.SupportsTags' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
+# Synopsis: Azure resources should be tagged using a standard convention.
+Rule 'Azure.Resource.UseTags' -Ref 'AZR-000166' -With 'Azure.Resource.SupportsTags' -Tag @{ release = 'GA'; ruleSet = '2020_06'; 'Azure.WAF/pillar' = 'Cost Optimization'; } {
     Reason $LocalizedData.ResourceNotTagged
     # List of resource that support tags can be found here: https://docs.microsoft.com/en-us/azure/azure-resource-manager/tag-support
     $Assert.HasField($TargetObject, 'tags')
     $Assert.Create(($TargetObject.Tags.PSObject.Members | Where-Object { $_.MemberType -eq 'NoteProperty' }) -ne $Null)
 }
 
-# Synopsis: Resources should be deployed to allowed regions
+# Synopsis:Resources should be deployed to allowed regions.
 Rule 'Azure.Resource.AllowedRegions' -Ref 'AZR-000167' -If { ($Null -ne $Configuration.Azure_AllowedRegions) -and ($Configuration.Azure_AllowedRegions.Length -gt 0) -and (SupportsRegions) -and $PSRule.TargetType -ne 'Microsoft.Resources/deployments' } -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $region = @($Configuration.Azure_AllowedRegions);
     foreach ($r in $Configuration.Azure_AllowedRegions) {

--- a/src/PSRule.Rules.Azure/rules/Common.Selector.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Common.Selector.Rule.yaml
@@ -48,7 +48,6 @@ spec:
       notStartsWith:
       - Microsoft.Addons/
       - Microsoft.Advisor/
-      - Microsoft.Authorization/
       - Microsoft.Billing/
       - Microsoft.Blueprint/
       - Microsoft.Capacity/
@@ -58,12 +57,20 @@ spec:
       - Microsoft.Security/
       - microsoft.support/
       - Microsoft.WorkloadMonitor/
+      - Microsoft.ManagedServices/
+      - Microsoft.Management/
+      - Microsoft.PolicyInsights/
 
     # Exclude resource types that do not support tags
     - type: '.'
       notIn:
       - Microsoft.Subscription
       - Microsoft.AzureActiveDirectory/b2ctenants
+      - Microsoft.OperationsManagement/solutions
+      # - Microsoft.AAD/domainServices/oucontainer
+      # - Microsoft.Automation/automationAccounts/softwareUpdateConfigurations
+      - Microsoft.Kubernetes/registeredSubscriptions
+      - Microsoft.Network/privateDnsZonesInternal
     - type: '.'
       notEndsWith:
       - /providers/roleAssignments
@@ -86,6 +93,27 @@ spec:
       - type: '.'
         in:
         - Microsoft.CostManagement/Connectors
+
+    - anyOf:
+      - type: '.'
+        notStartsWith: Microsoft.KubernetesConfiguration/
+      - type: '.'
+        in:
+        - Microsoft.KubernetesConfiguration/privateLinkScopes
+
+    - anyOf:
+      - type: '.'
+        notStartsWith: Microsoft.ManagedIdentity/
+      - type: '.'
+        in:
+        - Microsoft.ManagedIdentity/userAssignedIdentities
+
+    - anyOf:
+      - type: '.'
+        notStartsWith: Microsoft.Authorization/
+      - type: '.'
+        in:
+        - Microsoft.Authorization/resourceManagementPrivateLinks
 
     - anyOf:
       - type: '.'

--- a/tests/PSRule.Rules.Azure.Tests/Common.Selector.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Common.Selector.Tests.ps1
@@ -55,6 +55,11 @@ Describe 'SupportsTags' -Tag 'Common', 'Filters', 'SupportsTags' {
             'microsoft.insights/dataCollectionEndpoints'
             'microsoft.insights/components'
             'microsoft.insights/workbooks'
+            'Microsoft.KubernetesConfiguration/privateLinkScopes'
+            'Microsoft.Kubernetes/connectedClusters'
+            'Microsoft.ManagedIdentity/userAssignedIdentities'
+            'Microsoft.Authorization/resourceManagementPrivateLinks'
+            'Microsoft.Network/privateDnsZones'
         )
 
         $notSupportedTypes = @(
@@ -68,6 +73,18 @@ Describe 'SupportsTags' -Tag 'Common', 'Filters', 'SupportsTags' {
             'microsoft.insights/dataCollectionRuleAssociations'
             'microsoft.insights/logs'
             'Microsoft.AzureActiveDirectory/b2ctenants'
+            'Microsoft.KubernetesConfiguration/extensions'
+            'Microsoft.Kubernetes/registeredSubscriptions'
+            'Microsoft.ManagedServices/registrationDefinitions'
+            'Microsoft.ManagedIdentity/Identities'
+            'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials'
+            'Microsoft.Management/resources'
+            'Microsoft.OperationsManagement/solutions'
+            'Microsoft.PolicyInsights/remediations'
+            'Microsoft.AAD/domainServices/oucontainer'
+            'Microsoft.Automation/automationAccounts/softwareUpdateConfigurations'
+            'Microsoft.Network/privateDnsZonesInternal'
+            'Microsoft.Network/privateDnsZones/AAAA'
         )
     }
 


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.Resource.UseTags` for additional resources that don't support tags.

Fixes #2129 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
