### PR TITLE
Add support for managementGroupResourceId #2294

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -26,6 +26,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v1.28.0-B0045:
 
+- General improvements:
+  - Added support for `managementGroupResourceId` Bicep function by @BernieWhite.
+    [#2294](https://github.com/Azure/PSRule.Rules.Azure/issues/2294)
 - Engineering:
   - Bump Microsoft.CodeAnalysis.NetAnalyzers to v7.0.3.
     [#2281](https://github.com/Azure/PSRule.Rules.Azure/pull/2281)

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -730,6 +730,29 @@ namespace PSRule.Rules.Azure
             Assert.Throws<ExpressionArgumentException>(() => Functions.TenantResourceId(context, new object[] { "Unit.Test/type", 1 }));
         }
 
+        [Fact]
+        [Trait(TRAIT, TRAIT_RESOURCE)]
+        public void ManagementGroupResourceId()
+        {
+            var context = GetContext();
+
+            var actual = Functions.ManagementGroupResourceId(context, new object[] { "Unit.Test/type", "a" }) as string;
+            Assert.Equal("/providers/Microsoft.Management/managementGroups/psrule-test/providers/Unit.Test/type/a", actual);
+
+            context.ManagementGroup.Name = "mg1";
+            actual = Functions.ManagementGroupResourceId(context, new object[] { "Unit.Test/type/subtype", "a", "b" }) as string;
+            Assert.Equal("/providers/Microsoft.Management/managementGroups/mg1/providers/Unit.Test/type/a/subtype/b", actual);
+
+            actual = Functions.ManagementGroupResourceId(context, new object[] { "Unit.Test/type/subtype/subsubtype", "a", "b", "c" }) as string;
+            Assert.Equal("/providers/Microsoft.Management/managementGroups/mg1/providers/Unit.Test/type/a/subtype/b/subsubtype/c", actual);
+
+            Assert.Throws<ExpressionArgumentException>(() => Functions.ManagementGroupResourceId(context, null));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.ManagementGroupResourceId(context, new object[] { "Unit.Test/type" }));
+            Assert.Throws<TemplateFunctionException>(() => Functions.ManagementGroupResourceId(context, new object[] { "00000000-0000-0000-0000-000000000000", "Unit.Test/type" }));
+            Assert.Throws<TemplateFunctionException>(() => Functions.ManagementGroupResourceId(context, new object[] { "Unit.Test/type", "a", "b" }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.ManagementGroupResourceId(context, new object[] { "Unit.Test/type", 1 }));
+        }
+
         #endregion Resource
 
         #region Scope

--- a/tests/PSRule.Rules.Azure.Tests/ResourceHelperTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/ResourceHelperTests.cs
@@ -108,6 +108,12 @@ namespace PSRule.Rules.Azure
         }
 
         [Fact]
+        public void CombineResourceIdManagementGroup()
+        {
+            Assert.Equal("/providers/Microsoft.Management/managementGroups/mg1/providers/Microsoft.Authorization/policyAssignments/assignment1", ResourceHelper.CombineResourceId("mg1", new string[] { "Microsoft.Authorization/policyAssignments" }, new string[] { "assignment1" }));
+        }
+
+        [Fact]
         public void GetParentResourceId()
         {
             var resourceType = new string[]


### PR DESCRIPTION
## PR Summary

- Added support for `managementGroupResourceId` Bicep function.

Fixes #2294.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
