### PR TITLE
Use policy definition name #1959

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -30,6 +30,9 @@ What's changed since v1.28.2:
   - Databricks:
     - Check that workspaces use secure cluster connectivity by @BernieWhite.
       [#2334](https://github.com/Azure/PSRule.Rules.Azure/issues/2334)
+- General improvements:
+  - Use policy definition name when generating a rule from it by @BernieWhite.
+    [#1959](https://github.com/Azure/PSRule.Rules.Azure/issues/1959)
 - Bug fixes:
   - Fixed policy expansion with unquoted field property by @BernieWhite.
     [#2352](https://github.com/Azure/PSRule.Rules.Azure/issues/2352)

--- a/src/PSRule.Rules.Azure/Data/Policy/Models.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/Models.cs
@@ -63,11 +63,12 @@ namespace PSRule.Rules.Azure.Data.Policy
     /// </summary>
     internal sealed class PolicyDefinition
     {
-        public PolicyDefinition(string definitionId, string description, JObject value)
+        public PolicyDefinition(string definitionId, string description, JObject value, string displayName)
         {
             DefinitionId = definitionId;
             Description = description;
             Value = value;
+            DisplayName = displayName;
             Parameters = new Dictionary<string, IParameterValue>(StringComparer.OrdinalIgnoreCase);
             Types = new List<string>();
         }
@@ -91,6 +92,11 @@ namespace PSRule.Rules.Azure.Data.Policy
         /// The synopsis of the rule.
         /// </summary>
         public string Description { get; set; }
+
+        /// <summary>
+        /// The display name of the rule.
+        /// </summary>
+        public string DisplayName { get; set; }
 
         /// <summary>
         /// The raw original policy definition.

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
@@ -72,6 +72,7 @@ namespace PSRule.Rules.Azure.Data.Policy
         private const string PROPERTY_PADLEFT = "padLeft";
         private const string PROPERTY_PATH = "path";
         private const string PROPERTY_CONVERT = "convert";
+        private const string PROPERTY_NONCOMPLIANCEMESSAGES = "NonComplianceMessages";
         private const string EFFECT_DISABLED = "Disabled";
         private const string EFFECT_AUDITIFNOTEXISTS = "AuditIfNotExists";
         private const string EFFECT_DEPLOYIFNOTEXISTS = "DeployIfNotExists";
@@ -727,6 +728,10 @@ namespace PSRule.Rules.Azure.Data.Policy
                     // Get assignment parameters
                     if (properties.TryObjectProperty(PROPERTY_PARAMETERS, out var parameters))
                         AssignmentParameters(context, parameters);
+
+                    // Get non-compliance messages
+                    if (properties.TryArrayProperty(PROPERTY_NONCOMPLIANCEMESSAGES, out var nonComplianceMessages))
+                        AssignmentNonComplianceMessages(context, nonComplianceMessages.Values<JObject>());
                 }
 
                 // Get assignment policy definitions Definitions
@@ -749,6 +754,15 @@ namespace PSRule.Rules.Azure.Data.Policy
 
             foreach (var parameter in parameters.Children<JProperty>())
                 context.AddParameterAssignment(parameter.Name, parameter.Value);
+        }
+
+        /// <summary>
+        /// Add any non-compliance messages.
+        /// </summary>
+        protected virtual void AssignmentNonComplianceMessages(PolicyAssignmentContext context, IEnumerable<JObject> nonComplianceMessages)
+        {
+            if (nonComplianceMessages == null)
+                return;
         }
 
         /// <summary>
@@ -836,7 +850,7 @@ namespace PSRule.Rules.Azure.Data.Policy
 
             properties.TryStringProperty(PROPERTY_DISPLAYNAME, out var displayName);
             properties.TryStringProperty(PROPERTY_DESCRIPTION, out var description);
-            var result = new PolicyDefinition(policyDefinitionId, description, definition);
+            var result = new PolicyDefinition(policyDefinitionId, description, definition, displayName);
 
             // Set annotations
             if (properties.TryObjectProperty(PROPERTY_METADATA, out var metadata))

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyJsonRuleMapper.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyJsonRuleMapper.cs
@@ -19,7 +19,9 @@ namespace PSRule.Rules.Azure.Data.Policy
         private const string KIND_VALUE = "Rule";
         private const string PROPERTY_METADATA = "metadata";
         private const string PROPERTY_NAME = "name";
+        private const string PROPERTY_DISPLAYNAME = "displayName";
         private const string PROPERTY_SPEC = "spec";
+        private const string PROPERTY_RECOMMEND = "recommend";
         private const string PROPERTY_CONDITION = "condition";
         private const string PROPERTY_WHERE = "where";
         private const string PROPERTY_WITH = "with";
@@ -50,6 +52,11 @@ namespace PSRule.Rules.Azure.Data.Policy
             writer.WriteStartObject();
             writer.WritePropertyName(PROPERTY_NAME);
             writer.WriteValue(definition.Name);
+            if (definition.DisplayName != null)
+            {
+                writer.WritePropertyName(PROPERTY_DISPLAYNAME);
+                writer.WriteValue(definition.DisplayName);
+            }
             WriteTags(writer, definition);
             WriteAnnotations(writer, definition);
             writer.WriteEndObject();
@@ -57,6 +64,8 @@ namespace PSRule.Rules.Azure.Data.Policy
             // Spec
             writer.WritePropertyName(PROPERTY_SPEC);
             writer.WriteStartObject();
+            writer.WritePropertyName(PROPERTY_RECOMMEND);
+            writer.WriteValue(definition.Description);
             WriteType(writer, serializer, definition);
             WriteWith(writer, serializer, definition);
             WriteWhere(writer, serializer, definition);

--- a/tests/PSRule.Rules.Azure.Tests/PolicyAssignmentVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/PolicyAssignmentVisitorTests.cs
@@ -152,6 +152,8 @@ namespace PSRule.Rules.Azure
             var actual = definitions.FirstOrDefault(definition => definition.DefinitionId == "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988");
             Assert.NotNull(actual);
             Assert.Equal("Azure.Policy.8fc87228ae18", actual.Name);
+            Assert.Equal("Allowed locations for resource groups", actual.DisplayName);
+            Assert.Equal("This policy enables you to restrict the locations your organization can create resource groups in. Use to enforce your geo-compliance requirements.", actual.Description);
             Assert.Equal("General", actual.Category);
             Assert.Equal("1.0.0", actual.Version);
             Assert.Single(actual.Types);
@@ -176,6 +178,8 @@ namespace PSRule.Rules.Azure
             var actual = definitions.FirstOrDefault(definition => definition.DefinitionId == "/providers/Microsoft.Authorization/policyDefinitions/96670d01-0a4d-4649-9c89-2d3abc0a5025");
             Assert.NotNull(actual);
             Assert.Equal("Azure.Policy.6db2a8060ade", actual.Name);
+            Assert.Equal("Require a tag on resource groups", actual.DisplayName);
+            Assert.Equal("Enforces existence of a tag on resource groups.", actual.Description);
             Assert.Equal("Tags", actual.Category);
             Assert.Equal("1.0.0", actual.Version);
             Assert.Single(actual.Types);

--- a/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesData.jsonc
+++ b/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesData.jsonc
@@ -5,6 +5,7 @@
     "kind": "Rule",
     "metadata": {
       "name": "Azure.Policy.65db1c629a22",
+      "displayName": "Deny Storage Account Not Using Minumum TLS version",
       "tags": {
         "Azure.Policy/category": "Storage"
       },
@@ -14,6 +15,7 @@
       }
     },
     "spec": {
+      "recommend": "Minmum TLS version must be used on Storage accounts",
       "type": [
         "Microsoft.Storage/storageAccounts"
       ],
@@ -32,6 +34,7 @@
     "kind": "Rule",
     "metadata": {
       "name": "Azure.Policy.d49c9ce3b804",
+      "displayName": "Deploy Log Analytics extension for Linux VMs",
       "tags": {
         "Azure.Policy/category": "Monitoring"
       },
@@ -41,6 +44,7 @@
       }
     },
     "spec": {
+      "recommend": "Deploy Log Analytics extension for Linux VMs if the VM Image (OS) is in the list defined and the extension is not installed.",
       "type": [
         "Microsoft.Compute/virtualMachines"
       ],
@@ -329,6 +333,7 @@
     "kind": "Rule",
     "metadata": {
       "name": "Azure.Policy.eeb7e34479ef",
+      "displayName": "FunctionAppPullFromSpecifiedRegistry",
       "tags": {
         "Azure.Policy/category": "App Service"
       },
@@ -338,6 +343,7 @@
       }
     },
     "spec": {
+      "recommend": "Function app must pull from specified registry",
       "type": [
         "Microsoft.Web/sites"
       ],
@@ -385,11 +391,13 @@
     "kind": "Rule",
     "metadata": {
       "name": "Azure.Policy.48eab4644919",
+      "displayName": "DisableLBRuleSNAT",
       "annotations": {
         "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
       }
     },
     "spec": {
+      "recommend": "Enforce disabling of SNAT on load balancing rules",
       "type": [
         "Microsoft.Network/loadBalancers"
       ],
@@ -411,11 +419,13 @@
     "kind": "Rule",
     "metadata": {
       "name": "Azure.Policy.dd003b6a0803",
+      "displayName": "EnsureAtleastOneLBRule",
       "annotations": {
         "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
       }
     },
     "spec": {
+      "recommend": "Enforce atleast more than one LB rule",
       "type": [
         "Microsoft.Network/loadBalancers"
       ],
@@ -432,11 +442,13 @@
     "kind": "Rule",
     "metadata": {
       "name": "Azure.Policy.6ce831b6b744",
+      "displayName": "UniqueDescriptionNSG",
       "annotations": {
         "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
       }
     },
     "spec": {
+      "recommend": "Enforce unique description on one NSG rule",
       "type": [
         "Microsoft.Network/networkSecurityGroups"
       ],
@@ -458,11 +470,13 @@
     "kind": "Rule",
     "metadata": {
       "name": "Azure.Policy.09175cf78e7c",
+      "displayName": "DenyNSGRDPInboundPort",
       "annotations": {
         "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
       }
     },
     "spec": {
+      "recommend": "Denies RDP port on inbound NSG rules",
       "type": [
         "Microsoft.Network/networkSecurityGroups/securityRules"
       ],
@@ -492,11 +506,13 @@
     "kind": "Rule",
     "metadata": {
       "name": "Azure.Policy.9b51258eff45",
+      "displayName": "DenyPortsNSG",
       "annotations": {
         "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
       }
     },
     "spec": {
+      "recommend": "Deny common ports on NSG rules",
       "type": [
         "Microsoft.Network/networkSecurityGroups/securityRules",
         "Microsoft.Network/networkSecurityGroups"
@@ -573,11 +589,13 @@
     "kind": "Rule",
     "metadata": {
       "name": "Azure.Policy.b54abd1594e6",
+      "displayName": "PreventSubnetsWithoutNSG",
       "annotations": {
         "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
       }
     },
     "spec": {
+      "recommend": "Prevent subnets without NSG",
       "type": [
         "Microsoft.Network/virtualNetworks/subnets",
         "Microsoft.Network/virtualNetworks"
@@ -642,11 +660,13 @@
     "kind": "Rule",
     "metadata": {
       "name": "Azure.Policy.fe294bf42b80",
+      "displayName": "DenyPrivateEndpointSpecificSubnet",
       "annotations": {
         "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
       }
     },
     "spec": {
+      "recommend": "Prevent private endpoint being created in specific subnet",
       "type": [
         "Microsoft.Network/privateEndpoints"
       ],
@@ -683,6 +703,7 @@
     "kind": "Rule",
     "metadata": {
       "name": "Azure.Policy.237646e7bc12",
+      "displayName": "View and configure system diagnostic data",
       "tags": {
         "Azure.Policy/category": "Regulatory Compliance"
       },
@@ -692,6 +713,7 @@
       }
     },
     "spec": {
+      "recommend": "View and configure system diagnostic data",
       "type": [
         "Microsoft.Resources/subscriptions"
       ],

--- a/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesPrefixData.jsonc
+++ b/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesPrefixData.jsonc
@@ -5,6 +5,7 @@
     "kind": "Rule",
     "metadata": {
       "name": "AzureCustomPrefix.Policy.61bca30d0de3",
+      "displayName": "Allowed locations",
       "tags": {
         "Azure.Policy/category": "General"
       },
@@ -14,6 +15,7 @@
       }
     },
     "spec": {
+      "recommend": "This policy enables you to restrict the locations your organization can specify when deploying resources. Use to enforce your geo-compliance requirements. Excludes resource groups, Microsoft.AzureActiveDirectory/b2cDirectories, and resources that use the 'global' region.",
       "with": [
         "PSRule.Rules.Azure\\Azure.Resource.SupportsTags"
       ],


### PR DESCRIPTION
## PR Summary

- Use policy definition name when generating a rule from it.

Fixes #1959 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
