### PR TITLE
Fixes mismatch of RG policy type #2338

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,8 @@ What's changed since v1.28.0:
 - Bug fixes:
   - Fixed `parseCidr` with `/32` is not valid by @BernieWhite.
     [#2336](https://github.com/Azure/PSRule.Rules.Azure/issues/2336)
+  - Fixed mismatch of resource group type on policy as code rules by @BernieWhite.
+    [#2338](https://github.com/Azure/PSRule.Rules.Azure/issues/2338)
 
 ## v1.28.0
 

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
@@ -82,6 +82,8 @@ namespace PSRule.Rules.Azure.Data.Policy
         private const string TYPE_SECURITYASSESSMENTS = "Microsoft.Security/assessments";
         private const string TYPE_GUESTCONFIGURATIONASSIGNMENTS = "Microsoft.GuestConfiguration/guestConfigurationAssignments";
         private const string TYPE_BACKUPPROTECTEDITEMS = "Microsoft.RecoveryServices/backupprotecteditems";
+        private const string TYPE_SUBSCRIPTION_RESOURCEGROUP = "Microsoft.Resources/subscriptions/resourceGroups";
+        private const string TYPE_RESOURCEGROUP = "Microsoft.Resources/resourceGroups";
 
         private static readonly CultureInfo AzureCulture = new("en-US");
 
@@ -417,6 +419,9 @@ namespace PSRule.Rules.Azure.Data.Policy
                         // Set policy rule type
                         else if (hasFieldType && child.TryGetProperty(PROPERTY_EQUALS, out field))
                         {
+                            if (string.Equals(TYPE_SUBSCRIPTION_RESOURCEGROUP, field, StringComparison.OrdinalIgnoreCase))
+                                field = TYPE_RESOURCEGROUP;
+
                             types.Add(field);
                             SetPolicyRuleType(field);
                         }

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -31,6 +31,9 @@
     <None Update="environments.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Policy.assignment.2.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Policy.assignment.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Rules.Azure.Tests/Policy.assignment.2.json
+++ b/tests/PSRule.Rules.Azure.Tests/Policy.assignment.2.json
@@ -1,0 +1,91 @@
+[
+  {
+    "Identity": null,
+    "Location": null,
+    "Name": "8a3e449a009c485b930b36f2",
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/8a3e449a009c485b930b36f2",
+    "ResourceName": "8a3e449a009c485b930b36f2",
+    "ResourceGroupName": null,
+    "ResourceType": "Microsoft.Authorization/policyAssignments",
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "Sku": null,
+    "PolicyAssignmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/8a3e449a009c485b930b36f2",
+    "Properties": {
+      "Scope": "/subscriptions/00000000-0000-0000-0000-000000000000",
+      "NotScopes": [],
+      "DisplayName": "Allowed locations for resource groups",
+      "Description": null,
+      "Metadata": {
+        "assignedBy": "",
+        "parameterScopes": {
+          "listOfAllowedLocations": "/subscriptions/00000000-0000-0000-0000-000000000000"
+        },
+        "createdBy": "",
+        "createdOn": "",
+        "updatedBy": null,
+        "updatedOn": null
+      },
+      "EnforcementMode": 0,
+      "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988",
+      "Parameters": {
+        "listOfAllowedLocations": {
+          "value": [
+            "australiaeast",
+            "australiasoutheast",
+            "eastus",
+            "westus"
+          ]
+        }
+      },
+      "NonComplianceMessages": []
+    },
+    "PolicyDefinitions": [
+      {
+        "Name": "e765b5de-1225-4ba3-bd56-1ac6695af988",
+        "ResourceId": "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988",
+        "ResourceName": "e765b5de-1225-4ba3-bd56-1ac6695af988",
+        "ResourceType": "Microsoft.Authorization/policyDefinitions",
+        "SubscriptionId": null,
+        "Properties": {
+          "Description": "This policy enables you to restrict the locations your organization can create resource groups in. Use to enforce your geo-compliance requirements.",
+          "DisplayName": "Allowed locations for resource groups",
+          "Metadata": {
+            "version": "1.0.0",
+            "category": "General"
+          },
+          "Mode": "All",
+          "Parameters": {
+            "listOfAllowedLocations": {
+              "type": "Array",
+              "metadata": {
+                "description": "The list of locations that resource groups can be created in.",
+                "strongType": "location",
+                "displayName": "Allowed locations"
+              }
+            }
+          },
+          "PolicyRule": {
+            "if": {
+              "allOf": [
+                {
+                  "field": "type",
+                  "equals": "Microsoft.Resources/subscriptions/resourceGroups"
+                },
+                {
+                  "field": "location",
+                  "notIn": "[parameters('listOfAllowedLocations')]"
+                }
+              ]
+            },
+            "then": {
+              "effect": "deny"
+            }
+          },
+          "PolicyType": 2
+        },
+        "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
+      }
+    ],
+    "exemptions": []
+  }
+]

--- a/tests/PSRule.Rules.Azure.Tests/PolicyAssignmentVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/PolicyAssignmentVisitorTests.cs
@@ -126,6 +126,31 @@ namespace PSRule.Rules.Azure
             Assert.Single(definitions);
         }
 
+        [Fact]
+        public void GetResourceGroupLocation()
+        {
+            var context = new PolicyAssignmentContext(GetContext());
+            var visitor = new PolicyAssignmentDataExportVisitor();
+            foreach (var assignment in GetAssignmentData("Policy.assignment.2.json").Where(a => a["Name"].Value<string>() == "8a3e449a009c485b930b36f2"))
+                visitor.Visit(context, assignment);
+
+            var definitions = context.GetDefinitions();
+            Assert.NotNull(definitions);
+            Assert.Single(definitions);
+
+            // Check category and version
+            var actual = definitions.FirstOrDefault(definition => definition.DefinitionId == "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988");
+            Assert.NotNull(actual);
+            Assert.Equal("Azure.Policy.0bf4ad02faba", actual.Name);
+            Assert.Equal("General", actual.Category);
+            Assert.Equal("1.0.0", actual.Version);
+            Assert.Single(actual.Types);
+            Assert.Equal("Microsoft.Resources/resourceGroups", actual.Types[0]);
+            Assert.Null(actual.Where);
+            Assert.Equal("{\"allOf\":[{\"field\":\"location\",\"notIn\":[\"australiaeast\",\"australiasoutheast\",\"eastus\",\"westus\"]}]}", actual.Condition.ToString(Formatting.None));
+            Assert.Null(actual.With);
+        }
+
         #region Helper methods
 
         private static PipelineContext GetContext(PSRuleOption option = null)


### PR DESCRIPTION
## PR Summary

- Fixed mismatch of resource group type on policy as code rules.

Fixes #2338 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
