### PR TITLE
Pre-release v1.28.0-B0159

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.28.0-B0159 (pre-release)
+
 What's changed since pre-release v1.28.0-B0115:
 
 - New features:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.28.0-B0115:

- New features:
  - Added June 2023 baselines `Azure.GA_2023_06` and `Azure.Preview_2023_06` by @BernieWhite.
    [#2310](https://github.com/Azure/PSRule.Rules.Azure/issues/2310)
    - Includes rules released before or during June 2023.
    - Marked `Azure.GA_2023_03` and `Azure.Preview_2023_03` baselines as obsolete.
- Engineering:
  - Bump xunit to v2.5.0.
    [#2306](https://github.com/Azure/PSRule.Rules.Azure/pull/2306)
  - Bump xunit.runner.visualstudio to v2.5.0.
    [#2307](https://github.com/Azure/PSRule.Rules.Azure/pull/2307)
- Bug fixes:
  - Fixed Redis firewall rules can not bind to start by @BernieWhite.
    [#2303](https://github.com/Azure/PSRule.Rules.Azure/issues/2303)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**

