### PR TITLE
Fixes out of bounds for first on empty array #2372

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,8 @@ What's changed since pre-release v1.29.0-B0036:
 - Bug fixes:
   - Fixed array contains with JArray by @BernieWhite.
     [#2368](https://github.com/Azure/PSRule.Rules.Azure/issues/2368)
+  - Fixed index out of bounds of array with first function on empty array by @BernieWhite.
+    [#2372](https://github.com/Azure/PSRule.Rules.Azure/issues/2372)
 
 ## v1.29.0-B0036 (pre-release)
 

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -370,9 +370,9 @@ namespace PSRule.Rules.Azure.Data.Template
             if (args[0] is IMock mock && mock.BaseType != TypePrimitive.String && mock is JToken token)
                 return token.First;
             else if (args[0] is Array avalue)
-                return avalue.GetValue(0);
+                return avalue.Length > 0 ? avalue.GetValue(0) : null;
             else if (args[0] is JArray jArray)
-                return jArray.First;
+                return jArray.Count > 0 ? jArray.First : null;
             else if (ExpressionHelpers.TryString(args[0], out var svalue))
                 return new string(svalue[0], 1);
 
@@ -530,9 +530,9 @@ namespace PSRule.Rules.Azure.Data.Template
             if (args[0] is IMock mock && mock.BaseType != TypePrimitive.String && mock is JToken token)
                 return token.Last;
             else if (args[0] is Array avalue)
-                return avalue.GetValue(avalue.Length - 1);
+                return avalue.Length > 0 ? avalue.GetValue(avalue.Length - 1) : null;
             else if (args[0] is JArray jArray)
-                return jArray.Last;
+                return jArray.Count > 0 ? jArray.Last : null;
             else if (ExpressionHelpers.TryString(args[0], out var svalue))
                 return new string(svalue[svalue.Length - 1], 1);
 

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -220,6 +220,13 @@ namespace PSRule.Rules.Azure
             // Array
             actual1 = Functions.First(context, new object[] { new string[] { "one", "two", "three" } }) as string;
             Assert.Equal("one", actual1);
+            actual1 = Functions.First(context, new object[] { System.Array.Empty<string>() }) as string;
+            Assert.Null(actual1);
+            actual1 = Functions.First(context, new object[] { new JArray() }) as string;
+            Assert.Null(actual1);
+            actual1 = Functions.First(context, new object[] { null }) as string;
+            Assert.Null(actual1);
+
             var actual2 = Functions.First(context, new object[] { new Mock.MockArray() });
             Assert.Null(actual2);
 
@@ -333,6 +340,12 @@ namespace PSRule.Rules.Azure
             // String
             var actual1 = Functions.Last(context, new object[] { "one" }) as string;
             Assert.Equal("e", actual1);
+            actual1 = Functions.Last(context, new object[] { System.Array.Empty<string>() }) as string;
+            Assert.Null(actual1);
+            actual1 = Functions.Last(context, new object[] { new JArray() }) as string;
+            Assert.Null(actual1);
+            actual1 = Functions.Last(context, new object[] { null }) as string;
+            Assert.Null(actual1);
 
             // Array
             actual1 = Functions.Last(context, new object[] { new string[] { "one", "two", "three" } }) as string;

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -697,6 +697,10 @@ namespace PSRule.Rules.Azure
             Assert.Equal(2, oldDogs["value"].Value<JArray>().Count);
             Assert.Equal("Evie", oldDogs["value"][0]["name"].Value<string>());
             Assert.Equal("Kira", oldDogs["value"][1]["name"].Value<string>());
+            Assert.True(templateContext.RootDeployment.TryOutput("firstOldDogs", out JObject firstOldDogs));
+            Assert.Equal("Evie", firstOldDogs["value"]["name"].Value<string>());
+            Assert.True(templateContext.RootDeployment.TryOutput("firstOldDogsEmpty", out JObject firstOldDogsEmpty));
+            Assert.True(firstOldDogsEmpty["value"].Type == JTokenType.Null);
 
             // Map
             Assert.True(templateContext.RootDeployment.TryOutput("dogNames", out JObject dogNames));

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.13.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.13.bicep
@@ -37,6 +37,8 @@ output arrayOutput array = flatten(arrayToTest)
 
 // Filter
 output oldDogs array = filter(dogs, dog => dog.age >= 5)
+output firstOldDogs object = first(filter(dogs, dog => dog.age >= 5))
+output firstOldDogsEmpty object = first(filter(dogs, dog => dog.age >= 10))
 
 param environment string = 'subnet1'
 

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.13.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.13.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.18.4.5664",
-      "templateHash": "11736978922554133719"
+      "version": "0.20.4.51522",
+      "templateHash": "7710253816038152126"
     }
   },
   "parameters": {
@@ -89,8 +89,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "13364432189836274534"
+              "version": "0.20.4.51522",
+              "templateHash": "11278873704136171034"
             }
           },
           "variables": {
@@ -156,14 +156,12 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "languageVersion": "1.10-experimental",
           "contentVersion": "1.0.0.0",
           "metadata": {
-            "_EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "13077654233608092220"
+              "version": "0.20.4.51522",
+              "templateHash": "16150672466446768033"
             }
           },
           "parameters": {
@@ -171,7 +169,7 @@
               "type": "string"
             }
           },
-          "resources": {}
+          "resources": []
         }
       },
       "dependsOn": [
@@ -187,6 +185,14 @@
     "oldDogs": {
       "type": "array",
       "value": "[filter(variables('dogs'), lambda('dog', greaterOrEquals(lambdaVariables('dog').age, 5)))]"
+    },
+    "firstOldDogs": {
+      "type": "object",
+      "value": "[first(filter(variables('dogs'), lambda('dog', greaterOrEquals(lambdaVariables('dog').age, 5))))]"
+    },
+    "firstOldDogsEmpty": {
+      "type": "object",
+      "value": "[first(filter(variables('dogs'), lambda('dog', greaterOrEquals(lambdaVariables('dog').age, 10))))]"
     },
     "vnetId": {
       "type": "string",


### PR DESCRIPTION
## PR Summary

- Fixed index out of bounds of array with first function on empty array.

Fixes #2372 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
