### PR TITLE
Pre-release v1.30.0-B0080

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -28,10 +28,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.30.0-B0080 (pre-release)
+
 What's changed since pre-release v1.30.0-B0047:
 
 - General improvements:
-  - **Important change:** Replaced `Azure_AllowedRegions` option with `AZURE_RESOURCE_ALLOWED_LOCATIONS`. [#941](https://github.com/Azure/PSRule.Rules.Azure/issues/941)
+  - **Important change:** Replaced the `Azure_AllowedRegions` option with `AZURE_RESOURCE_ALLOWED_LOCATIONS`.
+    [#941](https://github.com/Azure/PSRule.Rules.Azure/issues/941)
     - For compatibility, if `Azure_AllowedRegions` is set it will be used instead of `AZURE_RESOURCE_ALLOWED_LOCATIONS`.
     - If only `AZURE_RESOURCE_ALLOWED_LOCATIONS` is set, this value will be used.
     - The default will be used neither options are configured.


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.30.0-B0047:

- General improvements:
  - **Important change:** Replaced the `Azure_AllowedRegions` option with `AZURE_RESOURCE_ALLOWED_LOCATIONS`.
    [#941](https://github.com/Azure/PSRule.Rules.Azure/issues/941)
    - For compatibility, if `Azure_AllowedRegions` is set it will be used instead of `AZURE_RESOURCE_ALLOWED_LOCATIONS`.
    - If only `AZURE_RESOURCE_ALLOWED_LOCATIONS` is set, this value will be used.
    - The default will be used neither options are configured.
    - If `Azure_AllowedRegions` is set a warning will be generated until the configuration is removed.
    - Support for `Azure_AllowedRegions` is deprecated and will be removed in v2.
- Engineering:
  - Bump Microsoft.NET.Test.Sdk to v17.7.2.
    [#2407](https://github.com/Azure/PSRule.Rules.Azure/pull/2407)
  - Bump BenchmarkDotNet to v0.13.8.
    [#2425](https://github.com/Azure/PSRule.Rules.Azure/pull/2425)
  - Bump BenchmarkDotNet.Diagnostics.Windows to v0.13.8.
    [#2425](https://github.com/Azure/PSRule.Rules.Azure/pull/2425)
- Bug fixes:
  - Fixed false positive with `Azure.Storage.SecureTransfer` on new API versions by @BernieWhite.
    [#2414](https://github.com/Azure/PSRule.Rules.Azure/issues/2414)
  - Fixed false positive with `Azure.VNET.LocalDNS` for DNS server addresses out of local scope by @BernieWhite.
    [#2370](https://github.com/Azure/PSRule.Rules.Azure/issues/2370)
    - This bug fix introduces a configuration option to flag when DNS from an Identity subscription is used.
    - Set `AZURE_VNET_DNS_WITH_IDENTITY` to `true` when using an Identity subscription for DNS.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
