### PR TITLE
Release v1.28.1

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.28.1
+
 What's changed since v1.28.0:
 
 - Bug fixes:


### PR DESCRIPTION
## PR Summary

What's changed since v1.28.0:

- Bug fixes:
  - Fixed `parseCidr` with `/32` is not valid by @BernieWhite.
    [#2336](https://github.com/Azure/PSRule.Rules.Azure/issues/2336)
  - Fixed mismatch of resource group type on policy as code rules by @BernieWhite.
    [#2338](https://github.com/Azure/PSRule.Rules.Azure/issues/2338)
  - Fixed length cannot be less than zero when converting policy to rules by @BernieWhite.
    [#1802](https://github.com/Azure/PSRule.Rules.Azure/issues/1802)
  - Fixed naming rules for MariaDB by @BernieWhite.
    [#2335](https://github.com/Azure/PSRule.Rules.Azure/issues/2335)
    - Updated `Azure.MariaDB.VNETRuleName` to allow for parent resources.
    - Updated `Azure.MariaDB.FirewallRuleName` to allow for parent resources.
  - Fixed network watcher existence check by @BernieWhite.
    [#2342](https://github.com/Azure/PSRule.Rules.Azure/issues/2342)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
