### PR TITLE
Fixed non-sensitive parameter name patterns #2528

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -28,6 +28,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.31.0:
+
+- Bug fixes:
+  - Fixed additional non-sensitive parameter name patterns by `Azure.Deployment.SecureParameter` by @BernieWhite.
+    [#2528](https://github.com/Azure/PSRule.Rules.Azure/issues/2528)
+    - Added support for configuration of the rule by setting `AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES`.
+
 ## v1.31.0
 
 What's changed since v1.30.3:

--- a/docs/en/rules/Azure.Deployment.AdminUsername.md
+++ b/docs/en/rules/Azure.Deployment.AdminUsername.md
@@ -15,7 +15,7 @@ Use secure parameters for sensitive resource properties.
 ## DESCRIPTION
 
 Resource properties can be configured using a hardcoded value or Azure Bicep/ template expressions.
-When specifing sensitive values use _secure_ parameters such as `secureString` or `secureObject`.
+When specifying sensitive values use _secure_ parameters such as `secureString` or `secureObject`.
 
 Sensitive values that use deterministic expressions such as hardcodes string literals or variables are not secure.
 
@@ -30,7 +30,7 @@ Avoid using deterministic values for sensitive properties.
 
 To deploy resources that pass this rule:
 
-- Use parameters to specify sensitive properties.
+- Use secure parameters to specify sensitive properties.
 
 For example:
 
@@ -87,7 +87,7 @@ For example:
 
 To deploy resources that pass this rule:
 
-- steps
+- Use secure parameters to specify sensitive properties.
 
 For example:
 
@@ -146,7 +146,7 @@ resource vm1 'Microsoft.Compute/virtualMachines@2022-03-01' = {
 ## NOTES
 
 Configure `AZURE_DEPLOYMENT_SENSITIVE_PROPERTY_NAMES` to specify sensitive property names.
-By default the following values are used:
+By default, the following values are used:
 
 - `adminUsername`
 - `administratorLogin`

--- a/docs/en/rules/Azure.Deployment.SecureParameter.md
+++ b/docs/en/rules/Azure.Deployment.SecureParameter.md
@@ -1,5 +1,5 @@
 ---
-reviewed: 2023-10-25
+reviewed: 2023-11-13
 severity: Critical
 pillar: Security
 category: Infrastructure provisioning
@@ -84,8 +84,14 @@ resource goodSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
 This rule uses a heuristics to determine if a parameter should use a secure type:
 
 - Any parameter with a name containing `password`, `secret`, or `token` will be considered sensitive.
+  - Except parameter names containing `passwordlength`, `secretname`, `secreturl`, `secreturi`, or `tokenname`.
 - Any parameter with a name ending in `key` or `keys` will be considered sensitive.
-- Any parameter with a name ending in `publickey` or `publickeys` will not be considered sensitive.
+  - Except parameter names ending in `publickey` or `publickeys`.
+
+If you identify a parameter that is _not sensitive_, and is incorrectly flagged by this rule, you can override the rule.
+To override this rule:
+
+- Set the `AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES` configuration value to identify parameters that are not sensitive.
 
 ## LINKS
 

--- a/docs/setup/configuring-rules.md
+++ b/docs/setup/configuring-rules.md
@@ -322,6 +322,80 @@ configuration:
   AZURE_COSMOS_DEFENDER_PER_ACCOUNT: true
 ```
 
+### AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES
+
+:octicons-milestone-24: v1.31.1
+
+> Applies to [Azure.Deployment.SecureParameter](../en/rules/Azure.Deployment.SecureParameter.md).
+
+This configuration overrides the default list of parameter names that are considered sensitive.
+By setting this configuration option, any parameters names specified are not considered sensitive.
+
+By default, `AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES` is not configured.
+
+Syntax:
+
+```yaml
+configuration:
+  AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES: array
+```
+
+Default:
+
+```yaml
+# YAML: The default AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES configuration option
+configuration:
+  AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES: []
+```
+
+Example:
+
+```yaml
+# YAML: Set the AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES configuration option to enabled
+configuration:
+  AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES:
+    - notSecret
+```
+
+### AZURE_DEPLOYMENT_SENSITIVE_PROPERTY_NAMES
+
+:octicons-milestone-24: v1.20.0
+
+> Applies to [Azure.Deployment.AdminUsername](../en/rules/Azure.Deployment.AdminUsername.md).
+
+This configuration identifies potentially sensitive properties that should not use hardcoded values.
+By setting this configuration option, properties with the specified names will generate a failure when a hardcoded value is detected.
+
+Syntax:
+
+```yaml
+configuration:
+  AZURE_DEPLOYMENT_SENSITIVE_PROPERTY_NAMES: array
+```
+
+Default:
+
+```yaml
+# YAML: The default AZURE_DEPLOYMENT_SENSITIVE_PROPERTY_NAMES configuration option
+configuration:
+  AZURE_DEPLOYMENT_SENSITIVE_PROPERTY_NAMES:
+    - adminUsername
+    - administratorLogin
+    - administratorLoginPassword
+```
+
+Example:
+
+```yaml
+# YAML: Set the AZURE_DEPLOYMENT_SENSITIVE_PROPERTY_NAMES configuration option to enabled
+configuration:
+  AZURE_DEPLOYMENT_SENSITIVE_PROPERTY_NAMES:
+    - adminUsername
+    - administratorLogin
+    - administratorLoginPassword
+    - loginName
+```
+
 ### AZURE_RESOURCE_ALLOWED_LOCATIONS
 
 :octicons-milestone-24: v1.30.0

--- a/src/PSRule.Rules.Azure/rules/Azure.Deployment.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Deployment.Rule.ps1
@@ -73,8 +73,14 @@ function global:GetSecureParameter {
                         '*key'
                         '*keys'
                     )).Result -and
-                    $parameter.Name -notlike '*publickey' -and
-                    $parameter.Name -notlike '*publickeys' -and
+                    $parameter.Name -notLike '*publickey' -and
+                    $parameter.Name -notLike '*publickeys' -and
+                    $parameter.Name -notLike '*passwordlength*' -and
+                    $parameter.Name -notLike '*secretname*' -and
+                    $parameter.Name -notLike '*secreturl*' -and
+                    $parameter.Name -notLike '*secreturi*' -and
+                    $parameter.Name -notLike '*tokenname*' -and
+                    $Assert.NotIn($parameter, 'Name', $Configuration.GetStringValues('AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES')).Result -and
                     $Null -ne $parameter.Value.type
                 ) {
                     $count++

--- a/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
@@ -40,6 +40,8 @@ spec:
     - administratorLogin
     - administratorLoginPassword
 
+    AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES: []
+
     # Configure Container Apps external ingress
     AZURE_CONTAINERAPPS_RESTRICT_INGRESS: false
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Deployment.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Deployment.Tests.ps1
@@ -86,6 +86,9 @@ Describe 'Azure.Deployment' -Tag 'Deployment' {
                 Module = 'PSRule.Rules.Azure'
                 WarningAction = 'SilentlyContinue'
                 ErrorAction = 'Stop'
+                Option = @{
+                    'Configuration.AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES' = @('notSecret')
+                }
             }
         }
 
@@ -97,13 +100,13 @@ Describe 'Azure.Deployment' -Tag 'Deployment' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            # $ruleResult.Length | Should -Be 2;
+            $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -BeIn 'nestedDeployment-I';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            # $ruleResult.Length | Should -Be 1;
+            $ruleResult.Length | Should -Be 9;
             $ruleResult.TargetName | Should -BeIn 'nestedDeployment-A', 'nestedDeployment-B', 'nestedDeployment-C', 'nestedDeployment-D', 'nestedDeployment-E', 'nestedDeployment-F', 'nestedDeployment-G', 'nestedDeployment-H', 'nestedDeployment-J';
         }
     }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Deployments.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Deployments.json
@@ -293,6 +293,18 @@
           },
           "secretValue": {
             "type": "SecureString"
+          },
+          "publicKey": {
+            "type": "string"
+          },
+          "KeyVaultSecretName": {
+            "type": "string"
+          },
+          "targetSecretUrl": {
+            "type": "string"
+          },
+          "notSecret": {
+            "type": "string"
           }
         },
         "variables": {},


### PR DESCRIPTION
## PR Summary

- Fixed additional non-sensitive parameter name patterns.
- Added support for configuration of the rule by setting `AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES`.

Fixes #2528 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
