### PR TITLE
Fixes null and array index handling #2535 #2548

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -33,6 +33,10 @@ What's changed since v1.31.2:
 - Bug fixes:
   - Fixed incorrect scope generated for subscription aliases by @BernieWhite.
     [#2545](https://github.com/Azure/PSRule.Rules.Azure/issues/2545)
+  - Fixed null dereferenced properties in map lambda by @BernieWhite.
+    [#2535](https://github.com/Azure/PSRule.Rules.Azure/issues/2535)
+  - Fixed handling of for array index symbols by @BernieWhite.
+    [#2548](https://github.com/Azure/PSRule.Rules.Azure/issues/2548)
 
 ## v1.31.2
 

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
@@ -161,6 +161,9 @@ namespace PSRule.Rules.Azure.Data.Policy
             public SubscriptionOption Subscription { get; }
             public TenantOption Tenant { get; }
             public ManagementGroupOption ManagementGroup { get; }
+
+            public bool ShouldThrowMissingProperty => true;
+
             public string PolicyRulePrefix { get; }
             public string FieldPrefix
             {
@@ -171,12 +174,12 @@ namespace PSRule.Rules.Azure.Data.Policy
             }
 
             /// <summary>
-            /// A unique identifer for the current assignment that is being processed.
+            /// A unique identifier for the current assignment that is being processed.
             /// </summary>
             internal string AssignmentId { get; private set; }
 
             /// <summary>
-            /// A unique identifer for the current policy definition that is being processed.
+            /// A unique identifier for the current policy definition that is being processed.
             /// </summary>
             internal string PolicyDefinitionId { get; private set; }
 
@@ -554,10 +557,10 @@ namespace PSRule.Rules.Azure.Data.Policy
                 switch (type)
                 {
                     case ParameterType.Boolean:
-                        definition.AddParameter(new LazyParameter<bool>(parameterName, type, value));
+                        definition.AddParameter(new LazyParameter<bool?>(parameterName, type, value));
                         break;
                     case ParameterType.Integer:
-                        definition.AddParameter(new LazyParameter<long>(parameterName, type, value));
+                        definition.AddParameter(new LazyParameter<long?>(parameterName, type, value));
                         break;
                     case ParameterType.String:
                         definition.AddParameter(new LazyParameter<string>(parameterName, type, value));
@@ -569,10 +572,10 @@ namespace PSRule.Rules.Azure.Data.Policy
                         definition.AddParameter(new LazyParameter<JObject>(parameterName, type, value));
                         break;
                     case ParameterType.Float:
-                        definition.AddParameter(new LazyParameter<float>(parameterName, type, value));
+                        definition.AddParameter(new LazyParameter<float?>(parameterName, type, value));
                         break;
                     case ParameterType.DateTime:
-                        definition.AddParameter(new LazyParameter<DateTime>(parameterName, type, value));
+                        definition.AddParameter(new LazyParameter<DateTime?>(parameterName, type, value));
                         break;
                 }
             }
@@ -1526,15 +1529,15 @@ namespace PSRule.Rules.Azure.Data.Policy
             {
                 existenceCondition
             };
-            var existanceExpression = new JObject
+            var existenceExpression = new JObject
             {
                 { PROPERTY_FIELD, PROPERTY_RESOURCES },
                 { PROPERTY_ALLOF, allOf }
             };
             if (subselector != null && subselector.Count > 0)
-                existanceExpression[PROPERTY_WHERE] = subselector;
+                existenceExpression[PROPERTY_WHERE] = subselector;
 
-            return existanceExpression;
+            return existenceExpression;
         }
 
         private static JObject AndNameCondition(JObject details, JObject condition)

--- a/src/PSRule.Rules.Azure/Data/Template/DeploymentSymbol.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/DeploymentSymbol.cs
@@ -9,7 +9,7 @@ namespace PSRule.Rules.Azure.Data.Template
     {
         None = 0,
         Array = 1,
-        Object = 2,
+        Object = 2
     }
 
     internal interface IDeploymentSymbol
@@ -37,9 +37,9 @@ namespace PSRule.Rules.Azure.Data.Template
             return name == null ? null : new ArrayDeploymentSymbol(name);
         }
 
-        internal static IDeploymentSymbol NewObject(string name)
+        internal static IDeploymentSymbol NewObject(string name, ResourceValue resource = null)
         {
-            return name == null ? null : new ObjectDeploymentSymbol(name);
+            return name == null ? null : new ObjectDeploymentSymbol(name, resource);
         }
     }
 
@@ -47,8 +47,12 @@ namespace PSRule.Rules.Azure.Data.Template
     {
         private ResourceValue _Resource;
 
-        public ObjectDeploymentSymbol(string name)
-            : base(name) { }
+        public ObjectDeploymentSymbol(string name, ResourceValue resource)
+            : base(name)
+        {
+            if (resource != null)
+                Configure(resource);
+        }
 
         public DeploymentSymbolKind Kind => DeploymentSymbolKind.Object;
 

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
@@ -162,6 +162,9 @@ namespace PSRule.Rules.Azure.Data.Template
             if (ExpressionHelpers.TryPropertyOrField(result, propertyName, out var value))
                 return value;
 
+            if (!context.ShouldThrowMissingProperty)
+                return null;
+
             throw new ExpressionReferenceException(propertyName, string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.PropertyNotFound, propertyName));
         }
     }

--- a/src/PSRule.Rules.Azure/Data/Template/ITemplateContext.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ITemplateContext.cs
@@ -53,6 +53,8 @@ namespace PSRule.Rules.Azure.Data.Template
 
         ManagementGroupOption ManagementGroup { get; }
 
+        bool ShouldThrowMissingProperty { get; }
+
         ExpressionFnOuter BuildExpression(string s);
 
         CloudEnvironment GetEnvironment();
@@ -117,6 +119,8 @@ namespace PSRule.Rules.Azure.Data.Template
         public TenantOption Tenant => _Inner.Tenant;
 
         public ManagementGroupOption ManagementGroup => _Inner.ManagementGroup;
+
+        public virtual bool ShouldThrowMissingProperty => true;
 
         public ExpressionFnOuter BuildExpression(string s)
         {

--- a/src/PSRule.Rules.Azure/Data/Template/LambdaExpressionFn.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/LambdaExpressionFn.cs
@@ -32,6 +32,8 @@ namespace PSRule.Rules.Azure.Data.Template
                 _Variables = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             }
 
+            public override bool ShouldThrowMissingProperty => false;
+
             public override bool TryLambdaVariable(string variableName, out object value)
             {
                 return _Variables.TryGetValue(variableName, out value);

--- a/src/PSRule.Rules.Azure/Data/Template/Mocks.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Mocks.cs
@@ -485,7 +485,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 value = new JValue(key);
                 return true;
             }
-            
+
             // Handle name and type
             if (StringComparer.OrdinalIgnoreCase.Equals(key, "name"))
             {

--- a/src/PSRule.Rules.Azure/Data/Template/RuleDataExportVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/RuleDataExportVisitor.cs
@@ -264,7 +264,7 @@ namespace PSRule.Rules.Azure.Data.Template
                     if (!rule.ContainsKeyInsensitive(PROPERTY_RULEID))
                         rule[PROPERTY_RULEID] = Guid.NewGuid().ToString();
                 }
-                
+
             }
             return true;
         }

--- a/src/PSRule.Rules.Azure/Pipeline/Export/ResourceExportVisitor.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/Export/ResourceExportVisitor.cs
@@ -190,7 +190,7 @@ namespace PSRule.Rules.Azure.Pipeline.Export
             if (ResourceHelper.TryResourceGroup(resourceId, out var subscriptionId, out var resourceGroupName) &&
                 !string.Equals(resourceType, TYPE_RESOURCES_RESOURCEGROUP, StringComparison.OrdinalIgnoreCase))
                 resource.Add(PROPERTY_RESOURCEGROUPNAME, resourceGroupName);
-            
+
             if (!string.IsNullOrEmpty(subscriptionId))
                 resource.Add(PROPERTY_SUBSCRIPTIONID, subscriptionId);
         }

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -905,10 +905,14 @@ namespace PSRule.Rules.Azure
         [Fact]
         public void NullableParameters()
         {
-            var resources = ProcessTemplate(GetSourcePath("Tests.Bicep.27.json"), null, out _);
+            var resources = ProcessTemplate(GetSourcePath("Tests.Bicep.27.json"), null, out var templateContext);
             Assert.Equal(4, resources.Length);
 
-            var actual = resources[2];
+            var actual = resources[1];
+            Assert.Equal("Microsoft.Resources/deployments", actual["type"].Value<string>());
+            Assert.Equal("child", actual["name"].Value<string>());
+
+            actual = resources[2];
             Assert.Equal("Microsoft.Storage/storageAccounts", actual["type"].Value<string>());
             Assert.Equal("TLS1_2", actual["properties"]["minimumTlsVersion"].Value<string>());
             Assert.Empty(actual["resources"][0]["properties"]["cors"]["corsRules"].Value<JArray>());
@@ -916,6 +920,10 @@ namespace PSRule.Rules.Azure
             actual = resources[3];
             Assert.Equal("Microsoft.KeyVault/vaults", actual["type"].Value<string>());
             Assert.Empty(actual["properties"]["accessPolicies"].Value<JArray>());
+
+            // Check outputs.
+            Assert.True(templateContext.RootDeployment.TryOutput("childFromFor", out JObject result));
+            Assert.Equal("sourceId", result["value"].Value<string>());
         }
 
         [Fact]

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.27.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.27.bicep
@@ -3,5 +3,6 @@
 
 module child 'Tests.Bicep.27.child.bicep' = {
   name: 'child'
-  params: {}
 }
+
+output childFromFor string = child.outputs.fromFor

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.27.child.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.27.child.bicep
@@ -67,3 +67,41 @@ resource kvSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = [for item in 
     value: item.value
   }
 }]
+
+resource storageAccount_objectReplicationPolicy 'Microsoft.Storage/storageAccounts/objectReplicationPolicies@2022-09-01' = {
+  name: 'default'
+  parent: storage
+  properties: {
+    sourceAccount: 'sourceId'
+    destinationAccount: 'destId'
+    rules: [
+      {
+        ruleId: null
+        sourceContainer: 'source'
+        destinationContainer: 'dest'
+        filters: null
+      }
+    ]
+  }
+}
+
+resource storageAccount_objectReplicationPolicyItems 'Microsoft.Storage/storageAccounts/objectReplicationPolicies@2022-09-01' = [for (item, index) in [ 1 ]: {
+  name: 'default${index}'
+  parent: storage
+  properties: {
+    sourceAccount: 'sourceId'
+    destinationAccount: 'destId'
+    rules: [
+      {
+        ruleId: null
+        sourceContainer: 'source'
+        destinationContainer: 'dest'
+        filters: null
+      }
+    ]
+  }
+}]
+
+output policyId string = storageAccount_objectReplicationPolicy.properties.policyId
+output ruleIds string[] = map(storageAccount_objectReplicationPolicy.properties.rules, rule => rule.ruleId)
+output fromFor string = storageAccount_objectReplicationPolicyItems[0].properties.sourceAccount

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.27.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.27.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "15341554075500882140"
+      "templateHash": "1063354008601109842"
     }
   },
   "resources": [
@@ -18,7 +18,6 @@
           "scope": "inner"
         },
         "mode": "Incremental",
-        "parameters": {},
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
           "languageVersion": "2.0",
@@ -27,7 +26,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.23.1.45101",
-              "templateHash": "1045026030740697206"
+              "templateHash": "11238883118622659404"
             }
           },
           "definitions": {
@@ -151,10 +150,77 @@
               "properties": {
                 "value": "[variables('secretList')[copyIndex()].value]"
               }
+            },
+            "storageAccount_objectReplicationPolicy": {
+              "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}/{1}', 'test', 'default')]",
+              "properties": {
+                "sourceAccount": "sourceId",
+                "destinationAccount": "destId",
+                "rules": [
+                  {
+                    "ruleId": null,
+                    "sourceContainer": "source",
+                    "destinationContainer": "dest",
+                    "filters": null
+                  }
+                ]
+              },
+              "dependsOn": [
+                "storage"
+              ]
+            },
+            "storageAccount_objectReplicationPolicyItems": {
+              "copy": {
+                "name": "storageAccount_objectReplicationPolicyItems",
+                "count": "[length(createArray(1))]"
+              },
+              "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}/{1}', 'test', format('default{0}', copyIndex()))]",
+              "properties": {
+                "sourceAccount": "sourceId",
+                "destinationAccount": "destId",
+                "rules": [
+                  {
+                    "ruleId": null,
+                    "sourceContainer": "source",
+                    "destinationContainer": "dest",
+                    "filters": null
+                  }
+                ]
+              },
+              "dependsOn": [
+                "storage"
+              ]
+            }
+          },
+          "outputs": {
+            "policyId": {
+              "type": "string",
+              "value": "[reference('storageAccount_objectReplicationPolicy').policyId]"
+            },
+            "ruleIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "value": "[map(reference('storageAccount_objectReplicationPolicy').rules, lambda('rule', lambdaVariables('rule').ruleId))]"
+            },
+            "fromFor": {
+              "type": "string",
+              "value": "[reference(format('storageAccount_objectReplicationPolicyItems[{0}]', 0)).sourceAccount]"
             }
           }
         }
       }
     }
-  ]
+  ],
+  "outputs": {
+    "childFromFor": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'child'), '2022-09-01').outputs.fromFor.value]"
+    }
+  }
 }


### PR DESCRIPTION
## PR Summary

  - Fixed null dereferenced properties in map lambda.
  - Fixed handling of for array index symbols.

Fixes #2535 
Fixes #2548

Related to microsoft/PSRule#1640

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
