### PR TITLE
Pre-release v1.30.0-B0047

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -24,6 +24,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.30.0-B0047 (pre-release)
+
 What's changed since pre-release v1.30.0-B0026:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.30.0-B0026:

- Engineering:
  - Bump Microsoft.CodeAnalysis.NetAnalyzers to v7.0.4.
    [#2405](https://github.com/Azure/PSRule.Rules.Azure/pull/2405)
- Bug fixes:
  - Fixed lambda map in map variable by @BernieWhite.
    [#2410](https://github.com/Azure/PSRule.Rules.Azure/issues/2410)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**