### PR TITLE
Added support for safe dereference operator #2322

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -42,6 +42,8 @@ What's changed since pre-release v1.28.0-B0159:
     [#2321](https://github.com/Azure/PSRule.Rules.Azure/issues/2321)
   - Fixed handling of nested mock objects @BernieWhite.
     [#2325](https://github.com/Azure/PSRule.Rules.Azure/issues/2325)
+  - Fixed late binding of `coalesce` function by @BernieWhite.
+    [#2328](https://github.com/Azure/PSRule.Rules.Azure/issues/2328)
 
 ## v1.28.0-B0159 (pre-release)
 

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -26,6 +26,10 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v1.28.0-B0159:
 
+- General improvements:
+  - Added support for safe dereference operator by @BernieWhite.
+    [#2322](https://github.com/Azure/PSRule.Rules.Azure/issues/2322)
+    - Added support for `tryGet` Bicep function.
 - Engineering:
   - Bump BenchmarkDotNet to v0.13.6.
     [#2317](https://github.com/Azure/PSRule.Rules.Azure/pull/2317)

--- a/src/PSRule.Rules.Azure/Common/DictionaryExtensions.cs
+++ b/src/PSRule.Rules.Azure/Common/DictionaryExtensions.cs
@@ -1,11 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace PSRule.Rules.Azure
 {
+    /// <summary>
+    /// Extension methods for dictionary instances.
+    /// </summary>
     internal static class DictionaryExtensions
     {
         [DebuggerStepThrough]
@@ -33,6 +37,18 @@ namespace PSRule.Rules.Azure
             if (dictionary.TryGetValue(key, out var v) && v is T result)
             {
                 value = result;
+                return true;
+            }
+            return false;
+        }
+
+        [DebuggerStepThrough]
+        public static bool TryGetValue(this IDictionary dictionary, string key, out object value)
+        {
+            value = default;
+            if (dictionary.Contains(key))
+            {
+                value = dictionary[key];
                 return true;
             }
             return false;

--- a/src/PSRule.Rules.Azure/Common/TypeExtensions.cs
+++ b/src/PSRule.Rules.Azure/Common/TypeExtensions.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Reflection;
+
+namespace PSRule.Rules.Azure
+{
+    /// <summary>
+    /// Extensions for types.
+    /// </summary>
+    internal static class TypeExtensions
+    {
+        public static bool TryGetValue(this Type type, object instance, string propertyOrField, out object value)
+        {
+            value = null;
+            var property = type.GetProperty(propertyOrField, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.GetProperty | BindingFlags.Public);
+            if (property != null)
+            {
+                value = property.GetValue(instance);
+                return true;
+            }
+
+            // Try field
+            var field = type.GetField(propertyOrField, BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.GetField | BindingFlags.Public);
+            if (field != null)
+            {
+                value = field.GetValue(instance);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -60,7 +60,7 @@ namespace PSRule.Rules.Azure.Data.Template
             new FunctionDescriptor("union", Union),
 
             // Comparison
-            new FunctionDescriptor("coalesce", Coalesce),
+            new FunctionDescriptor("coalesce", Coalesce, delayBinding: true),
             new FunctionDescriptor("equals", Equals),
             new FunctionDescriptor("greater", Greater),
             new FunctionDescriptor("greaterOrEquals", GreaterOrEquals),
@@ -218,6 +218,7 @@ namespace PSRule.Rules.Azure.Data.Template
 
             for (var i = 0; i < args.Length; i++)
             {
+                args[i] = GetExpression(context, args[i]);
                 if (!IsNull(args[i]))
                     return args[i];
             }

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -56,6 +56,7 @@ namespace PSRule.Rules.Azure.Data.Template
             new FunctionDescriptor("range", Range),
             new FunctionDescriptor("skip", Skip),
             new FunctionDescriptor("take", Take),
+            new FunctionDescriptor("tryGet", TryGet),
             new FunctionDescriptor("union", Union),
 
             // Comparison
@@ -310,17 +311,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 throw ArgumentsOutOfRange(nameof(Contains), args);
 
             var objectToFind = args[1];
-
-            if (args[0] is Array avalue)
-                return Contains(avalue, objectToFind);
-            else if (args[0] is JArray jArray)
-                return jArray.Contains(JToken.FromObject(objectToFind));
-            else if (args[0] is string svalue)
-                return svalue.Contains(objectToFind.ToString());
-            else if (args[0] is JObject jObject)
-                return jObject.ContainsKeyInsensitive(objectToFind.ToString());
-
-            return false;
+            return HasChild(args[0], objectToFind);
         }
 
         /// <summary>
@@ -703,6 +694,23 @@ namespace PSRule.Rules.Azure.Data.Template
             }
 
             throw ArgumentFormatInvalid(nameof(Take));
+        }
+
+        internal static object TryGet(ITemplateContext context, object[] args)
+        {
+            if (args == null || args.Length < 2)
+                throw ArgumentsOutOfRange(nameof(TryGet), args);
+
+            var o = args[0];
+            for (var i = 1; i < args.Length; i++)
+            {
+                if (args[i] is string propertyName && ExpressionHelpers.TryPropertyOrField(o, propertyName, out var value) ||
+                    args[i] is int index && ExpressionHelpers.TryIndex(o, index, out value))
+                    o = value;
+                else
+                    return null;
+            }
+            return o;
         }
 
         internal static object Union(ITemplateContext context, object[] args)
@@ -2161,6 +2169,20 @@ namespace PSRule.Rules.Azure.Data.Template
                 value = jObject;
                 return true;
             }
+            return false;
+        }
+
+        private static bool HasChild(object value, object child)
+        {
+            if (value is Array avalue)
+                return Contains(avalue, child);
+            else if (value is JArray jArray)
+                return jArray.Contains(JToken.FromObject(child));
+            else if (value is string svalue)
+                return svalue.Contains(child.ToString());
+            else if (value is JObject jObject)
+                return jObject.ContainsKeyInsensitive(child.ToString());
+
             return false;
         }
 

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -58,21 +58,19 @@ namespace PSRule.Rules.Azure
         [Trait(TRAIT, TRAIT_ARRAY)]
         public void Coalesce()
         {
+            ExpressionFnOuter throws = (context) => throw new NotImplementedException();
             var context = GetContext();
 
-            var actual1 = Functions.Coalesce(context, new object[] { null, null, 1, 2, 3 });
-            var actual2 = Functions.Coalesce(context, new object[] { null, null, "a", "b", "c" });
-            var actual3 = Functions.Coalesce(context, new object[] { null, JObject.Parse("{ \"a\": \"b\", \"c\": \"d\" }") }) as JToken;
-            var actual4 = Functions.Coalesce(context, new object[] { null });
-            var actual5 = Functions.Coalesce(context, new object[] { null, null });
-            Assert.Equal(1, actual1);
-            Assert.Equal("a", actual2);
-            Assert.Equal("b", actual3["a"]);
-            Assert.Null(actual4);
-            Assert.Null(actual5);
+            Assert.Equal(1, Functions.Coalesce(context, new object[] { null, null, 1, 2, 3 }));
+            Assert.Equal("a", Functions.Coalesce(context, new object[] { null, null, "a", "b", "c" }));
+            Assert.Equal("b", (Functions.Coalesce(context, new object[] { null, JObject.Parse("{ \"a\": \"b\", \"c\": \"d\" }") }) as JToken)["a"]);
+            Assert.Null(Functions.Coalesce(context, new object[] { null }));
+            Assert.Null(Functions.Coalesce(context, new object[] { null, null }));
+            Assert.Equal("a", Functions.Coalesce(context, new object[] { null, "a", throws }));
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Coalesce(context, null));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Coalesce(context, System.Array.Empty<object>()));
+            Assert.Throws<NotImplementedException>(() => Functions.Coalesce(context, new object[] { null, throws }));
         }
 
         [Fact]

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -563,6 +563,36 @@ namespace PSRule.Rules.Azure
             Assert.Equal(2, actual2.Length);
         }
 
+        [Fact]
+        [Trait(TRAIT, TRAIT_ARRAY)]
+        public void TryGet()
+        {
+            var context = GetContext();
+            var testObject = new JObject
+            {
+                {
+                    "properties", new JObject
+                    {
+                        { "displayName", "Test 001" },
+                        { "values", new JArray("Value 1", "Value 2") }
+                    }
+                }
+            };
+
+            Assert.Equal("Test 001", (Functions.TryGet(context, new object[] { testObject, "properties" }) as JObject)["displayName"].Value<string>());
+            Assert.Equal("Test 001", (Functions.TryGet(context, new object[] { testObject, "properties", "displayName" }) as JValue).Value<string>());
+            Assert.Equal("Value 2", (Functions.TryGet(context, new object[] { testObject, "properties", "values", 1 }) as JValue).Value<string>());
+            Assert.Null(Functions.TryGet(context, new object[] { testObject, "properties", "values", 2 }));
+            Assert.Null(Functions.TryGet(context, new object[] { testObject, "notValue" }));
+            Assert.Null(Functions.TryGet(context, new object[] { testObject, "notValue", 0 }));
+            Assert.Null(Functions.TryGet(context, new object[] { testObject, "properties", "notValue" }));
+            Assert.Null(Functions.TryGet(context, new object[] { testObject, "properties", "notValue", "value" }));
+
+            Assert.Throws<ExpressionArgumentException>(() => Functions.TryGet(context, null));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.TryGet(context, System.Array.Empty<object>()));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.TryGet(context, new object[] { "one" }));
+        }
+
         #endregion Array and object
 
         #region Resource

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -843,6 +843,11 @@ namespace PSRule.Rules.Azure
         {
             var resources = ProcessTemplate(GetSourcePath("Tests.Bicep.23.json"), null, out _);
             Assert.Equal(2, resources.Length);
+
+            var actual = resources[1]["resources"][0].Value<JObject>();
+            Assert.NotNull(actual);
+            Assert.Equal("ps-rule-test-deployment/test", actual["name"].Value<string>());
+            Assert.Equal("Test 001", actual["properties"]["displayName"].Value<string>());
         }
 
         #region Helper methods

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.19.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.19.bicep
@@ -29,7 +29,7 @@ resource taskDeployment 'Microsoft.Resources/deployments@2020-10-01' = {
   properties: {
     mode: 'Incremental'
     parameters: {
-      Enabled: (!contains(task.Config, 'Disable')) || (!task.Config.Disable)
+      Enabled: (!contains(task.Config, 'Disable')) || (!task.?Config.Disable)
     }
   }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.19.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.19.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.16.2.56959",
-      "templateHash": "5576463692274334464"
+      "version": "0.19.5.34762",
+      "templateHash": "18012838074292175007"
     }
   },
   "parameters": {
@@ -46,7 +46,7 @@
       "properties": {
         "mode": "Incremental",
         "parameters": {
-          "Enabled": "[or(not(contains(variables('task').Config, 'Disable')), not(variables('task').Config.Disable))]"
+          "Enabled": "[or(not(contains(variables('task').Config, 'Disable')), not(tryGet(variables('task'), 'Config', 'Disable')))]"
         }
       }
     }

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.23.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.23.bicep
@@ -10,7 +10,7 @@ param identityId string = '/subscriptions/nnn/resourceGroups/nnn/providers/Micro
 param values array = [
   {
     name: 'test'
-    displayName: 'test'
+    displayName: 'Test 001'
     secretIdentifier: 'test'
   }
 ]
@@ -36,11 +36,11 @@ resource value 'Microsoft.ApiManagement/service/namedValues@2022-08-01' = [for i
   parent: service
   name: item.name
   properties: {
-    displayName: contains(item, 'displayName') ? item.displayName : item.name
+    displayName: item.?displayName ?? item.name
     secret: contains(item, 'secretIdentifier')
     value: contains(item, 'secretIdentifier') ? null : item.value
     keyVault: contains(item, 'secretIdentifier') ? {
-      identityClientId: service.identity.userAssignedIdentities[identityId].clientId
+      identityClientId: service.identity.?userAssignedIdentities[identityId].clientId
       secretIdentifier: item.secretIdentifier
     } : null
   }

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.23.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.23.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.19.5.34762",
-      "templateHash": "10835172705049310715"
+      "templateHash": "2098796325415382221"
     }
   },
   "parameters": {
@@ -28,7 +28,7 @@
       "defaultValue": [
         {
           "name": "test",
-          "displayName": "test",
+          "displayName": "Test 001",
           "secretIdentifier": "test"
         }
       ]
@@ -63,10 +63,10 @@
       "apiVersion": "2022-08-01",
       "name": "[format('{0}/{1}', parameters('name'), parameters('values')[copyIndex()].name)]",
       "properties": {
-        "displayName": "[if(contains(parameters('values')[copyIndex()], 'displayName'), parameters('values')[copyIndex()].displayName, parameters('values')[copyIndex()].name)]",
+        "displayName": "[coalesce(tryGet(parameters('values')[copyIndex()], 'displayName'), parameters('values')[copyIndex()].name)]",
         "secret": "[contains(parameters('values')[copyIndex()], 'secretIdentifier')]",
         "value": "[if(contains(parameters('values')[copyIndex()], 'secretIdentifier'), null(), parameters('values')[copyIndex()].value)]",
-        "keyVault": "[if(contains(parameters('values')[copyIndex()], 'secretIdentifier'), createObject('identityClientId', reference('service', '2022-08-01', 'full').identity.userAssignedIdentities[parameters('identityId')].clientId, 'secretIdentifier', parameters('values')[copyIndex()].secretIdentifier), null())]"
+        "keyVault": "[if(contains(parameters('values')[copyIndex()], 'secretIdentifier'), createObject('identityClientId', tryGet(reference('service', '2022-08-01', 'full').identity, 'userAssignedIdentities', parameters('identityId'), 'clientId'), 'secretIdentifier', parameters('values')[copyIndex()].secretIdentifier), null())]"
       },
       "dependsOn": [
         "service"


### PR DESCRIPTION
## PR Summary

- Added support for safe dereference operator.
- Fixed late binding of `coalesce` function.

Fixes #2322 
Fixes #2328 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
