### PR TITLE
Fixed naming rules for MariaDB #2335

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -33,6 +33,10 @@ What's changed since v1.28.0:
     [#2338](https://github.com/Azure/PSRule.Rules.Azure/issues/2338)
   - Fixed length cannot be less than zero when converting policy to rules by @BernieWhite.
     [#1802](https://github.com/Azure/PSRule.Rules.Azure/issues/1802)
+  - Fixed naming rules for MariaDB by @BernieWhite.
+    [#2335](https://github.com/Azure/PSRule.Rules.Azure/issues/2335)
+    - Updated `Azure.MariaDB.VNETRuleName` to allow for parent resources.
+    - Updated `Azure.MariaDB.FirewallRuleName` to allow for parent resources.
 
 ## v1.28.0
 

--- a/docs/en/rules/Azure.Firewall.Name.md
+++ b/docs/en/rules/Azure.Firewall.Name.md
@@ -1,5 +1,5 @@
 ---
-reviewed: 2021/11/27
+reviewed: 2023-07-22
 severity: Awareness
 pillar: Operational Excellence
 category: Repeatable infrastructure
@@ -29,6 +29,61 @@ The requirements for Firewall names are:
 Consider using names that meet Firewall naming requirements.
 Additionally consider naming resources with a standard naming convention.
 
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy firewalls that pass this rule:
+
+- Set the `name` property to align to resource naming requirements.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.Network/azureFirewalls",
+  "apiVersion": "2023-02-01",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "properties": {
+    "sku": {
+      "name": "AZFW_VNet",
+      "tier": "Premium"
+    },
+    "firewallPolicy": {
+      "id": "[resourceId('Microsoft.Network/firewallPolicies', format('{0}_policy', parameters('name')))]"
+    }
+  },
+  "dependsOn": [
+    "firewall_policy"
+  ]
+}
+```
+
+### Configure with Bicep
+
+To deploy firewalls that pass this rule:
+
+- Set the `name` property to align to resource naming requirements.
+
+For example:
+
+```bicep
+resource firewall 'Microsoft.Network/azureFirewalls@2023-02-01' = {
+  name: name
+  location: location
+  properties: {
+    sku: {
+      name: 'AZFW_VNet'
+      tier: 'Premium'
+    }
+    firewallPolicy: {
+      id: firewall_policy.id
+    }
+  }
+}
+```
+
 ## NOTES
 
 This rule does not check if Firewall names are unique.
@@ -36,6 +91,8 @@ This rule does not check if Firewall names are unique.
 ## LINKS
 
 - [Repeatable infrastructure](https://learn.microsoft.com/azure/architecture/framework/devops/automation-infrastructure)
-- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/azure/azure-resource-manager/management/resource-name-rules)
-- [Azure deployment reference](https://docs.microsoft.com/azure/templates/microsoft.network/azurefirewalls)
-- [Recommended abbreviations for Azure resource types](https://docs.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)
+- [Naming rules and restrictions for Azure resources](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftnetwork)
+- [Define your naming convention](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming)
+- [Resource naming and tagging decision guide](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming-and-tagging-decision-guide)
+- [Abbreviation examples for Azure resources](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)
+- [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.network/azurefirewalls)

--- a/docs/en/rules/Azure.MariaDB.DatabaseName.md
+++ b/docs/en/rules/Azure.MariaDB.DatabaseName.md
@@ -1,4 +1,5 @@
 ---
+reviewed: 2023-07-22
 severity: Awareness
 pillar: Operational Excellence
 category: Repeatable infrastructure
@@ -33,4 +34,7 @@ This rule does not check if Azure Database for MariaDB database names are unique
 
 - [Repeatable infrastructure](https://learn.microsoft.com/azure/architecture/framework/devops/automation-infrastructure)
 - [Naming rules and restrictions Azure Database for MariaDB resources](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb)
+- [Define your naming convention](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming)
+- [Resource naming and tagging decision guide](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming-and-tagging-decision-guide)
+- [Abbreviation examples for Azure resources](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)
 - [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.dbformariadb/servers/databases)

--- a/docs/en/rules/Azure.MariaDB.GeoRedundantBackup.md
+++ b/docs/en/rules/Azure.MariaDB.GeoRedundantBackup.md
@@ -38,20 +38,23 @@ For example:
 {
   "type": "Microsoft.DBforMariaDB/servers",
   "apiVersion": "2018-06-01",
-  "name": "[parameters('serverName')]",
+  "name": "[parameters('name')]",
   "location": "[parameters('location')]",
   "sku": {
-    "name": "[parameters('skuName')]",
+    "name": "[parameters('sku')]",
     "tier": "GeneralPurpose",
-    "capacity": "[parameters('SkuCapacity')]",
+    "capacity": "[parameters('skuCapacity')]",
     "size": "[format('{0}', parameters('skuSizeMB'))]",
-    "family": "[parameters('skuFamily')]"
+    "family": "Gen5"
   },
   "properties": {
+    "sslEnforcement": "Enabled",
+    "minimalTlsVersion": "TLS1_2",
     "createMode": "Default",
-    "version": "[parameters('mariadbVersion')]",
+    "version": "10.3",
     "administratorLogin": "[parameters('administratorLogin')]",
     "administratorLoginPassword": "[parameters('administratorLoginPassword')]",
+    "publicNetworkAccess": "Disabled",
     "storageProfile": {
       "storageMB": "[parameters('skuSizeMB')]",
       "backupRetentionDays": 7,
@@ -70,21 +73,24 @@ To deploy Azure Database for MariaDB Servers that pass this rule:
 For example:
 
 ```bicep
-resource mariaDbServer 'Microsoft.DBforMariaDB/servers@2018-06-01' = {
-  name: serverName
+resource server 'Microsoft.DBforMariaDB/servers@2018-06-01' = {
+  name: name
   location: location
   sku: {
-    name: skuName
+    name: sku
     tier: 'GeneralPurpose'
     capacity: skuCapacity
-    size: '${skuSizeMB}' 
-    family: skuFamily
+    size: '${skuSizeMB}'
+    family: 'Gen5'
   }
   properties: {
+    sslEnforcement: 'Enabled'
+    minimalTlsVersion: 'TLS1_2'
     createMode: 'Default'
-    version: mariadbVersion
+    version: '10.3'
     administratorLogin: administratorLogin
     administratorLoginPassword: administratorLoginPassword
+    publicNetworkAccess: 'Disabled'
     storageProfile: {
       storageMB: skuSizeMB
       backupRetentionDays: 7
@@ -96,7 +102,8 @@ resource mariaDbServer 'Microsoft.DBforMariaDB/servers@2018-06-01' = {
 
 ## NOTES
 
-This rule is only applicable for Azure Database for Maria DB Servers with `General Purpose` and `Memory Optimized` tiers. The `Basic` tier does not support geo-redundant backup storage.
+This rule is only applicable for Azure Database for Maria DB Servers with `General Purpose` and `Memory Optimized` tiers.
+The `Basic` tier does not support geo-redundant backup storage.
 
 ## LINKS
 

--- a/docs/en/rules/Azure.MariaDB.MinTLS.md
+++ b/docs/en/rules/Azure.MariaDB.MinTLS.md
@@ -38,21 +38,23 @@ For example:
 {
   "type": "Microsoft.DBforMariaDB/servers",
   "apiVersion": "2018-06-01",
-  "name": "[parameters('serverName')]",
+  "name": "[parameters('name')]",
   "location": "[parameters('location')]",
   "sku": {
-    "name": "[parameters('skuName')]",
+    "name": "[parameters('sku')]",
     "tier": "GeneralPurpose",
-    "capacity": "[parameters('SkuCapacity')]",
+    "capacity": "[parameters('skuCapacity')]",
     "size": "[format('{0}', parameters('skuSizeMB'))]",
-    "family": "[parameters('skuFamily')]"
+    "family": "Gen5"
   },
   "properties": {
+    "sslEnforcement": "Enabled",
     "minimalTlsVersion": "TLS1_2",
     "createMode": "Default",
-    "version": "[parameters('mariadbVersion')]",
+    "version": "10.3",
     "administratorLogin": "[parameters('administratorLogin')]",
     "administratorLoginPassword": "[parameters('administratorLoginPassword')]",
+    "publicNetworkAccess": "Disabled",
     "storageProfile": {
       "storageMB": "[parameters('skuSizeMB')]",
       "backupRetentionDays": 7,
@@ -71,22 +73,24 @@ To deploy Azure Database for MariaDB Servers that pass this rule:
 For example:
 
 ```bicep
-resource mariaDbServer 'Microsoft.DBforMariaDB/servers@2018-06-01' = {
-  name: serverName
+resource server 'Microsoft.DBforMariaDB/servers@2018-06-01' = {
+  name: name
   location: location
   sku: {
-    name: skuName
+    name: sku
     tier: 'GeneralPurpose'
     capacity: skuCapacity
-    size: '${skuSizeMB}' 
-    family: skuFamily
+    size: '${skuSizeMB}'
+    family: 'Gen5'
   }
   properties: {
+    sslEnforcement: 'Enabled'
     minimalTlsVersion: 'TLS1_2'
     createMode: 'Default'
-    version: mariadbVersion
+    version: '10.3'
     administratorLogin: administratorLogin
     administratorLoginPassword: administratorLoginPassword
+    publicNetworkAccess: 'Disabled'
     storageProfile: {
       storageMB: skuSizeMB
       backupRetentionDays: 7

--- a/docs/en/rules/Azure.MariaDB.ServerName.md
+++ b/docs/en/rules/Azure.MariaDB.ServerName.md
@@ -27,6 +27,82 @@ The requirements for Azure Database for MariaDB server names are:
 Consider using names that meet Azure Database for MariaDB server naming requirements.
 Additionally consider naming resources with a standard naming convention.
 
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy servers that pass this rule:
+
+- Set the `name` property to align to resource naming requirements.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.DBforMariaDB/servers",
+  "apiVersion": "2018-06-01",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "sku": {
+    "name": "[parameters('sku')]",
+    "tier": "GeneralPurpose",
+    "capacity": "[parameters('skuCapacity')]",
+    "size": "[format('{0}', parameters('skuSizeMB'))]",
+    "family": "Gen5"
+  },
+  "properties": {
+    "sslEnforcement": "Enabled",
+    "minimalTlsVersion": "TLS1_2",
+    "createMode": "Default",
+    "version": "10.3",
+    "administratorLogin": "[parameters('administratorLogin')]",
+    "administratorLoginPassword": "[parameters('administratorLoginPassword')]",
+    "publicNetworkAccess": "Disabled",
+    "storageProfile": {
+      "storageMB": "[parameters('skuSizeMB')]",
+      "backupRetentionDays": 7,
+      "geoRedundantBackup": "Enabled"
+    }
+  }
+}
+```
+
+### Configure with Bicep
+
+To deploy servers that pass this rule:
+
+- Set the `name` property to align to resource naming requirements.
+
+For example:
+
+```bicep
+resource server 'Microsoft.DBforMariaDB/servers@2018-06-01' = {
+  name: name
+  location: location
+  sku: {
+    name: sku
+    tier: 'GeneralPurpose'
+    capacity: skuCapacity
+    size: '${skuSizeMB}'
+    family: 'Gen5'
+  }
+  properties: {
+    sslEnforcement: 'Enabled'
+    minimalTlsVersion: 'TLS1_2'
+    createMode: 'Default'
+    version: '10.3'
+    administratorLogin: administratorLogin
+    administratorLoginPassword: administratorLoginPassword
+    publicNetworkAccess: 'Disabled'
+    storageProfile: {
+      storageMB: skuSizeMB
+      backupRetentionDays: 7
+      geoRedundantBackup: 'Enabled'
+    }
+  }
+}
+```
+
 ## NOTES
 
 This rule does not check if Azure Database for MariaDB server names are unique.
@@ -35,4 +111,7 @@ This rule does not check if Azure Database for MariaDB server names are unique.
 
 - [Repeatable infrastructure](https://learn.microsoft.com/azure/architecture/framework/devops/automation-infrastructure)
 - [Naming rules and restrictions Azure Database for MariaDB resources](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb)
-- [Template reference](https://learn.microsoft.com/azure/templates/microsoft.dbformariadb/servers)
+- [Define your naming convention](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming)
+- [Resource naming and tagging decision guide](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming-and-tagging-decision-guide)
+- [Abbreviation examples for Azure resources](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)
+- [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.dbformariadb/servers)

--- a/docs/en/rules/Azure.MariaDB.UseSSL.md
+++ b/docs/en/rules/Azure.MariaDB.UseSSL.md
@@ -41,22 +41,23 @@ For example:
 {
   "type": "Microsoft.DBforMariaDB/servers",
   "apiVersion": "2018-06-01",
-  "name": "[parameters('serverName')]",
+  "name": "[parameters('name')]",
   "location": "[parameters('location')]",
   "sku": {
-    "name": "[parameters('skuName')]",
+    "name": "[parameters('sku')]",
     "tier": "GeneralPurpose",
-    "capacity": "[parameters('SkuCapacity')]",
+    "capacity": "[parameters('skuCapacity')]",
     "size": "[format('{0}', parameters('skuSizeMB'))]",
-    "family": "[parameters('skuFamily')]"
+    "family": "Gen5"
   },
   "properties": {
     "sslEnforcement": "Enabled",
     "minimalTlsVersion": "TLS1_2",
     "createMode": "Default",
-    "version": "[parameters('mariadbVersion')]",
+    "version": "10.3",
     "administratorLogin": "[parameters('administratorLogin')]",
     "administratorLoginPassword": "[parameters('administratorLoginPassword')]",
+    "publicNetworkAccess": "Disabled",
     "storageProfile": {
       "storageMB": "[parameters('skuSizeMB')]",
       "backupRetentionDays": 7,
@@ -75,23 +76,24 @@ To deploy Azure Database for MariaDB Servers that pass this rule:
 For example:
 
 ```bicep
-resource mariaDbServer 'Microsoft.DBforMariaDB/servers@2018-06-01' = {
-  name: serverName
+resource server 'Microsoft.DBforMariaDB/servers@2018-06-01' = {
+  name: name
   location: location
   sku: {
-    name: skuName
+    name: sku
     tier: 'GeneralPurpose'
     capacity: skuCapacity
-    size: '${skuSizeMB}' 
-    family: skuFamily
+    size: '${skuSizeMB}'
+    family: 'Gen5'
   }
   properties: {
     sslEnforcement: 'Enabled'
     minimalTlsVersion: 'TLS1_2'
     createMode: 'Default'
-    version: mariadbVersion
+    version: '10.3'
     administratorLogin: administratorLogin
     administratorLoginPassword: administratorLoginPassword
+    publicNetworkAccess: 'Disabled'
     storageProfile: {
       storageMB: skuSizeMB
       backupRetentionDays: 7

--- a/docs/en/rules/Azure.MariaDB.VNETRuleName.md
+++ b/docs/en/rules/Azure.MariaDB.VNETRuleName.md
@@ -33,4 +33,7 @@ This rule does not check if Azure Database for MariaDB VNET rule names are uniqu
 
 - [Repeatable infrastructure](https://learn.microsoft.com/azure/architecture/framework/devops/automation-infrastructure)
 - [Naming rules and restrictions Azure Database for MariaDB resources](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb)
-- [Template reference](https://learn.microsoft.com/azure/templates/microsoft.dbformariadb/servers/virtualnetworkrules)
+- [Define your naming convention](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming)
+- [Resource naming and tagging decision guide](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming-and-tagging-decision-guide)
+- [Abbreviation examples for Azure resources](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)
+- [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.dbformariadb/servers/virtualnetworkrules)

--- a/docs/examples-firewall.bicep
+++ b/docs/examples-firewall.bicep
@@ -27,12 +27,14 @@ resource firewall_policy 'Microsoft.Network/firewallPolicies@2021-05-01' = {
   }
 }
 
-resource firewall_with_policy 'Microsoft.Network/azureFirewalls@2021-05-01' = {
-  name: '${name}_with_policy'
+// An example Azure Firewall Premium with a linked firewall policy.
+resource firewall 'Microsoft.Network/azureFirewalls@2023-02-01' = {
+  name: name
   location: location
   properties: {
     sku: {
       name: 'AZFW_VNet'
+      tier: 'Premium'
     }
     firewallPolicy: {
       id: firewall_policy.id

--- a/docs/examples-firewall.json
+++ b/docs/examples-firewall.json
@@ -1,11 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "1.10-experimental",
   "contentVersion": "1.0.0.0",
   "metadata": {
+    "_EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
     "_generator": {
       "name": "bicep",
-      "version": "0.5.6.12127",
-      "templateHash": "6359428006480739944"
+      "version": "0.19.5.34762",
+      "templateHash": "17898570111117857053"
     }
   },
   "parameters": {
@@ -24,8 +26,8 @@
       }
     }
   },
-  "resources": [
-    {
+  "resources": {
+    "firewall_classic": {
       "type": "Microsoft.Network/azureFirewalls",
       "apiVersion": "2021-05-01",
       "name": "[format('{0}_classic', parameters('name'))]",
@@ -37,7 +39,7 @@
         "threatIntelMode": "Deny"
       }
     },
-    {
+    "firewall_policy": {
       "type": "Microsoft.Network/firewallPolicies",
       "apiVersion": "2021-05-01",
       "name": "[format('{0}_policy', parameters('name'))]",
@@ -45,30 +47,31 @@
         "threatIntelMode": "Deny"
       }
     },
-    {
+    "firewall": {
       "type": "Microsoft.Network/azureFirewalls",
-      "apiVersion": "2021-05-01",
-      "name": "[format('{0}_with_policy', parameters('name'))]",
+      "apiVersion": "2023-02-01",
+      "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "properties": {
         "sku": {
-          "name": "AZFW_VNet"
+          "name": "AZFW_VNet",
+          "tier": "Premium"
         },
         "firewallPolicy": {
           "id": "[resourceId('Microsoft.Network/firewallPolicies', format('{0}_policy', parameters('name')))]"
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Network/firewallPolicies', format('{0}_policy', parameters('name')))]"
+        "firewall_policy"
       ]
     },
-    {
+    "hub": {
       "type": "Microsoft.Network/virtualHubs",
       "apiVersion": "2021-05-01",
       "name": "[format('{0}_hub', parameters('name'))]",
       "location": "[parameters('location')]"
     },
-    {
+    "firewall_with_hub": {
       "type": "Microsoft.Network/azureFirewalls",
       "apiVersion": "2021-05-01",
       "name": "[format('{0}_with_hub', parameters('name'))]",
@@ -85,9 +88,9 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Network/firewallPolicies', format('{0}_policy', parameters('name')))]",
-        "[resourceId('Microsoft.Network/virtualHubs', format('{0}_hub', parameters('name')))]"
+        "firewall_policy",
+        "hub"
       ]
     }
-  ]
+  }
 }

--- a/docs/examples-mariadb.bicep
+++ b/docs/examples-mariadb.bicep
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Bicep documentation examples
+
+@sys.description('The name of the resource.')
+param name string
+
+@sys.description('The location resources will be deployed.')
+param location string = resourceGroup().location
+
+@sys.description('The name of the admin user account.')
+param administratorLogin string
+
+@secure()
+@sys.description('The secret for the admin user account.')
+param administratorLoginPassword string
+
+@sys.description('The sku to deploy.')
+param sku string = 'GP_Gen5_2'
+
+@sys.description('The sku capacity.')
+param skuCapacity int = 2
+
+@sys.description('The size of the storage.')
+param skuSizeMB int = 51200
+
+// An example Azure Database for MariaDB server using a general purpose SKU.
+resource server 'Microsoft.DBforMariaDB/servers@2018-06-01' = {
+  name: name
+  location: location
+  sku: {
+    name: sku
+    tier: 'GeneralPurpose'
+    capacity: skuCapacity
+    size: '${skuSizeMB}'
+    family: 'Gen5'
+  }
+  properties: {
+    sslEnforcement: 'Enabled'
+    minimalTlsVersion: 'TLS1_2'
+    createMode: 'Default'
+    version: '10.3'
+    administratorLogin: administratorLogin
+    administratorLoginPassword: administratorLoginPassword
+    publicNetworkAccess: 'Disabled'
+    storageProfile: {
+      storageMB: skuSizeMB
+      backupRetentionDays: 7
+      geoRedundantBackup: 'Enabled'
+    }
+  }
+}

--- a/docs/examples-mariadb.json
+++ b/docs/examples-mariadb.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "1.10-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
+    "_generator": {
+      "name": "bicep",
+      "version": "0.19.5.34762",
+      "templateHash": "2540591518092935825"
+    }
+  },
+  "parameters": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location resources will be deployed."
+      }
+    },
+    "administratorLogin": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the admin user account."
+      }
+    },
+    "administratorLoginPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The secret for the admin user account."
+      }
+    },
+    "sku": {
+      "type": "string",
+      "defaultValue": "GP_Gen5_2",
+      "metadata": {
+        "description": "The sku to deploy."
+      }
+    },
+    "skuCapacity": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "The sku capacity."
+      }
+    },
+    "skuSizeMB": {
+      "type": "int",
+      "defaultValue": 51200,
+      "metadata": {
+        "description": "The size of the storage."
+      }
+    }
+  },
+  "resources": {
+    "server": {
+      "type": "Microsoft.DBforMariaDB/servers",
+      "apiVersion": "2018-06-01",
+      "name": "[parameters('name')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('sku')]",
+        "tier": "GeneralPurpose",
+        "capacity": "[parameters('skuCapacity')]",
+        "size": "[format('{0}', parameters('skuSizeMB'))]",
+        "family": "Gen5"
+      },
+      "properties": {
+        "sslEnforcement": "Enabled",
+        "minimalTlsVersion": "TLS1_2",
+        "createMode": "Default",
+        "version": "10.3",
+        "administratorLogin": "[parameters('administratorLogin')]",
+        "administratorLoginPassword": "[parameters('administratorLoginPassword')]",
+        "publicNetworkAccess": "Disabled",
+        "storageProfile": {
+          "storageMB": "[parameters('skuSizeMB')]",
+          "backupRetentionDays": 7,
+          "geoRedundantBackup": "Enabled"
+        }
+      }
+    }
+  }
+}

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -83,7 +83,6 @@
     APIMApiVersionConstraintMinApiVersionNotFound = "The api management instance is missing minimum api version configuration."
     MySQLGeoRedundantBackupNotConfigured = "The Azure Database for MySQL '{0}' should have geo-redundant backup configured."
     SingleDeploymentModelRetirement = "The Azure Database for MySQL Single Server deployment model is on the retirement path. Migrate to the Azure Database for MySQL Flexible Server deployment model."
-    MariaDBGeoRedundantBackupNotConfigured = "The Azure Database for MariaDB '{0}' should have geo-redundant backup configured."
     PostgreSQLGeoRedundantBackupNotConfigured = "The Azure Database for PostgreSQL '{0}' should have geo-redundant backup configured."
     SQLServerVMDisks = "The virtual machine used for running SQL Server should use Premium disks or greater."
     KeyVaultAuditDiagnosticSetting = "Minimum one diagnostic setting should have ({0}) configured or category group ({1}) configured."

--- a/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.ps1
@@ -7,14 +7,8 @@
 
 #region Rules
 
-# Synopsis: Azure Database for MariaDB should store backups in a geo-redundant storage.
-Rule 'Azure.MariaDB.GeoRedundantBackup' -Ref 'AZR-000329' -Type 'Microsoft.DBforMariaDB/servers' -If { HasMariaDBTierSupportingGeoRedundantBackup } -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
-    $Assert.HasFieldValue($TargetObject, 'properties.storageProfile.geoRedundantBackup', 'Enabled').
-    Reason($LocalizedData.MariaDBGeoRedundantBackupNotConfigured, $PSRule.TargetName)
-}
-
 # Synopsis: Enable Microsoft Defender for Cloud for Azure Database for MariaDB.
-Rule 'Azure.MariaDB.DefenderCloud' -Ref 'AZR-000330' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/securityAlertPolicies' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+Rule 'Azure.MariaDB.DefenderCloud' -Ref 'AZR-000330' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/securityAlertPolicies' -Tag @{ release = 'GA'; ruleSet = '2022_12'; 'Azure.WAF/pillar' = 'Security'; } {
     if ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers') {
         $defenderConfigs = @(GetSubResources -ResourceType 'Microsoft.DBforMariaDB/servers/securityAlertPolicies')
         if ($defenderConfigs.Length -eq 0) {
@@ -31,17 +25,17 @@ Rule 'Azure.MariaDB.DefenderCloud' -Ref 'AZR-000330' -Type 'Microsoft.DBforMaria
 }
 
 # Synopsis: Azure Database for MariaDB servers should only accept encrypted connections.
-Rule 'Azure.MariaDB.UseSSL' -Ref 'AZR-000334' -Type 'Microsoft.DBforMariaDB/servers' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+Rule 'Azure.MariaDB.UseSSL' -Ref 'AZR-000334' -Type 'Microsoft.DBforMariaDB/servers' -Tag @{ release = 'GA'; ruleSet = '2022_12'; 'Azure.WAF/pillar' = 'Security'; } {
     $Assert.HasFieldValue($TargetObject, 'properties.sslEnforcement', 'Enabled').Reason($LocalizedData.MariaDBEncryptedConnection)
 }
 
 # Synopsis: Azure Database for MariaDB servers should reject TLS versions older than 1.2.
-Rule 'Azure.MariaDB.MinTLS' -Ref 'AZR-000335' -Type 'Microsoft.DBforMariaDB/servers' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+Rule 'Azure.MariaDB.MinTLS' -Ref 'AZR-000335' -Type 'Microsoft.DBforMariaDB/servers' -Tag @{ release = 'GA'; ruleSet = '2022_12'; 'Azure.WAF/pillar' = 'Security'; } {
     $Assert.HasFieldValue($TargetObject, 'properties.minimalTlsVersion', 'TLS1_2')
 }
 
 # Synopsis: Azure Database for MariaDB servers should meet naming requirements.
-Rule 'Azure.MariaDB.ServerName' -Ref 'AZR-000336' -Type 'Microsoft.DBforMariaDB/servers' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+Rule 'Azure.MariaDB.ServerName' -Ref 'AZR-000336' -Type 'Microsoft.DBforMariaDB/servers' -Tag @{ release = 'GA'; ruleSet = '2022_12'; 'Azure.WAF/pillar' = 'Operational Excellence'; } {
     # https://learn.microsoft.com/nb-no/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb
 
     # Between 3 and 63 characters long
@@ -54,7 +48,7 @@ Rule 'Azure.MariaDB.ServerName' -Ref 'AZR-000336' -Type 'Microsoft.DBforMariaDB/
 }
 
 # Synopsis: Azure Database for MariaDB databases should meet naming requirements.
-Rule 'Azure.MariaDB.DatabaseName' -Ref 'AZR-000337' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/databases' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+Rule 'Azure.MariaDB.DatabaseName' -Ref 'AZR-000337' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/databases' -Tag @{ release = 'GA'; ruleSet = '2022_12'; 'Azure.WAF/pillar' = 'Operational Excellence'; } {
     # https://learn.microsoft.com/nb-no/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb
 
     $databases = @(GetMariaDBDatabaseName)
@@ -73,12 +67,10 @@ Rule 'Azure.MariaDB.DatabaseName' -Ref 'AZR-000337' -Type 'Microsoft.DBforMariaD
 }
 
 # Synopsis: Azure Database for MariaDB firewall rules should meet naming requirements.
-Rule 'Azure.MariaDB.FirewallRuleName' -Ref 'AZR-000338' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/firewallRules' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
-    # https://learn.microsoft.com/nb-no/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb
-
+Rule 'Azure.MariaDB.FirewallRuleName' -Ref 'AZR-000338' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/firewallRules' -Tag @{ release = 'GA'; ruleSet = '2022_12'; 'Azure.WAF/pillar' = 'Operational Excellence'; } {
     $firewallRules = @(GetMariaDBFirewallRuleName)
     if ($firewallRules.Length -eq 0) {
-        $Assert.Pass()
+        return $Assert.Pass()
     }
 
     foreach ($firewallRule in $firewallRules) {
@@ -92,12 +84,10 @@ Rule 'Azure.MariaDB.FirewallRuleName' -Ref 'AZR-000338' -Type 'Microsoft.DBforMa
 }
 
 # Synopsis: Azure Database for MariaDB VNET rules should meet naming requirements.
-Rule 'Azure.MariaDB.VNETRuleName' -Ref 'AZR-000339' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/virtualNetworkRules' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
-    # https://learn.microsoft.com/nb-no/azure/azure-resource-manager/management/resource-name-rules#microsoftdbformariadb
-
+Rule 'Azure.MariaDB.VNETRuleName' -Ref 'AZR-000339' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/virtualNetworkRules' -Tag @{ release = 'GA'; ruleSet = '2022_12'; 'Azure.WAF/pillar' = 'Operational Excellence'; } {
     $virtualNetworkRules = @(GetMariaDBVNETRuleName)
     if ($virtualNetworkRules.Length -eq 0) {
-        $Assert.Pass()
+        return $Assert.Pass()
     }
 
     foreach ($virtualNetworkRule in $virtualNetworkRules) {
@@ -111,15 +101,15 @@ Rule 'Azure.MariaDB.VNETRuleName' -Ref 'AZR-000339' -Type 'Microsoft.DBforMariaD
 }
 
 # Synopsis: Determine if access from Azure services is required.
-Rule 'Azure.MariaDB.AllowAzureAccess' -Ref 'AZR-000342' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/firewallRules' -Tag @{ release = 'GA'; ruleSet = '2022_12' } {
+Rule 'Azure.MariaDB.AllowAzureAccess' -Ref 'AZR-000342' -Type 'Microsoft.DBforMariaDB/servers', 'Microsoft.DBforMariaDB/servers/firewallRules' -Tag @{ release = 'GA'; ruleSet = '2022_12'; 'Azure.WAF/pillar' = 'Security'; } {
     $firewallAllowAzureServices = @(GetMariaDBFirewallRule |
         Where-Object { $_.properties.startIpAddress -eq '0.0.0.0' -and $_.properties.endIpAddress -eq '0.0.0.0' })
-    
+
     $Assert.Less($firewallAllowAzureServices, '.', 1).Reason($LocalizedData.MariaDBFirewallAllowAzureServices)
 }
 
 # Synopsis: Determine if there is an excessive number of firewall rules.
-Rule 'Azure.MariaDB.FirewallRuleCount'-Ref 'AZR-000343' -Type 'Microsoft.DBforMariaDB/servers' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+Rule 'Azure.MariaDB.FirewallRuleCount'-Ref 'AZR-000343' -Type 'Microsoft.DBforMariaDB/servers' -Tag @{ release = 'GA'; ruleSet = '2022_12'; 'Azure.WAF/pillar' = 'Security'; } {
     $firewallRules = @(GetSubResources -ResourceType 'Microsoft.DBforMariaDB/servers/firewallRules')
 
     $Assert.LessOrEqual($firewallRules, '.', 10).
@@ -127,7 +117,7 @@ Rule 'Azure.MariaDB.FirewallRuleCount'-Ref 'AZR-000343' -Type 'Microsoft.DBforMa
 }
 
 # Synopsis: Determine if there is an excessive number of permitted IP addresses.
-Rule 'Azure.MariaDB.FirewallIPRange' -Ref 'AZR-000344' -Type 'Microsoft.DBforMariaDB/servers' -Tag @{ release = 'GA'; ruleSet = '2022_12'; } {
+Rule 'Azure.MariaDB.FirewallIPRange' -Ref 'AZR-000344' -Type 'Microsoft.DBforMariaDB/servers' -Tag @{ release = 'GA'; ruleSet = '2022_12'; 'Azure.WAF/pillar' = 'Security'; } {
     $summary = GetIPAddressSummary
 
     [int]$public = [int]$summary.Public
@@ -138,15 +128,6 @@ Rule 'Azure.MariaDB.FirewallIPRange' -Ref 'AZR-000344' -Type 'Microsoft.DBforMar
 #endregion Rules
 
 #region Helper functions
-
-function global:HasMariaDBTierSupportingGeoRedundantBackup {
-    [CmdletBinding()]
-    [OutputType([System.Boolean])]
-    param ()
-    process {
-        $Assert.in($TargetObject, 'sku.tier', @('GeneralPurpose', 'MemoryOptimized')).Result
-    }
-}
 
 function global:GetMariaDBDatabaseName {
     [CmdletBinding()]
@@ -170,10 +151,10 @@ function global:GetMariaDBFirewallRuleName {
     process {
         if ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers') {
             GetSubResources -ResourceType 'Microsoft.DBforMariaDB/servers/firewallRules' |
-            ForEach-Object { $_.name }
+            ForEach-Object { ($_.name -split '/')[-1] }
         }
         elseif ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers/firewallRules') {
-            $PSRule.TargetName
+            ($PSRule.TargetName -split '/')[-1]
         }
     }
 }
@@ -185,10 +166,10 @@ function global:GetMariaDBVNETRuleName {
     process {
         if ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers') {
             GetSubResources -ResourceType 'Microsoft.DBforMariaDB/servers/virtualNetworkRules' |
-            ForEach-Object { $_.name }
+            ForEach-Object { ($_.name -split '/')[-1] }
         }
         elseif ($PSRule.TargetType -eq 'Microsoft.DBforMariaDB/servers/virtualNetworkRules') {
-            $PSRule.TargetName
+            ($PSRule.TargetName -split '/')[-1]
         }
     }
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.MariaDB.Rule.yaml
@@ -1,0 +1,65 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Rules for Azure Database for MariaDB
+#
+
+#region Rules
+
+---
+# Synopsis: Azure Database for MariaDB should store backups in a geo-redundant storage.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.MariaDB.GeoRedundantBackup
+  ref: AZR-000329
+  tags:
+    release: GA
+    ruleSet: 2022_12
+    Azure.WAF/pillar: Reliability
+spec:
+  type:
+  - Microsoft.DBforMariaDB/servers
+  with:
+    - Azure.MariaDB.IsGeneralPurpose
+    - Azure.MariaDB.IsMemoryOptimized
+  condition:
+    field: properties.storageProfile.geoRedundantBackup
+    equals: Enabled
+
+#endregion Rules
+
+#
+# Selectors for Azure Database for MariaDB
+#
+
+#region Selectors
+
+---
+# Synopsis: MariaDB instances using the general purpose tier.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Azure.MariaDB.IsGeneralPurpose
+  annotations:
+    exportable: false
+spec:
+  if:
+    field: sku.tier
+    equals: GeneralPurpose
+
+---
+# Synopsis: MariaDB instances using the memory optimized tier.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Azure.MariaDB.IsMemoryOptimized
+  annotations:
+    exportable: false
+spec:
+  if:
+    field: sku.tier
+    equals: MemoryOptimized
+
+#endregion Selectors

--- a/tests/PSRule.Rules.Azure.Tests/Azure.MariaDB.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.MariaDB.Tests.ps1
@@ -45,8 +45,8 @@ Describe 'Azure.MariaDB' -Tag 'MariaDB' {
             $ruleResult.Length | Should -Be 2;
             $ruleResult.TargetName | Should -BeIn 'server-A', 'server-B';
 
-            $ruleResult[0].Reason | Should -BeExactly "The Azure Database for MariaDB 'server-A' should have geo-redundant backup configured.";
-            $ruleResult[1].Reason | Should -BeExactly "The Azure Database for MariaDB 'server-B' should have geo-redundant backup configured.";
+            $ruleResult[0].Reason | Should -BeExactly "Path properties.storageProfile.geoRedundantBackup: Is set to 'Disabled'.";
+            $ruleResult[1].Reason | Should -BeExactly "Path properties.storageProfile.geoRedundantBackup: The field 'properties.storageProfile.geoRedundantBackup' does not exist.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -127,7 +127,7 @@ Describe 'Azure.MariaDB' -Tag 'MariaDB' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'server-C', 'rule-B';
+            $ruleResult.TargetName | Should -BeIn 'server-C', 'server-D/rule-B';
         }
 
         It 'Azure.MariaDB.FirewallRuleCount' {
@@ -283,7 +283,7 @@ Describe 'Azure.MariaDB' -Tag 'MariaDB' {
         BeforeDiscovery {
             $validNames = @(
                 'rule1'
-                'default'
+                'server1/default'
                 'allowed-developer'
                 'blocked-all'
                 'BLOCKED-ALL'
@@ -333,7 +333,7 @@ Describe 'Azure.MariaDB' -Tag 'MariaDB' {
             $validNames = @(
                 'AllowSubnet'
                 'Out-Default'
-                'IN-DEFAULT'
+                'server1/IN-DEFAULT'
                 'AllowPeeredSubnet'
             )
 

--- a/tests/PSRule.Rules.Azure.Tests/Resources.MariaDB.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.MariaDB.json
@@ -199,8 +199,12 @@
         "Name": "Default",
         "Properties": {
           "state": "Disabled",
-          "disabledAlerts": [""],
-          "emailAddresses": [""],
+          "disabledAlerts": [
+            ""
+          ],
+          "emailAddresses": [
+            ""
+          ],
           "emailAccountAdmins": true,
           "storageEndpoint": "https://account.blob.core.windows.net",
           "storageAccountAccessKey": "",
@@ -273,8 +277,12 @@
         "Name": "Default",
         "Properties": {
           "state": "Enabled",
-          "disabledAlerts": [""],
-          "emailAddresses": [""],
+          "disabledAlerts": [
+            ""
+          ],
+          "emailAddresses": [
+            ""
+          ],
           "emailAccountAdmins": true,
           "storageEndpoint": "https://account.blob.core.windows.net",
           "storageAccountAccessKey": "",
@@ -318,8 +326,8 @@
     "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DBforMariaDB/servers/server-D/firewallRules/rule-B",
     "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DBforMariaDB/servers/server-D/firewallRules/rule-B",
     "Location": "region",
-    "ResourceName": "rule-B",
-    "Name": "rule-B",
+    "ResourceName": "server-D/rule-B",
+    "Name": "server-D/rule-B",
     "Properties": {
       "startIpAddress": "20.67.176.40",
       "endIpAddress": "20.67.176.40"


### PR DESCRIPTION
## PR Summary

- Fixed naming rules for MariaDB.
  - Updated `Azure.MariaDB.VNETRuleName` to allow for parent resources.
  - Updated `Azure.MariaDB.FirewallRuleName` to allow for parent resources.

Fixes #2335 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
