### PR TITLE
Updates for Azure.AKS.Version #2404 #2446

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -36,6 +36,11 @@ What's changed since pre-release v1.30.0-B0080:
       [#2423](https://github.com/Azure/PSRule.Rules.Azure/issues/2423)
     - Check that Container Registries disables anonymous pull access by @BenjaminEngeset.
       [#2422](https://github.com/Azure/PSRule.Rules.Azure/issues/2422)
+- Updated rules:
+  - Azure Kubernetes Service:
+    - Updated `Azure.AKS.Version` to use latest stable version `1.26.6` by @BernieWhite.
+      [#2404](https://github.com/Azure/PSRule.Rules.Azure/issues/2404)
+      - Use `AZURE_AKS_CLUSTER_MINIMUM_VERSION` to configure the minimum version of the cluster.
 - Engineering:
   - Updated resource providers and policy aliases.
     [#2442](https://github.com/Azure/PSRule.Rules.Azure/pull/2442)
@@ -43,6 +48,9 @@ What's changed since pre-release v1.30.0-B0080:
     [#2436](https://github.com/Azure/PSRule.Rules.Azure/pull/2436)
   - Bump xunit.runner.visualstudio to v2.5.1.
     [#2435](https://github.com/Azure/PSRule.Rules.Azure/pull/2435)
+- Bug fixes:
+  - Fixed `Azure.AKS.Version` by excluding `node-image` channel by @BernieWhite.
+    [#2446](https://github.com/Azure/PSRule.Rules.Azure/issues/2446)
 
 ## v1.30.0-B0080 (pre-release)
 

--- a/docs/en/rules/Azure.AKS.Version.md
+++ b/docs/en/rules/Azure.AKS.Version.md
@@ -1,4 +1,5 @@
 ---
+reviewed: 2023-09-29
 severity: Important
 pillar: Reliability
 category: Requirements
@@ -15,12 +16,32 @@ AKS control plane and nodes pools should use a current stable release.
 
 ## DESCRIPTION
 
-The AKS support policy for Kubernetes is include N-2 stable minor releases.
-Additionally two patch releases for each minor version are supported.
+The AKS Kubernetes support policy provides support for the latest generally available (GA) three minor versions (N-2).
+This version support policy is based on the Kubernetes community support policy, who maintain the Kubernetes project.
+As the Kubernetes releases new minor versions, the old minor versions are deprecated and eventually removed from support.
+
+When your cluster or cluster nodes are running a version that is no longer supported, you may:
+
+- Encounter issues that may adversely affect the reliability of your cluster and cause down time.
+- Have bugs or security vulnerabilities that have already been mitigated by the Kubernetes community.
+- Introduce additional risk to your cluster and applications when you upgrade to a supported version.
+
+Additionally, AKS provides _Platform Support_ for subset of components following an N-3.
+
+AKS supports a feature called cluster auto-upgrade, which can be used to reduce operational overhead of upgrading your cluster.
+This feature allows you to configure your cluster to automatically upgrade to the latest supported minor version of Kubernetes.
+When you enable cluster auto-upgrade, the control plane and node pools are upgraded to the latest supported minor version.
+Two channels are available for cluster auto-upgrade that maintain Kubernetes minor versions `stable` and `rapid`.
+For details on the differences between the two channels, see the references below.
+
+You are able to define a planned maintenance window to schedule and control upgrades to your cluster.
+Use the Planned Maintenance window to schedule upgrades to your cluster during times of low business impact.
+Alternatively, consider using blue / green clusters.
 
 ## RECOMMENDATION
 
 Consider upgrading AKS control plane and nodes pools to the latest stable version of Kubernetes.
+Also consider enabling cluster auto-upgrade within a maintenance window to minimize operational overhead of cluster upgrades.
 
 ## EXAMPLES
 
@@ -28,14 +49,15 @@ Consider upgrading AKS control plane and nodes pools to the latest stable versio
 
 To deploy AKS clusters that pass this rule:
 
-- Set `properties.autoUpgradeProfile.upgradeChannel` to `rapid` or `stable` or `node-image` or set `properties.kubernetesVersion` to a newer stable version.
+- Set `properties.autoUpgradeProfile.upgradeChannel` to `rapid` or `stable`. OR
+- Set `properties.kubernetesVersion` to a newer stable version.
 
 For example:
 
 ```json
 {
     "type": "Microsoft.ContainerService/managedClusters",
-    "apiVersion": "2021-10-01",
+    "apiVersion": "2023-07-01",
     "name": "[parameters('clusterName')]",
     "location": "[parameters('location')]",
     "identity": {
@@ -45,7 +67,7 @@ For example:
         }
     },
     "properties": {
-        "kubernetesVersion": "1.25.6",
+        "kubernetesVersion": "1.26.6",
         "enableRBAC": true,
         "dnsPrefix": "[parameters('dnsPrefix')]",
         "agentPoolProfiles": "[variables('allPools')]",
@@ -107,12 +129,13 @@ For example:
 
 To deploy AKS clusters that pass this rule:
 
-- Set `properties.autoUpgradeProfile.upgradeChannel` to `rapid` or `stable` or `node-image` or set `properties.kubernetesVersion` to a newer stable version.
+- Set `properties.autoUpgradeProfile.upgradeChannel` to `rapid` or `stable`. OR
+- Set `properties.kubernetesVersion` to a newer stable version.
 
 For example:
 
 ```bicep
-resource cluster 'Microsoft.ContainerService/managedClusters@2021-10-01' = {
+resource cluster 'Microsoft.ContainerService/managedClusters@2023-07-01' = {
   location: location
   name: clusterName
   identity: {
@@ -122,7 +145,7 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2021-10-01' = {
     }
   }
   properties: {
-    kubernetesVersion: '1.25.6'
+    kubernetesVersion: '1.26.6'
     enableRBAC: true
     dnsPrefix: dnsPrefix
     agentPoolProfiles: allPools
@@ -184,13 +207,13 @@ az aks update -n '<name>' -g '<resource_group>' --auto-upgrade-channel 'stable'
 ```
 
 ```bash
-az aks upgrade -n '<name>' -g '<resource_group>' --kubernetes-version '1.25.6'
+az aks upgrade -n '<name>' -g '<resource_group>' --kubernetes-version '1.26.6'
 ```
 
 ### Configure with Azure PowerShell
 
 ```powershell
-Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -KubernetesVersion '1.25.6'
+Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -KubernetesVersion '1.26.6'
 ```
 
 ## NOTES
@@ -200,10 +223,17 @@ To configure this rule:
 
 - Override the `AZURE_AKS_CLUSTER_MINIMUM_VERSION` configuration value with the minimum Kubernetes version.
 
+If you must maintain AKS clusters for longer then the community support period, consider switch to Long Term Support (LTS).
+AKS LTS provides support for a specific Kubernetes version for a longer period of time.
+The first LTS release is 1.27.
+
 ## LINKS
 
-- [Target and non-functional requirements](https://learn.microsoft.com/azure/architecture/framework/resiliency/design-requirements#meet-application-platform-requirements)
+- [Target and non-functional requirements](https://learn.microsoft.com/azure/well-architected/resiliency/design-requirements#meet-application-platform-requirements)
 - [Automatically upgrade an Azure Kubernetes Service cluster](https://learn.microsoft.com/azure/aks/auto-upgrade-cluster)
-- [Supported Kubernetes versions in Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/supported-kubernetes-versions)
-- [Support policies for Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/support-policies)
-- [Azure deployment reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters)
+- [Supported Kubernetes versions in Azure Kubernetes Service](https://learn.microsoft.com/azure/aks/supported-kubernetes-versions#kubernetes-version-support-policy)
+- [Support policies for Azure Kubernetes Service](https://learn.microsoft.com/azure/aks/support-policies)
+- [Platform support policy](https://learn.microsoft.com/azure/aks/supported-kubernetes-versions#platform-support-policy)
+- [Blue-green deployment of AKS clusters](https://learn.microsoft.com/azure/architecture/guide/aks/blue-green-deployment-for-aks)
+- [Long Term Support (LTS)](https://learn.microsoft.com/azure/aks/supported-kubernetes-version#long-term-support-lts)
+- [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.containerservice/managedclusters)

--- a/docs/examples-aks.bicep
+++ b/docs/examples-aks.bicep
@@ -46,7 +46,7 @@ param systemPoolMin int
 param systemPoolMax int = 3
 
 @description('The version of Kubernetes.')
-param kubernetesVersion string = '1.25.6'
+param kubernetesVersion string = '1.26.6'
 
 @description('Maximum number of pods that can run on nodes in the system pool.')
 @minValue(30)
@@ -124,13 +124,13 @@ var userPools = [for i in range(0, length(pools)): {
 // Define resources
 
 // Cluster managed identity
-resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: identityName
   location: location
 }
 
 // An example AKS cluster
-resource cluster 'Microsoft.ContainerService/managedClusters@2023-04-01' = {
+resource cluster 'Microsoft.ContainerService/managedClusters@2023-07-01' = {
   location: location
   name: name
   identity: {
@@ -185,7 +185,7 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2023-04-01' = {
 }
 
 // An example AKS cluster with pools defined.
-resource clusterWithPools 'Microsoft.ContainerService/managedClusters@2023-04-01' = {
+resource clusterWithPools 'Microsoft.ContainerService/managedClusters@2023-07-01' = {
   location: location
   name: name
   identity: {

--- a/docs/examples-aks.json
+++ b/docs/examples-aks.json
@@ -1,13 +1,11 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-  "languageVersion": "1.10-experimental",
   "contentVersion": "1.0.0.0",
   "metadata": {
-    "_EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
     "_generator": {
       "name": "bicep",
-      "version": "0.18.4.5664",
-      "templateHash": "12666421165921150827"
+      "version": "0.21.1.54444",
+      "templateHash": "16848582474653805725"
     }
   },
   "parameters": {
@@ -56,26 +54,26 @@
     },
     "systemPoolMin": {
       "type": "int",
-      "maxValue": 50,
-      "minValue": 1,
       "metadata": {
         "description": "The minimum number of agent nodes for the system pool.",
         "example": 3
-      }
+      },
+      "minValue": 1,
+      "maxValue": 50
     },
     "systemPoolMax": {
       "type": "int",
       "defaultValue": 3,
-      "maxValue": 50,
-      "minValue": 1,
       "metadata": {
         "description": "The maximum number of agent nodes for the system pool.",
         "example": 3
-      }
+      },
+      "minValue": 1,
+      "maxValue": 50
     },
     "kubernetesVersion": {
       "type": "string",
-      "defaultValue": "1.25.6",
+      "defaultValue": "1.26.6",
       "metadata": {
         "description": "The version of Kubernetes."
       }
@@ -171,16 +169,16 @@
       }
     ]
   },
-  "resources": {
-    "identity": {
+  "resources": [
+    {
       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
-      "apiVersion": "2018-11-30",
+      "apiVersion": "2023-01-31",
       "name": "[parameters('identityName')]",
       "location": "[parameters('location')]"
     },
-    "cluster": {
+    {
       "type": "Microsoft.ContainerService/managedClusters",
-      "apiVersion": "2023-04-01",
+      "apiVersion": "2023-07-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "identity": {
@@ -233,12 +231,12 @@
         }
       },
       "dependsOn": [
-        "identity"
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
       ]
     },
-    "clusterWithPools": {
+    {
       "type": "Microsoft.ContainerService/managedClusters",
-      "apiVersion": "2023-04-01",
+      "apiVersion": "2023-07-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "identity": {
@@ -318,8 +316,8 @@
         }
       },
       "dependsOn": [
-        "identity"
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
       ]
     }
-  }
+  ]
 }

--- a/docs/setup/configuring-options.md
+++ b/docs/setup/configuring-options.md
@@ -52,7 +52,7 @@ Use comments to add context.
       AZURE_BICEP_MINIMUM_VERSION: '0.16.2'
 
       # Configure the minimum AKS cluster version.
-      AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.25.6
+      AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.26.6'
 
     rule:
       # Enable custom rules that don't exist in the baseline

--- a/docs/setup/configuring-rules.md
+++ b/docs/setup/configuring-rules.md
@@ -32,7 +32,7 @@ Default:
 ```yaml
 # YAML: The default AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option
 configuration:
-  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.25.6
+  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.26.6
 ```
 
 Example:

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -44,9 +44,9 @@ To update your configuration, use the new name instead.
     Set the `AZURE_AKS_CLUSTER_MINIMUM_VERSION` option in `ps-rule.yaml`.
 
     ```yaml
-    # YAML: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.25.6
+    # YAML: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.27.3
     configuration:
-      AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.25.6
+      AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.27.3
     ```
 
 === "Bash"
@@ -54,8 +54,8 @@ To update your configuration, use the new name instead.
     Set the `PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION` environment variable.
 
     ```bash
-    # Bash: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.25.6
-    export PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION="1.25.6"
+    # Bash: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.27.3
+    export PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION="1.27.3"
     ```
 
 === "GitHub Actions"
@@ -63,9 +63,9 @@ To update your configuration, use the new name instead.
     Set the `PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION` environment variable.
 
     ```yaml
-    # GitHub Actions: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.25.6
+    # GitHub Actions: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.27.3
     env:
-      PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.25.6'
+      PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.27.3'
     ```
 
 === "Azure Pipelines"
@@ -73,10 +73,10 @@ To update your configuration, use the new name instead.
     Set the `PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION` environment variable.
 
     ```yaml
-    # Azure Pipelines: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.25.6
+    # Azure Pipelines: Set the AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option to 1.27.3
     variables:
     - name: PSRULE_CONFIGURATION_AZURE_AKS_CLUSTER_MINIMUM_VERSION
-      value: '1.25.6'
+      value: '1.27.3'
     ```
 
 ### Removal of SupportsTags function

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -10,7 +10,7 @@ Rule 'Azure.AKS.Version' -Ref 'AZR-000015' -Type 'Microsoft.ContainerService/man
     $minVersion = $Configuration.GetValueOrDefault('Azure_AKSMinimumVersion', $Configuration.AZURE_AKS_CLUSTER_MINIMUM_VERSION);
     if ($PSRule.TargetType -eq 'Microsoft.ContainerService/managedClusters') {
         $upgradeChannel = $TargetObject.properties.autoUpgradeProfile.upgradeChannel
-        $expectedUpgradeChannels = @('rapid', 'stable', 'node-image')
+        $expectedUpgradeChannels = @('rapid', 'stable')
         if ($upgradeChannel -in $expectedUpgradeChannels -and !(IsExport)) {
             $Assert.Pass();
         }

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.yaml
@@ -15,8 +15,8 @@ metadata:
   name: Azure.AKS.MinNodeCount
   ref: AZR-000024
   tags:
-    release: 'GA'
-    ruleSet: '2020_06'
+    release: GA
+    ruleSet: 2020_06
     Azure.WAF/pillar: Reliability
 spec:
   type:
@@ -33,19 +33,19 @@ metadata:
   name: Azure.AKS.ManagedIdentity
   ref: AZR-000025
   tags:
-    release: 'GA'
-    ruleSet: '2020_06'
-    Azure.WAF/pillar: 'Security'
+    release: GA
+    ruleSet: 2020_06
+    Azure.WAF/pillar: Security
   labels:
     Azure.MCSB.v1/control: [ 'IM-1', 'IM-2' ]
 spec:
   type:
   - Microsoft.ContainerService/managedClusters
   condition:
-    field: 'Identity.Type'
+    field: Identity.Type
     in:
-      - 'SystemAssigned'
-      - 'UserAssigned'
+      - SystemAssigned
+      - UserAssigned
 
 ---
 # Synopsis: Use a Standard load-balancer with AKS clusters.
@@ -55,15 +55,15 @@ metadata:
   name: Azure.AKS.StandardLB
   ref: AZR-000026
   tags:
-    release: 'GA'
-    ruleSet: '2020_06'
+    release: GA
+    ruleSet: 2020_06
     Azure.WAF/pillar: Performance Efficiency
 spec:
   type:
   - Microsoft.ContainerService/managedClusters
   condition:
-    field: 'Properties.networkProfile.loadBalancerSku'
-    equals: 'standard'
+    field: properties.networkProfile.loadBalancerSku
+    equals: standard
 
 ---
 # Synopsis: Deploy AKS clusters with Network Policies enabled.
@@ -73,9 +73,9 @@ metadata:
   name: Azure.AKS.NetworkPolicy
   ref: AZR-000027
   tags:
-    release: 'GA'
-    ruleSet: '2020_06'
-    Azure.WAF/pillar: 'Security'
+    release: GA
+    ruleSet: 2020_06
+    Azure.WAF/pillar: Security
   labels:
     Azure.MCSB.v1/control: 'NS-1'
 spec:
@@ -95,16 +95,16 @@ metadata:
   name: Azure.AKS.AzurePolicyAddOn
   ref: AZR-000028
   tags:
-    release: 'GA'
-    ruleSet: '2020_12'
-    Azure.WAF/pillar: 'Security'
+    release: GA
+    ruleSet: 2020_12
+    Azure.WAF/pillar: Security
   labels:
     Azure.MCSB.v1/control: 'AM-2'
 spec:
   type:
   - Microsoft.ContainerService/managedClusters
   condition:
-    field: 'Properties.addonProfiles.azurePolicy.enabled'
+    field: properties.addonProfiles.azurePolicy.enabled
     equals: true
 
 ---
@@ -115,16 +115,16 @@ metadata:
   name: Azure.AKS.ManagedAAD
   ref: AZR-000029
   tags:
-    release: 'GA'
-    ruleSet: '2021_06'
-    Azure.WAF/pillar: 'Security'
+    release: GA
+    ruleSet: 2021_06
+    Azure.WAF/pillar: Security
   labels:
     Azure.MCSB.v1/control: [ 'IM-1', 'IM-2' ]
 spec:
   type:
   - Microsoft.ContainerService/managedClusters
   condition:
-    field: 'Properties.aadProfile.managed'
+    field: properties.aadProfile.managed
     equals: true
 
 ---
@@ -135,16 +135,16 @@ metadata:
   name: Azure.AKS.AuthorizedIPs
   ref: AZR-000030
   tags:
-    release: 'GA'
-    ruleSet: '2021_06'
-    Azure.WAF/pillar: 'Security'
+    release: GA
+    ruleSet: 2021_06
+    Azure.WAF/pillar: Security
   labels:
     Azure.MCSB.v1/control: 'NS-1'
 spec:
   type:
   - Microsoft.ContainerService/managedClusters
   condition:
-    field: 'Properties.apiServerAccessProfile.authorizedIPRanges'
+    field: properties.apiServerAccessProfile.authorizedIPRanges
     greaterOrEquals: 1
 
 ---
@@ -155,9 +155,9 @@ metadata:
   name: Azure.AKS.LocalAccounts
   ref: AZR-000031
   tags:
-    release: 'preview'
-    ruleSet: '2021_06'
-    Azure.WAF/pillar: 'Security'
+    release: preview
+    ruleSet: 2021_06
+    Azure.WAF/pillar: Security
   labels:
     Azure.MCSB.v1/control: [ 'IM-1', 'PA-7' ]
 spec:
@@ -175,9 +175,9 @@ metadata:
   name: Azure.AKS.AzureRBAC
   ref: AZR-000032
   tags:
-    release: 'GA'
-    ruleSet: '2021_06'
-    Azure.WAF/pillar: 'Security'
+    release: GA
+    ruleSet: 2021_06
+    Azure.WAF/pillar: Security
   labels:
     Azure.MCSB.v1/control: [ 'IM-1', 'PA-7' ]
 spec:
@@ -195,9 +195,9 @@ metadata:
   name: Azure.AKS.SecretStore
   ref: AZR-000033
   tags:
-    release: 'GA'
-    ruleSet: '2021_12'
-    Azure.WAF/pillar: 'Security'
+    release: GA
+    ruleSet: 2021_12
+    Azure.WAF/pillar: Security
   labels:
     Azure.MCSB.v1/control: 'IM-8'
 spec:
@@ -215,9 +215,9 @@ metadata:
   name: Azure.AKS.SecretStoreRotation
   ref: AZR-000034
   tags:
-    release: 'GA'
-    ruleSet: '2021_12'
-    Azure.WAF/pillar: 'Security'
+    release: GA
+    ruleSet: 2021_12
+    Azure.WAF/pillar: Security
   labels:
     Azure.MCSB.v1/control: 'DP-7'
 spec:
@@ -237,9 +237,9 @@ metadata:
   name: Azure.AKS.HttpAppRouting
   ref: AZR-000035
   tags:
-    release: 'GA'
-    ruleSet: '2021_12'
-    Azure.WAF/pillar: 'Security'
+    release: GA
+    ruleSet: 2021_12
+    Azure.WAF/pillar: Security
   labels:
     Azure.MCSB.v1/control: [ 'NS-1', 'DP-4' ]
 spec:
@@ -260,9 +260,9 @@ metadata:
   name: Azure.AKS.AutoUpgrade
   ref: AZR-000036
   tags:
-    release: 'GA'
-    ruleSet: '2021_12'
-    Azure.WAF/pillar: 'Security'
+    release: GA
+    ruleSet: 2021_12
+    Azure.WAF/pillar: Security
   labels:
     Azure.MCSB.v1/control: 'PV-7'
 spec:
@@ -283,9 +283,9 @@ metadata:
   name: Azure.AKS.UseRBAC
   ref: AZR-000038
   tags:
-    release: 'GA'
-    ruleSet: '2020_06'
-    Azure.WAF/pillar: 'Security'
+    release: GA
+    ruleSet: 2020_06
+    Azure.WAF/pillar: Security
   labels:
     Azure.MCSB.v1/control: [ 'IM-1','PA-7' ]
 spec:
@@ -303,8 +303,8 @@ metadata:
   name: Azure.AKS.Name
   ref: AZR-000039
   tags:
-    release: 'GA'
-    ruleSet: '2020_06'
+    release: GA
+    ruleSet: 2020_06
     Azure.WAF/pillar: Operational Excellence
 spec:
   type:
@@ -328,8 +328,8 @@ metadata:
   name: Azure.AKS.DNSPrefix
   ref: AZR-000040
   tags:
-    release: 'GA'
-    ruleSet: '2020_06'
+    release: GA
+    ruleSet: 2020_06
     Azure.WAF/pillar: Operational Excellence
 spec:
   type:
@@ -353,9 +353,9 @@ metadata:
   name: Azure.AKS.ContainerInsights
   ref: AZR-000041
   tags:
-    release: 'GA'
-    ruleSet: '2021_09'
-    Azure.WAF/pillar: 'Operational Excellence'
+    release: GA
+    ruleSet: 2021_09
+    Azure.WAF/pillar: Operational Excellence
   labels:
     Azure.MCSB.v1/control: 'LT-3'
 spec:

--- a/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
@@ -33,7 +33,7 @@ spec:
     AZURE_BICEP_CHECK_TOOL: false 
 
     # Configure minimum AKS cluster version
-    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.25.6'
+    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.26.6'
     AZURE_DEPLOYMENT_SENSITIVE_PROPERTY_NAMES:
     - adminUsername
     - administratorLogin

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -62,7 +62,7 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult.TargetName | Should -BeIn 'cluster-B';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[0].Reason | Should -BeExactly "Path Properties.kubernetesVersion: The version '1.13.8' does not match the constraint '>=1.25.6'.";
+            $ruleResult[0].Reason | Should -BeExactly "Path Properties.kubernetesVersion: The version '1.13.8' does not match the constraint '>=1.26.6'.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -50,7 +50,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.25.6",
+                "kubernetesVersion": "1.26.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -210,7 +210,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.25.6",
+                "kubernetesVersion": "1.26.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -395,7 +395,7 @@
                 "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-03')]",
                 "maxPods": 50,
                 "type": "VirtualMachineScaleSets",
-                "orchestratorVersion": "1.25.6",
+                "orchestratorVersion": "1.26.6",
                 "osType": "Linux",
                 "enableAutoScaling": false
             }
@@ -427,7 +427,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.25.6",
+                "kubernetesVersion": "1.26.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -628,7 +628,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.25.6",
+                "kubernetesVersion": "1.26.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName5'))]",
                 "agentPoolProfiles": [
                     {
@@ -831,7 +831,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.25.6",
+                "kubernetesVersion": "1.26.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName6'))]",
                 "agentPoolProfiles": [
                     {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -6,7 +6,7 @@
     "ResourceName": "cluster-A",
     "Name": "cluster-A",
     "Properties": {
-      "kubernetesVersion": "1.25.6",
+      "kubernetesVersion": "1.26.6",
       "dnsPrefix": "cluster-A",
       "fqdn": "cluster-A-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -18,7 +18,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "AvailabilitySet",
-          "orchestratorVersion": "1.25.6",
+          "orchestratorVersion": "1.26.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -172,7 +172,7 @@
     "ParentResource": null,
     "Properties": {
       "provisioningState": "Succeeded",
-      "kubernetesVersion": "1.25.6",
+      "kubernetesVersion": "1.26.6",
       "dnsPrefix": "cluster-C",
       "fqdn": "cluster-C-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -186,7 +186,7 @@
           "maxPods": 50,
           "type": "VirtualMachineScaleSets",
           "provisioningState": "Succeeded",
-          "orchestratorVersion": "1.25.6",
+          "orchestratorVersion": "1.26.6",
           "osType": "Linux",
           "enableAutoScaling": false
         }
@@ -300,7 +300,7 @@
     "Plan": null,
     "Properties": {
       "provisioningState": "Succeeded",
-      "kubernetesVersion": "1.25.6",
+      "kubernetesVersion": "1.26.6",
       "dnsPrefix": "cluster-D",
       "fqdn": "cluster-D-nnnnnnnn.hcp.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -313,7 +313,7 @@
           "maxPods": 50,
           "type": "VirtualMachineScaleSets",
           "provisioningState": "Succeeded",
-          "orchestratorVersion": "1.25.6",
+          "orchestratorVersion": "1.26.6",
           "nodeLabels": {},
           "mode": "System",
           "osType": "Linux",
@@ -495,7 +495,7 @@
       "powerState": {
         "code": "Running"
       },
-      "orchestratorVersion": "1.25.6",
+      "orchestratorVersion": "1.26.6",
       "nodeLabels": {},
       "mode": "System",
       "osType": "Linux",
@@ -565,7 +565,7 @@
       "powerState": {
         "code": "Running"
       },
-      "kubernetesVersion": "1.25.6",
+      "kubernetesVersion": "1.26.6",
       "dnsPrefix": "cluster-F",
       "fqdn": "cluster-F-00000000.hcp.region.azmk8s.io",
       "azurePortalFQDN": "cluster-F-00000000.portal.hcp.region.azmk8s.io",
@@ -586,7 +586,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.25.6",
+          "orchestratorVersion": "1.26.6",
           "nodeLabels": {},
           "mode": "System",
           "osType": "Linux",
@@ -793,7 +793,7 @@
     "ResourceName": "cluster-G",
     "Name": "cluster-G",
     "Properties": {
-      "kubernetesVersion": "1.25.6",
+      "kubernetesVersion": "1.26.6",
       "dnsPrefix": "cluster-G",
       "fqdn": "cluster-G-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -805,7 +805,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.25.6",
+          "orchestratorVersion": "1.26.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -968,7 +968,7 @@
     "ResourceName": "cluster-H",
     "Name": "cluster-H",
     "Properties": {
-      "kubernetesVersion": "1.25.6",
+      "kubernetesVersion": "1.26.6",
       "dnsPrefix": "cluster-H",
       "fqdn": "cluster-H-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -980,7 +980,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.25.6",
+          "orchestratorVersion": "1.26.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": []
@@ -1147,7 +1147,7 @@
     "ResourceName": "cluster-I",
     "Name": "cluster-I",
     "Properties": {
-      "kubernetesVersion": "1.25.6",
+      "kubernetesVersion": "1.26.6",
       "dnsPrefix": "cluster-I",
       "fqdn": "cluster-I-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1159,7 +1159,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.25.6",
+          "orchestratorVersion": "1.26.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -1325,7 +1325,7 @@
     "ResourceName": "cluster-J",
     "Name": "cluster-J",
     "Properties": {
-      "kubernetesVersion": "1.25.6",
+      "kubernetesVersion": "1.26.6",
       "dnsPrefix": "cluster-J",
       "fqdn": "cluster-J-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1337,7 +1337,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.25.6",
+          "orchestratorVersion": "1.26.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -1510,7 +1510,7 @@
       "powerState": {
         "code": "Running"
       },
-      "kubernetesVersion": "1.25.6",
+      "kubernetesVersion": "1.26.6",
       "dnsPrefix": "cluster-K",
       "fqdn": "cluster-K-00000000.hcp.eastus.azmk8s.io",
       "azurePortalFQDN": "cluster-K-00000000.portal.hcp.eastus.azmk8s.io",
@@ -1532,7 +1532,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.25.6",
+          "orchestratorVersion": "1.26.6",
           "mode": "System",
           "osType": "Linux",
           "osSKU": "Ubuntu",


### PR DESCRIPTION
## PR Summary

- Updated `Azure.AKS.Version` to use latest stable version `1.26.6`.
- Fixed `Azure.AKS.Version` by excluding `node-image` channel.

Fixes #2404 
Fixes #2446 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
