### PR TITLE
Fixes handling of MariaDB database name #2191

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.27.0-B0015:
+
 - New rules:
   - Arc-enabled Kubernetes cluster:
     - Check that Microsoft Defender for Containers extension for Arc-enabled Kubernetes clusters is configured by @BenjaminEngeset.
@@ -34,6 +36,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
   - Virtual Machine:
     - Check that a maintenance configuration for virtual machines is associated by @BenjaminEngeset.
       [#2121](https://github.com/Azure/PSRule.Rules.Azure/issues/2121)
+- Bug fixes:
+  - Fixed handling of database name in `Azure.MariaDB.Database` by @BernieWhite.
+    [#2191](https://github.com/Azure/PSRule.Rules.Azure/issues/2191)
 
 ## v1.27.0-B0015 (pre-release)
 

--- a/docs/en/rules/Azure.MariaDB.DatabaseName.md
+++ b/docs/en/rules/Azure.MariaDB.DatabaseName.md
@@ -33,4 +33,4 @@ This rule does not check if Azure Database for MariaDB database names are unique
 
 - [Repeatable infrastructure](https://learn.microsoft.com/azure/architecture/framework/devops/automation-infrastructure)
 - [Naming rules and restrictions Azure Database for MariaDB resources](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb)
-- [Template reference](https://learn.microsoft.com/azure/templates/microsoft.dbformariadb/servers/databases)
+- [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.dbformariadb/servers/databases)

--- a/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.ps1
@@ -155,10 +155,10 @@ function global:GetMariaDBDatabaseName {
     process {
         if ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers') {
             GetSubResources -ResourceType 'Microsoft.DBforMariaDB/servers/databases' |
-            ForEach-Object { $_.name }
+            ForEach-Object { ($_.name -split '/')[-1] }
         }
         elseif ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers/databases') {
-            $PSRule.TargetName
+            ($PSRule.TargetName -split '/')[-1]
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.MariaDB.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.MariaDB.Tests.ps1
@@ -236,6 +236,7 @@ Describe 'Azure.MariaDB' -Tag 'MariaDB' {
                 'MARIADBDATABASE1'
                 'mariadb-DATABASE1'
                 'MARIADB-DATABASE1'
+                'server1/MARIADB-DATABASE1'
             )
 
             $invalidNames = @(
@@ -243,6 +244,7 @@ Describe 'Azure.MariaDB' -Tag 'MariaDB' {
                 'mariadbdatabase1_'
                 'mariadbdatabase.1'
                 'MARIA.DB.DATABASE.1'
+                'server/MARIA.DB.DATABASE.1'
             )
         }
 


### PR DESCRIPTION
## PR Summary

- Fixed handling of database name in `Azure.MariaDB.Database`.

Fixes #2191

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
