### PR TITLE
Fixes Azure.Resource.AllowedRegions #2461

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -28,6 +28,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.30.0:
+
+- Bug fixes:
+  - Fixed `Azure.Resource.AllowedRegions` which was failing when no allowed regions were configured by @BernieWhite.
+    [#2461](https://github.com/Azure/PSRule.Rules.Azure/issues/2461)
+
 ## v1.30.0
 
 What's changed since v1.29.0:

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
 using System.Threading;
 using Newtonsoft.Json.Linq;
 using PSRule.Rules.Azure.Resources;

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
@@ -11,7 +11,6 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using Newtonsoft.Json.Linq;
-using PSRule.Rules.Azure.Resources;
 
 namespace PSRule.Rules.Azure.Data.Template
 {

--- a/src/PSRule.Rules.Azure/Runtime/RuntimeService.cs
+++ b/src/PSRule.Rules.Azure/Runtime/RuntimeService.cs
@@ -74,7 +74,12 @@ namespace PSRule.Rules.Azure.Runtime
             if (locations == null || locations.Length == 0)
                 return;
 
-            _AllowedLocations = new HashSet<string>(locations, LocationHelper.Comparer);
+            _AllowedLocations = new HashSet<string>(LocationHelper.Comparer);
+            for (var i = 0; i < locations.Length; i++)
+            {
+                if (!string.IsNullOrEmpty(locations[i]))
+                    _AllowedLocations.Add(locations[i]);
+            }
         }
 
         /// <inheritdoc/>
@@ -82,6 +87,7 @@ namespace PSRule.Rules.Azure.Runtime
         {
             return location == null ||
                 _AllowedLocations == null ||
+                _AllowedLocations.Count == 0 ||
                 _AllowedLocations.Contains(location);
         }
 

--- a/src/PSRule.Rules.Azure/rules/Conventions.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Conventions.Rule.ps1
@@ -24,7 +24,7 @@ Export-PSRuleConvention 'Azure.Context' -Initialize {
     $minimum = $Configuration.GetValueOrDefault('AZURE_BICEP_MINIMUM_VERSION', '0.4.451');
     $timeout = $Configuration.GetIntegerOrDefault('AZURE_BICEP_FILE_EXPANSION_TIMEOUT', 5);
     $check = $Configuration.GetBoolOrDefault('AZURE_BICEP_CHECK_TOOL', $False);
-    $allowedRegions = @($Configuration.GetValueOrDefault('Azure_AllowedRegions', $Configuration.AZURE_RESOURCE_ALLOWED_LOCATIONS));
+    $allowedRegions = @($Configuration.GetValueOrDefault('Azure_AllowedRegions', $Configuration.GetStringValues('AZURE_RESOURCE_ALLOWED_LOCATIONS')));
     $service = [PSRule.Rules.Azure.Runtime.Helper]::CreateService($minimum, $timeout);
 
     if ($allowedRegions.Length -gt 0) {

--- a/tests/PSRule.Rules.Azure.Tests/RuntimeHelperTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/RuntimeHelperTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Management.Automation;
@@ -51,6 +51,30 @@ namespace PSRule.Rules.Azure
             Assert.True(eval.Outbound("virtualNetwork", 80) == Data.Network.Access.Allow);
         }
 
+        [Fact]
+        public void CreateService()
+        {
+            var service = Helper.CreateService("1.0.0", 90);
+            Assert.NotNull(service);
+            Assert.Equal("1.0.0", service.Minimum);
+            Assert.Equal(90, service.Timeout);
+
+            service.WithAllowedLocations(null);
+            Assert.True(service.IsAllowedLocation("eastus"));
+
+            service.WithAllowedLocations(System.Array.Empty<string>());
+            Assert.True(service.IsAllowedLocation("eastus"));
+
+            service.WithAllowedLocations(new string[] { "westus" });
+            Assert.True(service.IsAllowedLocation("westus"));
+            Assert.False(service.IsAllowedLocation("eastus"));
+
+            service.WithAllowedLocations(new string[] { "" });
+            Assert.True(service.IsAllowedLocation("eastus"));
+        }
+
+        #region Helper methods
+
         private static PSObject NewSecurityRule(int priority, string access, string direction, string destinationAddressPrefix = null, string destinationPortRange = null)
         {
             var result = new PSObject();
@@ -68,5 +92,7 @@ namespace PSRule.Rules.Azure
             result.Properties.Add(new PSNoteProperty("properties", properties));
             return result;
         }
+
+        #endregion Helper methods
     }
 }


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.Resource.AllowedRegions` which was failing when no allowed regions were configured.

Fixes #2461 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
