### PR TITLE
Fix false positive with Azure.VNET.LocalDNS #2370

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -51,6 +51,8 @@
     "APPGW",
     "Architected",
     "AUDITIFNOTEXISTS",
+    "australiaeast",
+    "australiasoutheast",
     "AUTOMATIONACCOUNT",
     "autoscaler",
     "bicepparam",

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,10 @@ What's changed since pre-release v1.30.0-B0047:
 - Bug fixes:
   - Fixed false positive with `Azure.Storage.SecureTransfer` on new API versions by @BernieWhite.
     [#2414](https://github.com/Azure/PSRule.Rules.Azure/issues/2414)
+  - Fixed false positive with `Azure.VNET.LocalDNS` for DNS server addresses out of local scope by @BernieWhite.
+    [#2370](https://github.com/Azure/PSRule.Rules.Azure/issues/2370)
+    - This bug fix introduces a configuration option to flag when DNS from an Identity subscription is used.
+    - Set `AZURE_VNET_DNS_WITH_IDENTITY` to `true` when using an Identity subscription for DNS.
 
 ## v1.30.0-B0047 (pre-release)
 

--- a/docs/concepts/about_PSRule_Azure_Configuration.md
+++ b/docs/concepts/about_PSRule_Azure_Configuration.md
@@ -17,7 +17,7 @@ For details of setting configuration options see [PSRule options][1].
 
 The following configurations options are available for use:
 
-- [Azure_AKSMinimumVersion](#azure_aksminimumversion)
+- [AZURE_AKS_CLUSTER_MINIMUM_VERSION](#azure_aks_cluster_minimum_version)
 - [Azure_AKSNodeMinimumMaxPods](#azure_aksnodeminimummaxpods)
 - [Azure_AllowedRegions](#azure_allowedregions)
 - [Azure_MinimumCertificateLifetime](#azure_minimumcertificatelifetime)
@@ -33,7 +33,7 @@ The following configurations options are available for use:
 
   [1]: https://aka.ms/ps-rule/options
 
-### Azure_AKSMinimumVersion
+### AZURE_AKS_CLUSTER_MINIMUM_VERSION
 
 This configuration option determines the minimum version of Kubernetes for AKS clusters and node pools.
 Rules that check the Kubernetes version fail when the version is older than the version specified.

--- a/docs/en/baselines/Azure.All.md
+++ b/docs/en/baselines/Azure.All.md
@@ -391,10 +391,10 @@ Name | Synopsis | Severity
 [Azure.VMSS.ScriptExtensions](../rules/Azure.VMSS.ScriptExtensions.md) | Custom Script Extensions scripts that reference secret values must use the protectedSettings. | Important
 [Azure.VNET.BastionSubnet](../rules/Azure.VNET.BastionSubnet.md) | VNETs with a GatewaySubnet should have an AzureBastionSubnet to allow for out of band remote access to VMs. | Important
 [Azure.VNET.FirewallSubnet](../rules/Azure.VNET.FirewallSubnet.md) | Use Azure Firewall to filter network traffic to and from Azure resources. | Important
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.Default.md
+++ b/docs/en/baselines/Azure.Default.md
@@ -376,10 +376,10 @@ Name | Synopsis | Severity
 [Azure.VMSS.ScriptExtensions](../rules/Azure.VMSS.ScriptExtensions.md) | Custom Script Extensions scripts that reference secret values must use the protectedSettings. | Important
 [Azure.VNET.BastionSubnet](../rules/Azure.VNET.BastionSubnet.md) | VNETs with a GatewaySubnet should have an AzureBastionSubnet to allow for out of band remote access to VMs. | Important
 [Azure.VNET.FirewallSubnet](../rules/Azure.VNET.FirewallSubnet.md) | Use Azure Firewall to filter network traffic to and from Azure resources. | Important
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2020_06.md
+++ b/docs/en/baselines/Azure.GA_2020_06.md
@@ -136,10 +136,10 @@ Name | Synopsis | Severity
 [Azure.VM.UseManagedDisks](../rules/Azure.VM.UseManagedDisks.md) | Virtual machines (VMs) should use managed disks. | Important
 [Azure.VMSS.ComputerName](../rules/Azure.VMSS.ComputerName.md) | Virtual Machine Scale Set (VMSS) computer name should meet naming requirements. | Awareness
 [Azure.VMSS.Name](../rules/Azure.VMSS.Name.md) | Virtual Machine Scale Set (VMSS) names should meet naming requirements. | Awareness
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2020_09.md
+++ b/docs/en/baselines/Azure.GA_2020_09.md
@@ -152,10 +152,10 @@ Name | Synopsis | Severity
 [Azure.VM.UseManagedDisks](../rules/Azure.VM.UseManagedDisks.md) | Virtual machines (VMs) should use managed disks. | Important
 [Azure.VMSS.ComputerName](../rules/Azure.VMSS.ComputerName.md) | Virtual Machine Scale Set (VMSS) computer name should meet naming requirements. | Awareness
 [Azure.VMSS.Name](../rules/Azure.VMSS.Name.md) | Virtual Machine Scale Set (VMSS) names should meet naming requirements. | Awareness
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2020_12.md
+++ b/docs/en/baselines/Azure.GA_2020_12.md
@@ -176,10 +176,10 @@ Name | Synopsis | Severity
 [Azure.VM.UseManagedDisks](../rules/Azure.VM.UseManagedDisks.md) | Virtual machines (VMs) should use managed disks. | Important
 [Azure.VMSS.ComputerName](../rules/Azure.VMSS.ComputerName.md) | Virtual Machine Scale Set (VMSS) computer name should meet naming requirements. | Awareness
 [Azure.VMSS.Name](../rules/Azure.VMSS.Name.md) | Virtual Machine Scale Set (VMSS) names should meet naming requirements. | Awareness
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2021_03.md
+++ b/docs/en/baselines/Azure.GA_2021_03.md
@@ -191,10 +191,10 @@ Name | Synopsis | Severity
 [Azure.VM.UseManagedDisks](../rules/Azure.VM.UseManagedDisks.md) | Virtual machines (VMs) should use managed disks. | Important
 [Azure.VMSS.ComputerName](../rules/Azure.VMSS.ComputerName.md) | Virtual Machine Scale Set (VMSS) computer name should meet naming requirements. | Awareness
 [Azure.VMSS.Name](../rules/Azure.VMSS.Name.md) | Virtual Machine Scale Set (VMSS) names should meet naming requirements. | Awareness
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2021_06.md
+++ b/docs/en/baselines/Azure.GA_2021_06.md
@@ -205,10 +205,10 @@ Name | Synopsis | Severity
 [Azure.VM.UseManagedDisks](../rules/Azure.VM.UseManagedDisks.md) | Virtual machines (VMs) should use managed disks. | Important
 [Azure.VMSS.ComputerName](../rules/Azure.VMSS.ComputerName.md) | Virtual Machine Scale Set (VMSS) computer name should meet naming requirements. | Awareness
 [Azure.VMSS.Name](../rules/Azure.VMSS.Name.md) | Virtual Machine Scale Set (VMSS) names should meet naming requirements. | Awareness
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2021_09.md
+++ b/docs/en/baselines/Azure.GA_2021_09.md
@@ -224,10 +224,10 @@ Name | Synopsis | Severity
 [Azure.VM.UseManagedDisks](../rules/Azure.VM.UseManagedDisks.md) | Virtual machines (VMs) should use managed disks. | Important
 [Azure.VMSS.ComputerName](../rules/Azure.VMSS.ComputerName.md) | Virtual Machine Scale Set (VMSS) computer name should meet naming requirements. | Awareness
 [Azure.VMSS.Name](../rules/Azure.VMSS.Name.md) | Virtual Machine Scale Set (VMSS) names should meet naming requirements. | Awareness
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2021_12.md
+++ b/docs/en/baselines/Azure.GA_2021_12.md
@@ -247,10 +247,10 @@ Name | Synopsis | Severity
 [Azure.VM.UseManagedDisks](../rules/Azure.VM.UseManagedDisks.md) | Virtual machines (VMs) should use managed disks. | Important
 [Azure.VMSS.ComputerName](../rules/Azure.VMSS.ComputerName.md) | Virtual Machine Scale Set (VMSS) computer name should meet naming requirements. | Awareness
 [Azure.VMSS.Name](../rules/Azure.VMSS.Name.md) | Virtual Machine Scale Set (VMSS) names should meet naming requirements. | Awareness
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2022_03.md
+++ b/docs/en/baselines/Azure.GA_2022_03.md
@@ -261,10 +261,10 @@ Name | Synopsis | Severity
 [Azure.VM.UseManagedDisks](../rules/Azure.VM.UseManagedDisks.md) | Virtual machines (VMs) should use managed disks. | Important
 [Azure.VMSS.ComputerName](../rules/Azure.VMSS.ComputerName.md) | Virtual Machine Scale Set (VMSS) computer name should meet naming requirements. | Awareness
 [Azure.VMSS.Name](../rules/Azure.VMSS.Name.md) | Virtual Machine Scale Set (VMSS) names should meet naming requirements. | Awareness
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2022_06.md
+++ b/docs/en/baselines/Azure.GA_2022_06.md
@@ -265,10 +265,10 @@ Name | Synopsis | Severity
 [Azure.VM.UseManagedDisks](../rules/Azure.VM.UseManagedDisks.md) | Virtual machines (VMs) should use managed disks. | Important
 [Azure.VMSS.ComputerName](../rules/Azure.VMSS.ComputerName.md) | Virtual Machine Scale Set (VMSS) computer name should meet naming requirements. | Awareness
 [Azure.VMSS.Name](../rules/Azure.VMSS.Name.md) | Virtual Machine Scale Set (VMSS) names should meet naming requirements. | Awareness
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2022_09.md
+++ b/docs/en/baselines/Azure.GA_2022_09.md
@@ -297,10 +297,10 @@ Name | Synopsis | Severity
 [Azure.VMSS.ComputerName](../rules/Azure.VMSS.ComputerName.md) | Virtual Machine Scale Set (VMSS) computer name should meet naming requirements. | Awareness
 [Azure.VMSS.Name](../rules/Azure.VMSS.Name.md) | Virtual Machine Scale Set (VMSS) names should meet naming requirements. | Awareness
 [Azure.VMSS.PublicKey](../rules/Azure.VMSS.PublicKey.md) | Use SSH keys instead of common credentials to secure virtual machine scale sets against malicious activities. | Important
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2022_12.md
+++ b/docs/en/baselines/Azure.GA_2022_12.md
@@ -335,10 +335,10 @@ Name | Synopsis | Severity
 [Azure.VMSS.ScriptExtensions](../rules/Azure.VMSS.ScriptExtensions.md) | Custom Script Extensions scripts that reference secret values must use the protectedSettings. | Important
 [Azure.VNET.BastionSubnet](../rules/Azure.VNET.BastionSubnet.md) | VNETs with a GatewaySubnet should have an AzureBastionSubnet to allow for out of band remote access to VMs. | Important
 [Azure.VNET.FirewallSubnet](../rules/Azure.VNET.FirewallSubnet.md) | Use Azure Firewall to filter network traffic to and from Azure resources. | Important
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2023_03.md
+++ b/docs/en/baselines/Azure.GA_2023_03.md
@@ -355,10 +355,10 @@ Name | Synopsis | Severity
 [Azure.VMSS.ScriptExtensions](../rules/Azure.VMSS.ScriptExtensions.md) | Custom Script Extensions scripts that reference secret values must use the protectedSettings. | Important
 [Azure.VNET.BastionSubnet](../rules/Azure.VNET.BastionSubnet.md) | VNETs with a GatewaySubnet should have an AzureBastionSubnet to allow for out of band remote access to VMs. | Important
 [Azure.VNET.FirewallSubnet](../rules/Azure.VNET.FirewallSubnet.md) | Use Azure Firewall to filter network traffic to and from Azure resources. | Important
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.GA_2023_06.md
+++ b/docs/en/baselines/Azure.GA_2023_06.md
@@ -368,10 +368,10 @@ Name | Synopsis | Severity
 [Azure.VMSS.ScriptExtensions](../rules/Azure.VMSS.ScriptExtensions.md) | Custom Script Extensions scripts that reference secret values must use the protectedSettings. | Important
 [Azure.VNET.BastionSubnet](../rules/Azure.VNET.BastionSubnet.md) | VNETs with a GatewaySubnet should have an AzureBastionSubnet to allow for out of band remote access to VMs. | Important
 [Azure.VNET.FirewallSubnet](../rules/Azure.VNET.FirewallSubnet.md) | Use Azure Firewall to filter network traffic to and from Azure resources. | Important
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/baselines/Azure.Preview.md
+++ b/docs/en/baselines/Azure.Preview.md
@@ -391,10 +391,10 @@ Name | Synopsis | Severity
 [Azure.VMSS.ScriptExtensions](../rules/Azure.VMSS.ScriptExtensions.md) | Custom Script Extensions scripts that reference secret values must use the protectedSettings. | Important
 [Azure.VNET.BastionSubnet](../rules/Azure.VNET.BastionSubnet.md) | VNETs with a GatewaySubnet should have an AzureBastionSubnet to allow for out of band remote access to VMs. | Important
 [Azure.VNET.FirewallSubnet](../rules/Azure.VNET.FirewallSubnet.md) | Use Azure Firewall to filter network traffic to and from Azure resources. | Important
-[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.LocalDNS](../rules/Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important
 [Azure.VNET.Name](../rules/Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](../rules/Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
-[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important
+[Azure.VNET.SingleDNS](../rules/Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important
 [Azure.VNET.SubnetName](../rules/Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](../rules/Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical
 [Azure.VNG.ConnectionName](../rules/Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness

--- a/docs/en/rules/Azure.VNET.BastionSubnet.md
+++ b/docs/en/rules/Azure.VNET.BastionSubnet.md
@@ -44,9 +44,9 @@ For example:
 
 ```json
 {
-  "apiVersion": "2022-01-01",
+  "apiVersion": "2023-05-01",
   "type": "Microsoft.Network/virtualNetworks",
-  "name": "vnet-01",
+  "name": "[parameters('name')]",
   "location": "[parameters('location')]",
   "properties": {
     "addressSpace": {
@@ -78,13 +78,13 @@ For example:
 
 ```json
 {
-  "apiVersion": "2022-01-01",
+  "apiVersion": "2023-05-01",
   "type": "Microsoft.Network/virtualNetworks/subnets",
-  "name": "[format('{0}/{1}', 'vnet-01', 'AzureBastionSubnet')]",
+  "name": "[format('{0}/{1}', parameters('name'), 'AzureBastionSubnet')]",
   "properties": {
     "addressPrefix": "10.0.1.64/26"
   },
-  "dependsOn": ["[resourceId('Microsoft.Network/virtualNetworks', 'vnet-02')]"]
+  "dependsOn": ["[resourceId('Microsoft.Network/virtualNetworks', parameters('name'))]"]
 }
 ```
 
@@ -97,8 +97,8 @@ To deploy Virtual Networks that pass this rule:
 For example:
 
 ```bicep
-resource vnet 'Microsoft.Network/virtualNetworks@2022-01-01' = {
-  name: 'vnet-01'
+resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
+  name: name
   location: location
   properties: {
     addressSpace: {
@@ -131,7 +131,7 @@ To deploy Virtual Networks with a subnet sub-resource that pass this rule:
 For example:
 
 ```bicep
-resource bastionSubnet 'Microsoft.Network/virtualNetworks/subnets@2022-01-01' = {
+resource bastionSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-05-01' = {
   name: 'AzureBastionSubnet'
   parent: vnet
   properties: {

--- a/docs/en/rules/Azure.VNET.FirewallSubnet.md
+++ b/docs/en/rules/Azure.VNET.FirewallSubnet.md
@@ -1,5 +1,5 @@
 ---
-reviewed: 2022-11-05
+reviewed: 2023-09-09
 severity: Important
 pillar: Security
 category: Network segmentation
@@ -15,7 +15,7 @@ Use Azure Firewall to filter network traffic to and from Azure resources.
 
 ## DESCRIPTION
 
-Network segementation is a key component of a secure network architecture.
+Network segmentation is a key component of a secure network architecture.
 Azure provides several features that work together to provide strong network segmentation controls.
 
 Azure Firewall is a cloud native stateful Firewall as a service.
@@ -28,6 +28,8 @@ Some key advantages that Azure Firewall has over traditional solutions include:
   Supports Azure concepts that minimize the need for complex network configuration such as service/ FQDN tags and load balancing.
 - Managed by Azure, there is no need to deploy additional management infrastructure or consoles.
 - Built-in support for Infrastructure as Code (IaC), version control, and DevOps.
+
+For guidance on defining your network topology in Azure see Cloud Adoption Framework (CAF).
 
 ## RECOMMENDATION
 
@@ -46,8 +48,8 @@ For example:
 ```json
 {
   "type": "Microsoft.Network/virtualNetworks",
-  "apiVersion": "2022-05-01",
-  "name": "vnet-01",
+  "apiVersion": "2023-05-01",
+  "name": "[parameters('name')]",
   "location": "[parameters('location')]",
   "properties": {
     "addressSpace": {
@@ -82,8 +84,8 @@ To deploy Virtual Networks that pass this rule:
 For example:
 
 ```bicep
-resource virtualnetwork01 'Microsoft.Network/virtualNetworks@2022-05-01' = {
-  name: 'vnet-01'
+resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
+  name: name
   location: location
   properties: {
     addressSpace: {
@@ -111,7 +113,9 @@ resource virtualnetwork01 'Microsoft.Network/virtualNetworks@2022-05-01' = {
 
 ## LINKS
 
-- [Azure features for segmentation](https://learn.microsoft.com/azure/architecture/framework/security/design-network-segmentation#azure-features-for-segmentation)
+- [Azure features for segmentation](https://learn.microsoft.com/azure/well-architected/security/design-network-segmentation#azure-features-for-segmentation)
 - [Hub-spoke network topology in Azure](https://learn.microsoft.com/azure/architecture/reference-architectures/hybrid-networking/hub-spoke)
+- [Define an Azure network topology](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/define-an-azure-network-topology)
+- [What is Azure Firewall?](https://learn.microsoft.com/azure/firewall/overview)
 - [Azure VNET deployment reference](https://learn.microsoft.com/azure/templates/microsoft.network/virtualnetworks)
 - [Azure subnet deployment reference](https://learn.microsoft.com/azure/templates/microsoft.network/virtualnetworks/subnets)

--- a/docs/en/rules/Azure.VNET.LocalDNS.md
+++ b/docs/en/rules/Azure.VNET.LocalDNS.md
@@ -1,4 +1,5 @@
 ---
+reviewed: 2023-09-09
 severity: Important
 pillar: Reliability
 category: Resiliency and dependencies
@@ -10,12 +11,12 @@ online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VNET.L
 
 ## SYNOPSIS
 
-Virtual networks (VNETs) should use Azure local DNS servers.
+Virtual networks (VNETs) should use DNS servers deployed within the same Azure region.
 
 ## DESCRIPTION
 
 Virtual networks allow one or more custom DNS servers to be specified.
-These DNS servers that are inherited by connected services such as virtual machines.
+These DNS servers are inherited by connected services such as virtual machines.
 
 When configuring custom DNS server IP addresses, these servers must be accessible for name resolution to occur.
 Connectivity between services may be impacted if DNS server IP addresses are temporarily or permanently unavailable.
@@ -23,8 +24,12 @@ Connectivity between services may be impacted if DNS server IP addresses are tem
 Avoid taking a dependency on external DNS servers for local communication such as those deployed on-premises.
 This can be achieved by using DNS services deployed into the same Azure region.
 
-Where possible consider deploying Azure Private DNS Zones, a platform-as-a-service (PaaS) DNS service for VNETs.
-Alternativelym consider deploying redundant virtual machines (VMs) or network virtual appliances (NVA) to host DNS within Azure.
+Where possible consider deploying:
+
+- Azure DNS Private Resolver.
+- Azure Private DNS Zones.
+
+Alternatively, redundant virtual machines (VMs) can be deployed into Azure to perform DNS resolution.
 
 ## RECOMMENDATION
 
@@ -44,8 +49,8 @@ For example:
 ```json
 {
   "type": "Microsoft.Network/virtualNetworks",
-  "apiVersion": "2022-05-01",
-  "name": "vnet-01",
+  "apiVersion": "2023-05-01",
+  "name": "[parameters('name')]",
   "location": "[parameters('location')]",
   "properties": {
     "addressSpace": {
@@ -73,8 +78,8 @@ To deploy Virtual Networks that pass this rule:
 For example:
 
 ```bicep
-resource virtualnetwork01 'Microsoft.Network/virtualNetworks@2022-05-01' = {
-  name: 'vnet-01'
+resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
+  name: name
   location: location
   properties: {
     addressSpace: {
@@ -92,9 +97,30 @@ resource virtualnetwork01 'Microsoft.Network/virtualNetworks@2022-05-01' = {
 }
 ```
 
+## NOTES
+
+This rule applies when analyzing resources deployed to Azure (in-flight).
+
+When deploying Active Directory Domain Services (ADDS) within Azure, you may decide to:
+
+- Deploy an Identity subscription aligned to the Cloud Adoption Framework (CAF) Azure landing zone architecture.
+- Host DNS services on the same VMs as ADDS, located in a separate VNET spoke for the Identity subscription.
+
+When you do this, this rule may report a false positive by default.
+If you are using this configuration, we recommend you set the configuration option `AZURE_VNET_DNS_WITH_IDENTITY` to `true`.
+
+For example:
+
+```yaml
+configuration:
+  AZURE_VNET_DNS_WITH_IDENTITY: true
+```
+
 ## LINKS
 
-- [Understand the impact of dependencies](https://learn.microsoft.com/azure/architecture/framework/resiliency/design-resiliency#understand-the-impact-of-dependencies)
+- [Understand the impact of dependencies](https://learn.microsoft.com/azure/well-architected/resiliency/design-resiliency#understand-the-impact-of-dependencies)
 - [Hub-spoke network topology in Azure](https://learn.microsoft.com/azure/architecture/reference-architectures/hybrid-networking/hub-spoke)
 - [Azure landing zone conceptual architecture](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/#azure-landing-zone-conceptual-architecture)
+- [What is Azure DNS Private Resolver?](https://learn.microsoft.com/azure/dns/dns-private-resolver-overview)
+- [What is Azure Private DNS?](https://learn.microsoft.com/azure/dns/private-dns-overview)
 - [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.network/virtualnetworks)

--- a/docs/en/rules/Azure.VNET.SingleDNS.md
+++ b/docs/en/rules/Azure.VNET.SingleDNS.md
@@ -10,7 +10,7 @@ online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VNET.S
 
 ## SYNOPSIS
 
-VNETs should have at least two DNS servers assigned.
+Virtual networks (VNETs) should have at least two DNS servers assigned.
 
 ## DESCRIPTION
 
@@ -35,8 +35,8 @@ For example:
 ```json
 {
   "type": "Microsoft.Network/virtualNetworks",
-  "apiVersion": "2022-05-01",
-  "name": "vnet-01",
+  "apiVersion": "2023-05-01",
+  "name": "[parameters('name')]",
   "location": "[parameters('location')]",
   "properties": {
     "addressSpace": {
@@ -64,8 +64,8 @@ To deploy Virtual Networks that pass this rule:
 For example:
 
 ```bicep
-resource virtualnetwork01 'Microsoft.Network/virtualNetworks@2022-05-01' = {
-  name: 'vnet-01'
+resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
+  name: name
   location: location
   properties: {
     addressSpace: {

--- a/docs/en/rules/Azure.VNET.UseNSGs.md
+++ b/docs/en/rules/Azure.VNET.UseNSGs.md
@@ -32,7 +32,7 @@ These subnets are:
 
 ## RECOMMENDATION
 
-For virtual network subnets, ensure that a network security groups (NSGs) are assigned.
+Consider assigning a network security group (NSG) to each virtual network subnet.
 
 ## EXAMPLES
 
@@ -46,43 +46,43 @@ For example:
 
 ```json
 {
-    "type": "Microsoft.Network/virtualNetworks",
-    "apiVersion": "2021-02-01",
-    "name": "vnet-001",
-    "location": "[parameters('location')]",
-    "properties": {
-        "addressSpace": {
-            "addressPrefixes": [
-                "10.0.0.0/16"
-            ]
-        },
-        "dhcpOptions": {
-            "dnsServers": [
-                "10.0.1.4",
-                "10.0.1.5"
-            ]
-        },
-        "subnets": [
-            {
-                "name": "GatewaySubnet",
-                "properties": {
-                    "addressPrefix": "10.0.0.0/24"
-                }
-            },
-            {
-                "name": "snet-001",
-                "properties": {
-                    "addressPrefix": "10.0.1.0/24",
-                    "networkSecurityGroup": {
-                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-001')]"
-                    }
-                }
-            }
-        ]
+  "type": "Microsoft.Network/virtualNetworks",
+  "apiVersion": "2023-05-01",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "properties": {
+    "addressSpace": {
+      "addressPrefixes": [
+        "10.0.0.0/16"
+      ]
     },
-    "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-001')]"
+    "dhcpOptions": {
+      "dnsServers": [
+        "10.0.1.4",
+        "10.0.1.5"
+      ]
+    },
+    "subnets": [
+      {
+        "name": "GatewaySubnet",
+        "properties": {
+          "addressPrefix": "10.0.0.0/24"
+        }
+      },
+      {
+        "name": "snet-001",
+        "properties": {
+          "addressPrefix": "10.0.1.0/24",
+          "networkSecurityGroup": {
+            "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]"
+          }
+        }
+      }
     ]
+  },
+  "dependsOn": [
+    "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]"
+  ]
 }
 ```
 
@@ -95,8 +95,8 @@ To deploy virtual network subnets that pass this rule:
 For example:
 
 ```bicep
-resource vnet 'Microsoft.Network/virtualNetworks@2021-02-01' = {
-  name: 'vnet-001'
+resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
+  name: name
   location: location
   properties: {
     addressSpace: {

--- a/docs/en/rules/index.md
+++ b/docs/en/rules/index.md
@@ -284,8 +284,8 @@ AZR-000260 | [Azure.VM.PPGName](Azure.VM.PPGName.md) | Proximity Placement Group
 AZR-000261 | [Azure.VMSS.Name](Azure.VMSS.Name.md) | Virtual Machine Scale Set (VMSS) names should meet naming requirements. | GA
 AZR-000262 | [Azure.VMSS.ComputerName](Azure.VMSS.ComputerName.md) | Virtual Machine Scale Set (VMSS) computer name should meet naming requirements. | GA
 AZR-000263 | [Azure.VNET.UseNSGs](Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | GA
-AZR-000264 | [Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | GA
-AZR-000265 | [Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | GA
+AZR-000264 | [Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | GA
+AZR-000265 | [Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | GA
 AZR-000266 | [Azure.VNET.PeerState](Azure.VNET.PeerState.md) | VNET peering connections must be connected. | GA
 AZR-000267 | [Azure.VNET.SubnetName](Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | GA
 AZR-000268 | [Azure.VNET.Name](Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | GA

--- a/docs/en/rules/module.md
+++ b/docs/en/rules/module.md
@@ -381,8 +381,8 @@ Name | Synopsis | Severity | Level
 [Azure.APIM.MultiRegion](Azure.APIM.MultiRegion.md) | API Management instances should use multi-region deployment to improve service availability. | Important | Error
 [Azure.APIM.MultiRegionGateway](Azure.APIM.MultiRegionGateway.md) | API Management instances should have multi-region deployment gateways enabled. | Important | Error
 [Azure.AppService.PlanInstanceCount](Azure.AppService.PlanInstanceCount.md) | App Service Plan should use a minimum number of instances for failover. | Important | Error
-[Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important | Error
-[Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important | Error
+[Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important | Error
+[Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important | Error
 
 ### Resource deployment
 

--- a/docs/en/rules/resource.md
+++ b/docs/en/rules/resource.md
@@ -673,10 +673,10 @@ Name | Synopsis | Severity | Level
 ---- | -------- | -------- | -----
 [Azure.VNET.BastionSubnet](Azure.VNET.BastionSubnet.md) | VNETs with a GatewaySubnet should have an AzureBastionSubnet to allow for out of band remote access to VMs. | Important | Error
 [Azure.VNET.FirewallSubnet](Azure.VNET.FirewallSubnet.md) | Use Azure Firewall to filter network traffic to and from Azure resources. | Important | Error
-[Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important | Error
+[Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important | Error
 [Azure.VNET.Name](Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness | Error
 [Azure.VNET.PeerState](Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important | Error
-[Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important | Error
+[Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important | Error
 [Azure.VNET.SubnetName](Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness | Error
 [Azure.VNET.UseNSGs](Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical | Error
 

--- a/docs/es/rules/index.md
+++ b/docs/es/rules/index.md
@@ -284,8 +284,8 @@ AZR-000260 | [Azure.VM.PPGName](Azure.VM.PPGName.md) | Proximity Placement Group
 AZR-000261 | [Azure.VMSS.Name](Azure.VMSS.Name.md) | Virtual Machine Scale Set (VMSS) names should meet naming requirements. | GA
 AZR-000262 | [Azure.VMSS.ComputerName](Azure.VMSS.ComputerName.md) | Virtual Machine Scale Set (VMSS) computer name should meet naming requirements. | GA
 AZR-000263 | [Azure.VNET.UseNSGs](Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | GA
-AZR-000264 | [Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | GA
-AZR-000265 | [Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | GA
+AZR-000264 | [Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | GA
+AZR-000265 | [Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | GA
 AZR-000266 | [Azure.VNET.PeerState](Azure.VNET.PeerState.md) | VNET peering connections must be connected. | GA
 AZR-000267 | [Azure.VNET.SubnetName](Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | GA
 AZR-000268 | [Azure.VNET.Name](Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | GA

--- a/docs/es/rules/module.md
+++ b/docs/es/rules/module.md
@@ -381,8 +381,8 @@ Name | Synopsis | Severity | Level
 [Azure.APIM.MultiRegion](Azure.APIM.MultiRegion.md) | API Management instances should use multi-region deployment to improve service availability. | Important | Error
 [Azure.APIM.MultiRegionGateway](Azure.APIM.MultiRegionGateway.md) | API Management instances should have multi-region deployment gateways enabled. | Important | Error
 [Azure.AppService.PlanInstanceCount](Azure.AppService.PlanInstanceCount.md) | App Service Plan should use a minimum number of instances for failover. | Important | Error
-[Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important | Error
-[Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important | Error
+[Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important | Error
+[Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important | Error
 
 ### Resource deployment
 

--- a/docs/es/rules/resource.md
+++ b/docs/es/rules/resource.md
@@ -673,10 +673,10 @@ Name | Synopsis | Severity | Level
 ---- | -------- | -------- | -----
 [Azure.VNET.BastionSubnet](Azure.VNET.BastionSubnet.md) | VNETs with a GatewaySubnet should have an AzureBastionSubnet to allow for out of band remote access to VMs. | Important | Error
 [Azure.VNET.FirewallSubnet](Azure.VNET.FirewallSubnet.md) | Use Azure Firewall to filter network traffic to and from Azure resources. | Important | Error
-[Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important | Error
+[Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use DNS servers deployed within the same Azure region. | Important | Error
 [Azure.VNET.Name](Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness | Error
 [Azure.VNET.PeerState](Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important | Error
-[Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Important | Error
+[Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | Virtual networks (VNETs) should have at least two DNS servers assigned. | Important | Error
 [Azure.VNET.SubnetName](Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness | Error
 [Azure.VNET.UseNSGs](Azure.VNET.UseNSGs.md) | Virtual network (VNET) subnets should have Network Security Groups (NSGs) assigned. | Critical | Error
 

--- a/docs/examples-vnet.json
+++ b/docs/examples-vnet.json
@@ -4,11 +4,17 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.12.1.58429",
-      "templateHash": "10916983340852253317"
+      "version": "0.21.1.54444",
+      "templateHash": "5558385779567236827"
     }
   },
   "parameters": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the resource."
+      }
+    },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
@@ -31,8 +37,61 @@
   },
   "resources": [
     {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2023-05-01",
+      "name": "[parameters('name')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        },
+        "dhcpOptions": {
+          "dnsServers": [
+            "10.0.1.4",
+            "10.0.1.5"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "GatewaySubnet",
+            "properties": {
+              "addressPrefix": "10.0.0.0/24"
+            }
+          },
+          {
+            "name": "snet-001",
+            "properties": {
+              "addressPrefix": "10.0.1.0/24",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]"
+              }
+            }
+          },
+          {
+            "name": "snet-002",
+            "properties": {
+              "addressPrefix": "10.0.2.0/24",
+              "delegations": [
+                {
+                  "name": "HSM",
+                  "properties": {
+                    "serviceName": "Microsoft.HardwareSecurityModules/dedicatedHSMs"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]"
+      ]
+    },
+    {
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2022-01-01",
+      "apiVersion": "2023-05-01",
       "name": "[parameters('nsgName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -101,67 +160,14 @@
     },
     {
       "type": "Microsoft.Network/applicationSecurityGroups",
-      "apiVersion": "2022-01-01",
+      "apiVersion": "2023-05-01",
       "name": "[parameters('asgName')]",
       "location": "[parameters('location')]",
       "properties": {}
     },
     {
-      "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2022-01-01",
-      "name": "vnet-001",
-      "location": "[parameters('location')]",
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "10.0.0.0/16"
-          ]
-        },
-        "dhcpOptions": {
-          "dnsServers": [
-            "10.0.1.4",
-            "10.0.1.5"
-          ]
-        },
-        "subnets": [
-          {
-            "name": "GatewaySubnet",
-            "properties": {
-              "addressPrefix": "10.0.0.0/24"
-            }
-          },
-          {
-            "name": "snet-001",
-            "properties": {
-              "addressPrefix": "10.0.1.0/24",
-              "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]"
-              }
-            }
-          },
-          {
-            "name": "snet-002",
-            "properties": {
-              "addressPrefix": "10.0.2.0/24",
-              "delegations": [
-                {
-                  "name": "HSM",
-                  "properties": {
-                    "serviceName": "Microsoft.HardwareSecurityModules/dedicatedHSMs"
-                  }
-                }
-              ]
-            }
-          }
-        ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]"
-      ]
-    },
-    {
       "type": "Microsoft.Network/loadBalancers",
-      "apiVersion": "2022-01-01",
+      "apiVersion": "2023-05-01",
       "name": "[parameters('lbName')]",
       "location": "[parameters('location')]",
       "sku": {
@@ -174,7 +180,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[reference(resourceId('Microsoft.Network/virtualNetworks', 'vnet-001'), '2022-01-01').subnets[1].id]"
+                "id": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('name')), '2023-05-01').subnets[1].id]"
               }
             },
             "zones": [
@@ -186,12 +192,12 @@
         ]
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', 'vnet-001')]"
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('name'))]"
       ]
     },
     {
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2022-05-01",
+      "apiVersion": "2023-05-01",
       "name": "vnet-01",
       "location": "[parameters('location')]",
       "properties": {
@@ -230,7 +236,7 @@
     },
     {
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2022-05-01",
+      "apiVersion": "2023-05-01",
       "name": "vnet-02",
       "location": "[parameters('location')]",
       "properties": {
@@ -249,7 +255,7 @@
     },
     {
       "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2022-05-01",
+      "apiVersion": "2023-05-01",
       "name": "[format('{0}/{1}', 'vnet-02', 'GatewaySubnet')]",
       "properties": {
         "addressPrefix": "10.0.0.0/27"
@@ -260,7 +266,7 @@
     },
     {
       "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2022-05-01",
+      "apiVersion": "2023-05-01",
       "name": "[format('{0}/{1}', 'vnet-02', 'AzureBastionSubnet')]",
       "properties": {
         "addressPrefix": "10.0.0.0/26"

--- a/docs/setup/configuring-rules.md
+++ b/docs/setup/configuring-rules.md
@@ -7,15 +7,13 @@ author: BernieWhite
 PSRule for Azure include several rules that can be configured.
 Setting these values overrides the default configuration with organization specific values.
 
-## Configuration
-
 !!! Tip
     Each of these configuration options are set within the `ps-rule.yaml` file.
     To learn how to set configuration options see [Configuring options][1].
 
   [1]: configuring-options.md
 
-### AKS minimum Kubernetes version
+### AZURE_AKS_CLUSTER_MINIMUM_VERSION
 
 :octicons-milestone-24: v1.12.0
 
@@ -45,128 +43,7 @@ configuration:
   AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.22.4
 ```
 
-### AKS minimum max pods
-
-This configuration option determines the minimum allowed max pods setting per node pool.
-When an AKS cluster node pool is created, a `maxPods` option is used to determine the maximum number of pods for each node in the node pool.
-
-Depending on your workloads it may make sense to change this option:
-
-- Micro-services/ web applications: 50+
-- Data movement/ processing: 20-30
-
-Syntax:
-
-```yaml
-configuration:
-  Azure_AKSNodeMinimumMaxPods: integer
-```
-
-Default:
-
-```yaml
-# YAML: The default Azure_AKSNodeMinimumMaxPods configuration option
-configuration:
-  Azure_AKSNodeMinimumMaxPods: 50
-```
-
-Example:
-
-```yaml
-# YAML: Set the Azure_AKSNodeMinimumMaxPods configuration option to 30
-configuration:
-  Azure_AKSNodeMinimumMaxPods: 30
-```
-
-### Allowed resource regions
-
-This configuration option specifies a list of allowed locations that resources can be deployed to.
-Rules that check the location of Azure resources fail when a resource or resource group is created in a different region.
-
-By default, `Azure_AllowedRegions` is not configured.
-The rule `Azure.Resource.AllowedRegions` is skipped when no allowed locations are configured.
-
-Syntax:
-
-```yaml
-configuration:
-  Azure_AllowedRegions: array # An array of regions
-```
-
-Default:
-
-```yaml
-# YAML: The default Azure_AllowedRegions configuration option
-configuration:
-  Azure_AllowedRegions: []
-```
-
-Example:
-
-```yaml
-# YAML: Set the Azure_AllowedRegions configuration option to Australia East, Australia South East
-configuration:
-  Azure_AllowedRegions:
-  - 'australiaeast'
-  - 'australiasoutheast'
-```
-
-### Minimum certificate lifetime
-
-This configuration option determines the minimum number of days allowed before certificate expiry.
-Rules that check certificate lifetime fail when the days remaining before expiry drop below this number.
-
-Syntax:
-
-```yaml
-configuration:
-  Azure_MinimumCertificateLifetime: integer
-```
-
-Default:
-
-```yaml
-# YAML: The default Azure_MinimumCertificateLifetime configuration option
-configuration:
-  Azure_MinimumCertificateLifetime: 30
-```
-
-Example:
-
-```yaml
-# YAML: Set the Azure_MinimumCertificateLifetime configuration option to 90
-configuration:
-  Azure_MinimumCertificateLifetime: 90
-```
-
-### Azure Policy maximum wavier
-
-This configuration option determines the maximum number of days in the future for a waiver policy exemption.
-
-Syntax:
-
-```yaml
-configuration:
-  AZURE_POLICY_WAIVER_MAX_EXPIRY: integer
-```
-
-Default:
-
-```yaml
-# YAML: The default AZURE_POLICY_WAIVER_MAX_EXPIRY configuration option
-configuration:
-  AZURE_POLICY_WAIVER_MAX_EXPIRY: 366
-```
-
-Example:
-
-```yaml
-# YAML: Set the AZURE_POLICY_WAIVER_MAX_EXPIRY configuration option to 90
-configuration:
-  AZURE_POLICY_WAIVER_MAX_EXPIRY: 90
-```
-
-### Azure AKS CNI minimum cluster subnet size
+### AZURE_AKS_CNI_MINIMUM_CLUSTER_SUBNET_SIZE
 
 This configuration option determines the minimum subnet size for Azure AKS CNI.
 
@@ -193,7 +70,7 @@ configuration:
   AZURE_AKS_CNI_MINIMUM_CLUSTER_SUBNET_SIZE: 26
 ```
 
-### Additional region availability zone list
+### AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST
 
 This configuration option adds availability zones that are not included in the existing [providers](https://github.com/Azure/PSRule.Rules.Azure/blob/main/data/providers/).
 You can use this option to add availability zones that are not included in the default list.
@@ -237,16 +114,16 @@ Example:
 # YAML: Set the AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST configuration option to Antarctica North and Antarctica South, with zones 1, 2, 3.
 configuration:
   AZURE_AKS_ADDITIONAL_REGION_AVAILABILITY_ZONE_LIST:
-  - location: 'Antarctica North'
+  - location: Antarctica North
     zones:
-      - "1"
-      - "2"
-      - "3"
-  - location: 'Antarctica South'
+      - '1'
+      - '2'
+      - '3'
+  - location: Antarctica South
     zones:
-      - "1"
-      - "2"
-      - "3"
+      - '1'
+      - '2'
+      - '3'
 ```
 
 The above example, both these forms of location are accepted:
@@ -262,7 +139,7 @@ The rules normalize these location formats so either is accepted in the configur
     If they do in the future exist, use this option add them prior to PSRule for Azure support.
     The above shows examples specific to `Azure.AKS.AvailabilityZone`, but behavior is consistent across all supported rules.
 
-### Azure AKS enabled platform log categories list
+### AZURE_AKS_ENABLED_PLATFORM_LOG_CATEGORIES_LIST
 
 This configuration option sets selective platform diagnostic categories to report on being enabled.
 
@@ -278,7 +155,12 @@ Default:
 ```yaml
 # YAML: The default AZURE_AKS_ENABLED_PLATFORM_LOG_CATEGORIES_LIST configuration option
 configuration:
-  AZURE_AKS_ENABLED_PLATFORM_LOG_CATEGORIES_LIST: ['cluster-autoscaler', 'kube-apiserver', 'kube-controller-manager', 'kube-scheduler', 'AllMetrics']
+  AZURE_AKS_ENABLED_PLATFORM_LOG_CATEGORIES_LIST:
+  - cluster-autoscaler
+  - kube-apiserver
+  - kube-controller-manager
+  - kube-scheduler
+  - AllMetrics
 ```
 
 Example:
@@ -286,10 +168,12 @@ Example:
 ```yaml
 # YAML: Set the AZURE_AKS_ENABLED_PLATFORM_LOG_CATEGORIES_LIST configuration option to cluster-autoscaler and AllMetrics categories only. 
 configuration:
-  AZURE_AKS_ENABLED_PLATFORM_LOG_CATEGORIES_LIST: ['cluster-autoscaler', 'AllMetrics']
+  AZURE_AKS_ENABLED_PLATFORM_LOG_CATEGORIES_LIST:
+  - cluster-autoscaler
+  - AllMetrics
 ```
 
-### Azure Automation Account enabled platform log categories list
+### AZURE_AUTOMATIONACCOUNT_ENABLED_PLATFORM_LOG_CATEGORIES_LIST
 
 This configuration option sets selective platform diagnostic categories to report on being enabled.
 
@@ -305,7 +189,11 @@ Default:
 ```yaml
 # YAML: The default AZURE_AUTOMATIONACCOUNT_ENABLED_PLATFORM_LOG_CATEGORIES_LIST configuration option
 configuration:
-  AZURE_AUTOMATIONACCOUNT_ENABLED_PLATFORM_LOG_CATEGORIES_LIST: ['JobLogs', 'JobStreams', 'DscNodeStatus', 'AllMetrics']
+  AZURE_AUTOMATIONACCOUNT_ENABLED_PLATFORM_LOG_CATEGORIES_LIST:
+  - JobLogs
+  - JobStreams
+  - DscNodeStatus
+  - AllMetrics
 ```
 
 Example:
@@ -313,10 +201,191 @@ Example:
 ```yaml
 # YAML: Set the AZURE_AUTOMATIONACCOUNT_ENABLED_PLATFORM_LOG_CATEGORIES_LIST configuration option to JobLogs and AllMetrics categories only. 
 configuration:
-  AZURE_AUTOMATIONACCOUNT_ENABLED_PLATFORM_LOG_CATEGORIES_LIST: ['JobLogs', 'AllMetrics']
+  AZURE_AUTOMATIONACCOUNT_ENABLED_PLATFORM_LOG_CATEGORIES_LIST:
+  - JobLogs
+  - AllMetrics
 ```
 
-### Azure Linux OS offers
+### Set the minimum MaxPods for a node pool
+
+This configuration option determines the minimum allowed max pods setting per node pool.
+When an AKS cluster node pool is created, a `maxPods` option is used to determine the maximum number of pods for each node in the node pool.
+
+Depending on your workloads it may make sense to change this option:
+
+- Micro-services/ web applications: 50+
+- Data movement/ processing: 20-30
+
+Syntax:
+
+```yaml
+configuration:
+  Azure_AKSNodeMinimumMaxPods: integer
+```
+
+Default:
+
+```yaml
+# YAML: The default Azure_AKSNodeMinimumMaxPods configuration option
+configuration:
+  Azure_AKSNodeMinimumMaxPods: 50
+```
+
+Example:
+
+```yaml
+# YAML: Set the Azure_AKSNodeMinimumMaxPods configuration option to 30
+configuration:
+  Azure_AKSNodeMinimumMaxPods: 30
+```
+
+### AZURE_APIM_MIN_API_VERSION
+
+This configuration option sets the minimum API version used for control plane API calls to API Management instances.
+Configure this option to change the minimum API version, which defaults to `'2021-08-01'`.
+
+Syntax:
+
+```yaml
+configuration:
+  AZURE_APIM_MIN_API_VERSION: string
+```
+
+Default:
+
+```yaml
+# YAML: The default AZURE_APIM_MIN_API_VERSION configuration option
+configuration:
+  AZURE_APIM_MIN_API_VERSION: '2021-08-01'
+```
+
+Example:
+
+```yaml
+# YAML: Set the AZURE_APIM_MIN_API_VERSION configuration option to '2021-12-01-preview'
+configuration:
+  AZURE_APIM_MIN_API_VERSION: '2021-12-01-preview'
+```
+
+### AZURE_CONTAINERAPPS_RESTRICT_INGRESS
+
+This configuration specifies whether if external ingress should be enabled or disabled.
+
+Syntax:
+
+```yaml
+configuration:
+  AZURE_CONTAINERAPPS_RESTRICT_INGRESS: boolean # An boolean value
+```
+
+Default:
+
+```yaml
+# YAML: The default AZURE_CONTAINERAPPS_RESTRICT_INGRESS configuration option
+configuration:
+  AZURE_CONTAINERAPPS_RESTRICT_INGRESS: false
+```
+
+Example:
+
+```yaml
+# YAML: Set the AZURE_CONTAINERAPPS_RESTRICT_INGRESS configuration option to enabled
+configuration:
+  AZURE_CONTAINERAPPS_RESTRICT_INGRESS: true
+```
+
+### AZURE_COSMOS_DEFENDER_PER_ACCOUNT
+
+This configuration option enables validation for that each Cosmos DB account is associated with a Microsoft Defender for Cosmos DB resource level plan.
+Configure this option to enable the per account validation, which defaults to `false`.
+
+Syntax:
+
+```yaml
+configuration:
+  AZURE_COSMOS_DEFENDER_PER_ACCOUNT: boolean
+```
+
+Default:
+
+```yaml
+# YAML: The default AZURE_COSMOS_DEFENDER_PER_ACCOUNT configuration option
+configuration:
+  AZURE_COSMOS_DEFENDER_PER_ACCOUNT: false
+```
+
+Example:
+
+```yaml
+# YAML: Set the AZURE_COSMOS_DEFENDER_PER_ACCOUNT configuration option to true
+configuration:
+  AZURE_COSMOS_DEFENDER_PER_ACCOUNT: true
+```
+
+### Azure_AllowedRegions
+
+This configuration option specifies a list of allowed locations that resources can be deployed to.
+Rules that check the location of Azure resources fail when a resource or resource group is created in a different region.
+
+By default, `Azure_AllowedRegions` is not configured.
+The rule `Azure.Resource.AllowedRegions` is skipped when no allowed locations are configured.
+
+Syntax:
+
+```yaml
+configuration:
+  Azure_AllowedRegions: array # An array of regions
+```
+
+Default:
+
+```yaml
+# YAML: The default Azure_AllowedRegions configuration option
+configuration:
+  Azure_AllowedRegions: []
+```
+
+Example:
+
+```yaml
+# YAML: Set the Azure_AllowedRegions configuration option to Australia East, Australia South East
+configuration:
+  Azure_AllowedRegions:
+  - australiaeast
+  - australiasoutheast
+```
+
+### Azure_MinimumCertificateLifetime
+
+This configuration option determines the minimum number of days allowed before certificate expiry.
+Rules that check certificate lifetime fail when the days remaining before expiry drop below this number.
+
+Syntax:
+
+```yaml
+configuration:
+  Azure_MinimumCertificateLifetime: integer
+```
+
+Default:
+
+```yaml
+# YAML: The default Azure_MinimumCertificateLifetime configuration option
+configuration:
+  Azure_MinimumCertificateLifetime: 30
+```
+
+Example:
+
+```yaml
+# YAML: Set the Azure_MinimumCertificateLifetime configuration option to 90
+configuration:
+  Azure_MinimumCertificateLifetime: 90
+```
+
+### AZURE_LINUX_OS_OFFERS
+
+:octicons-milestone-24: v1.20.0
 
 This configurations specifies names of offers corresponding to the Linux OS.
 It's mostly intended to be used when analyzing templates that use private Linux offerings.
@@ -347,29 +416,164 @@ configuration:
   - 'anotherLinuxOffer'
 ```
 
-### Azure Container Apps external ingress
+### AZURE_POLICY_IGNORE_LIST
 
-This configuration specifies whether if external ingress should be enabled or disabled.
+:octicons-milestone-24: v1.21.0
+
+This configuration option configures a custom list policy definitions to ignore when exporting policy to rules.
+In addition to the custom list, a built-in list of policies are ignored.
+The built-in list can be found [here](https://github.com/Azure/PSRule.Rules.Azure/blob/main/data/policy-ignore.json).
+
+Configure this option to ignore policy definitions that:
+
+- Already have a rule defined.
+- Are not relevant to testing Infrastructure as Code.
 
 Syntax:
 
 ```yaml
 configuration:
-  AZURE_CONTAINERAPPS_RESTRICT_INGRESS: boolean # An boolean value
+  AZURE_POLICY_IGNORE_LIST: array
 ```
 
 Default:
 
 ```yaml
-# YAML: The default AZURE_CONTAINERAPPS_RESTRICT_INGRESS configuration option
+# YAML: The default AZURE_POLICY_IGNORE_LIST configuration option
 configuration:
-  AZURE_CONTAINERAPPS_RESTRICT_INGRESS: false
+  AZURE_POLICY_IGNORE_LIST: []
 ```
 
 Example:
 
 ```yaml
-# YAML: Set the AZURE_CONTAINERAPPS_RESTRICT_INGRESS configuration option to enabled
+# YAML: Add a custom policy definition to ignore
+  AZURE_POLICY_IGNORE_LIST:
+  - '/providers/Microsoft.Authorization/policyDefinitions/1f314764-cb73-4fc9-b863-8eca98ac36e9'
+  - '/providers/Microsoft.Authorization/policyDefinitions/b54ed75b-3e1a-44ac-a333-05ba39b99ff0'
+```
+
+### AZURE_POLICY_RULE_PREFIX
+
+This configuration option sets the prefix for names of exported rules.
+Configure this option to change the prefix, which defaults to `Azure`.
+
+This configuration option will be ignored when `-Prefix` is used with `Export-AzPolicyAssignmentRuleData`.
+
+Syntax:
+
+```yaml
 configuration:
-  AZURE_CONTAINERAPPS_RESTRICT_INGRESS: true
+  AZURE_POLICY_RULE_PREFIX: string
+```
+
+Default:
+
+```yaml
+# YAML: The default AZURE_POLICY_RULE_PREFIX configuration option
+configuration:
+  AZURE_POLICY_RULE_PREFIX: Azure
+```
+
+Example:
+
+```yaml
+# YAML: Override the prefix of exported policy rules
+  AZURE_POLICY_RULE_PREFIX: AzureCustomPrefix
+```
+
+### AZURE_POLICY_WAIVER_MAX_EXPIRY
+
+This configuration option determines the maximum number of days in the future for a waiver policy exemption.
+
+Syntax:
+
+```yaml
+configuration:
+  AZURE_POLICY_WAIVER_MAX_EXPIRY: integer
+```
+
+Default:
+
+```yaml
+# YAML: The default AZURE_POLICY_WAIVER_MAX_EXPIRY configuration option
+configuration:
+  AZURE_POLICY_WAIVER_MAX_EXPIRY: 366
+```
+
+Example:
+
+```yaml
+# YAML: Set the AZURE_POLICY_WAIVER_MAX_EXPIRY configuration option to 90
+configuration:
+  AZURE_POLICY_WAIVER_MAX_EXPIRY: 90
+```
+
+### AZURE_STORAGE_DEFENDER_PER_ACCOUNT
+
+:octicons-milestone-24: v1.27.0
+
+This configuration option enables validation for that each storage account is associated with a Microsoft Defender for Storage resource level plan.
+Configure this option to enable the per account validation, which defaults to `false`.
+
+Syntax:
+
+```yaml
+configuration:
+  AZURE_STORAGE_DEFENDER_PER_ACCOUNT: boolean
+```
+
+Default:
+
+```yaml
+# YAML: The default AZURE_STORAGE_DEFENDER_PER_ACCOUNT configuration option
+configuration:
+  AZURE_STORAGE_DEFENDER_PER_ACCOUNT: false
+```
+
+Example:
+
+```yaml
+# YAML: Set the AZURE_STORAGE_DEFENDER_PER_ACCOUNT configuration option to true
+configuration:
+  AZURE_STORAGE_DEFENDER_PER_ACCOUNT: true
+```
+
+### AZURE_VNET_DNS_WITH_IDENTITY
+
+:octicons-milestone-24: v1.30.0
+
+> Applies to [Azure.VNET.LocalDNS](../en/rules/Azure.VNET.LocalDNS.md).
+
+Set this configuration option to `true` when DNS is deployed within the Identity subscription to avoid false positives.
+
+When deploying Active Directory Domain Services (ADDS) within Azure, you may decide to:
+
+- Deploy an Identity subscription aligned to the Cloud Adoption Framework (CAF) Azure landing zone architecture.
+- Host DNS services on the same VMs as ADDS, located in a separate VNET spoke for the Identity subscription.
+
+If you are using this configuration, we recommend you set the configuration option `AZURE_VNET_DNS_WITH_IDENTITY` to `true`.
+By default, this configuration option is set to `false`.
+
+Syntax:
+
+```yaml
+configuration:
+  AZURE_VNET_DNS_WITH_IDENTITY: boolean # An boolean value
+```
+
+Default:
+
+```yaml
+# YAML: The default AZURE_VNET_DNS_WITH_IDENTITY configuration option
+configuration:
+  AZURE_VNET_DNS_WITH_IDENTITY: false
+```
+
+Example:
+
+```yaml
+# YAML: Set the AZURE_VNET_DNS_WITH_IDENTITY configuration option to enabled
+configuration:
+  AZURE_VNET_DNS_WITH_IDENTITY: true
 ```

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -82,7 +82,7 @@ function global:HasPeerNetwork {
         if ($PSRule.TargetType -ne 'Microsoft.Network/virtualNetworks') {
             return $False;
         }
-        $peers = $TargetObject.Properties.virtualNetworkPeerings;
+        $peers = $TargetObject.properties.virtualNetworkPeerings;
         if ($Null -eq $peers) {
             return $False;
         }

--- a/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
@@ -42,6 +42,9 @@ spec:
     # Configure Container Apps external ingress
     AZURE_CONTAINERAPPS_RESTRICT_INGRESS: false
 
+    # Configure DNS is within the identity subscription
+    AZURE_VNET_DNS_WITH_IDENTITY: false
+
   convention:
     include:
     - Azure.Context

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VNET.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VNET.Tests.ps1
@@ -353,9 +353,7 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
-            $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'vnet-001';
+            $ruleResult | Should -BeNullOrEmpty;
         }
 
         It 'Azure.VNET.PeerState' {
@@ -374,6 +372,34 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'vnet-001';
+        }
+    }
+
+    Context 'With configuration' {
+        BeforeAll {
+            $invokeParams = @{
+                Baseline      = 'Azure.All'
+                Module        = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction   = 'Stop'
+                Option = @{
+                    'Configuration.AZURE_VNET_DNS_WITH_IDENTITY' = $true
+                }
+            }
+            $dataPath = Join-Path -Path $here -ChildPath 'Resources.VirtualNetwork.json';
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All -Name 'Azure.VNET.LocalDNS';
+        }
+
+        It 'Azure.VNET.LocalDNS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VNET.LocalDNS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -BeNullOrEmpty;
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Fixed false positive with `Azure.VNET.LocalDNS` for DNS server addresses out of local scope.

Fixes #2370

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
