### PR TITLE
Fixed Azure field binding #2460

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -28,6 +28,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.30.1:
+
+- Bug fixes:
+  - Fixed binding of results resourceId and resourceGroupName by @BenrieWhite.
+    [#2460](https://github.com/Azure/PSRule.Rules.Azure/issues/2460)
+
 ## v1.30.1
 
 What's changed since v1.30.0:

--- a/src/PSRule.Rules.Azure/Pipeline/Export/ResourceExportVisitor.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/Export/ResourceExportVisitor.cs
@@ -20,6 +20,7 @@ namespace PSRule.Rules.Azure.Pipeline.Export
         private const string PROPERTY_ZONES = "zones";
         private const string PROPERTY_RESOURCES = "resources";
         private const string PROPERTY_SUBSCRIPTIONID = "subscriptionId";
+        private const string PROPERTY_RESOURCEGROUPNAME = "resourceGroupName";
         private const string PROPERTY_KIND = "kind";
         private const string PROPERTY_SHAREDKEY = "sharedKey";
         private const string PROPERTY_NETWORKPROFILE = "networkProfile";
@@ -128,8 +129,8 @@ namespace PSRule.Rules.Azure.Pipeline.Export
 
             var resourceContext = new ResourceContext(context, tenantId);
 
-            // Set the subscription Id.
-            SetSubscriptionId(resource, resourceId);
+            // Set subscriptionId and resourceGroupName.
+            SetResourceIdentifiers(resource, resourceType, resourceId);
 
             // Ignore expand of these.
             if (string.Equals(resourceType, TYPE_VISUALSTUDIO_ACCOUNT, StringComparison.OrdinalIgnoreCase))
@@ -181,9 +182,16 @@ namespace PSRule.Rules.Azure.Pipeline.Export
                 resource.Add(PROPERTY_PROPERTIES, properties);
         }
 
-        private static void SetSubscriptionId(JObject resource, string resourceId)
+        /// <summary>
+        /// Set <c>subscriptionId</c> and <c>resourceGroupName</c> on the resource based on the provided <c>resourceId</c>.
+        /// </summary>
+        private static void SetResourceIdentifiers(JObject resource, string resourceType, string resourceId)
         {
-            if (ResourceHelper.TrySubscriptionId(resourceId, out var subscriptionId))
+            if (ResourceHelper.TryResourceGroup(resourceId, out var subscriptionId, out var resourceGroupName) &&
+                !string.Equals(resourceType, TYPE_RESOURCES_RESOURCEGROUP, StringComparison.OrdinalIgnoreCase))
+                resource.Add(PROPERTY_RESOURCEGROUPNAME, resourceGroupName);
+            
+            if (!string.IsNullOrEmpty(subscriptionId))
                 resource.Add(PROPERTY_SUBSCRIPTIONID, subscriptionId);
         }
 

--- a/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
@@ -21,19 +21,20 @@ spec:
     - ResourceType
     - type
     field:
-      resourceId: [ 'ResourceId' ]
-      subscriptionId: [ 'SubscriptionId' ]
-      resourceGroupName: [ 'ResourceGroupName' ]
+      resourceId: [ 'ResourceId', 'id' ]
+      subscriptionId: [ 'subscriptionId' ]
+      resourceGroupName: [ 'resourceGroupName' ]
   configuration:
     AZURE_PARAMETER_FILE_EXPANSION: false
     AZURE_PARAMETER_FILE_METADATA_LINK: false
     AZURE_BICEP_FILE_EXPANSION: false
     AZURE_BICEP_PARAMS_FILE_EXPANSION: false
     AZURE_BICEP_MINIMUM_VERSION: '0.4.451'
-    AZURE_BICEP_CHECK_TOOL: false 
+    AZURE_BICEP_CHECK_TOOL: false
 
     # Configure minimum AKS cluster version
     AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.26.6'
+
     AZURE_DEPLOYMENT_SENSITIVE_PROPERTY_NAMES:
     - adminUsername
     - administratorLogin

--- a/tests/PSRule.Rules.Azure.Tests/ResourceExportVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/ResourceExportVisitorTests.cs
@@ -20,6 +20,7 @@ namespace PSRule.Rules.Azure
             var resource = GetResourceObject("Microsoft.ContainerService/managedClusters");
             await visitor.VisitAsync(context, resource);
 
+            Assert.Equal("rg-test", resource["resourceGroupName"].Value<string>());
             Assert.Equal("ffffffff-ffff-ffff-ffff-ffffffffffff", resource["subscriptionId"].Value<string>());
             Assert.Equal("ffffffff-ffff-ffff-ffff-ffffffffffff", resource["tenantId"].Value<string>());
         }


### PR DESCRIPTION
## PR Summary

- Fixed binding of results resourceId and resourceGroupName.

Fixes #2460

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
