### PR TITLE
Pre-release v1.28.0-B0079

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.28.0-B0079 (pre-release)
+
 What's changed since pre-release v1.28.0-B0045:
 
 - General improvements:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.28.0-B0045:

- General improvements:
  - Added support for `managementGroupResourceId` Bicep function by @BernieWhite.
    [#2294](https://github.com/Azure/PSRule.Rules.Azure/issues/2294)
- Engineering:
  - Bump PSRule to v2.9.0.
    [#2293](https://github.com/Azure/PSRule.Rules.Azure/pull/2293)
  - Bump Microsoft.CodeAnalysis.NetAnalyzers to v7.0.3.
    [#2281](https://github.com/Azure/PSRule.Rules.Azure/pull/2281)
  - Bump Microsoft.NET.Test.Sdk to v17.6.3.
    [#2290](https://github.com/Azure/PSRule.Rules.Azure/pull/2290)
  - Bump coverlet.collector to v6.0.0.
    [#2232](https://github.com/Azure/PSRule.Rules.Azure/pull/2232)
- Bug fixes:
  - Fixed handling of JArray outputs with runtime values by @BernieWhite.
    [#2159](https://github.com/Azure/PSRule.Rules.Azure/issues/2159)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
