### PR TITLE
Pre-release v1.28.0-B0045

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.28.0-B0045 (pre-release)
+
 What's changed since pre-release v1.28.0-B0024:
 
 - Removed rules:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.28.0-B0024:

- Removed rules:
  - Azure Kubernetes Service:
    - Removed `Azure.AKS.PodIdentity` as pod identities has been replaced by workload identities by @BernieWhite.
      [#2273](https://github.com/Azure/PSRule.Rules.Azure/issues/2273)
- Engineering:
  - Bump Microsoft.NET.Test.Sdk to v17.6.2.
    [#2266](https://github.com/Azure/PSRule.Rules.Azure/pull/2266)
  - Bump Az.Resources to v6.7.0.
    [#2274](https://github.com/Azure/PSRule.Rules.Azure/pull/2274)
- Bug fixes:
  - Fixed false positive of `IsolatedV2` with `Azure.AppService.MinPlan` by @BernieWhite.
    [#2277](https://github.com/Azure/PSRule.Rules.Azure/issues/2277)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
