### PR TITLE
Fixed false positives for secure parameter #2556

### DIFF
--- a/.ps-rule/Rule.Rule.ps1
+++ b/.ps-rule/Rule.Rule.ps1
@@ -5,8 +5,8 @@
 Rule 'Rule.Name' -Type 'PSRule.Rules.Rule' {
     Recommend 'Rule name should be less than 35 characters to prevent being truncated.'
     Reason 'The rule name is too long.'
-    $Assert.LessOrEqual($TargetObject, 'RuleName', 35)
-    $Assert.StartsWith($TargetObject, 'RuleName', 'Azure.')
+    $Assert.LessOrEqual($TargetObject, 'Name', 35)
+    $Assert.StartsWith($TargetObject, 'Name', 'Azure.')
 }
 
 # Synopsis: Rules must use a valid opaque identifier.
@@ -83,7 +83,7 @@ Rule 'Rule.Annotations' -Type 'PSRule.Rules.Rule' {
 Rule 'Rule.OnlineHelp' -Type 'PSRule.Rules.Rule' {
     $Assert.HasFieldValue($TargetObject, 'Info.Annotations.''online version''')
     $Assert.StartsWith($TargetObject, 'Info.Annotations.''online version''', 'https://azure.github.io/PSRule.Rules.Azure/')
-    $Assert.EndsWith($TargetObject, 'Info.Annotations.''online version''', [String]::Concat('/rules/', $TargetObject.RuleName, '/'))
+    $Assert.EndsWith($TargetObject, 'Info.Annotations.''online version''', [String]::Concat('/rules/', $PSRule.TargetName, '/'))
 }
 
 # Synopsis: Use non-culture specific URLs for references to docs.microsoft.com.

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -28,6 +28,15 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.31.3:
+
+- General improvements:
+  - Updates to documentation by @BernieWhite.
+    [#2557](https://github.com/Azure/PSRule.Rules.Azure/issues/2557)
+- Bug fixes:
+  - Fixed additional false positives of `Azure.Deployment.SecureParameter` by @BernieWhite.
+    [#2556](https://github.com/Azure/PSRule.Rules.Azure/issues/2556)
+
 ## v1.31.3
 
 What's changed since v1.31.2:

--- a/docs/en/rules/Azure.Deployment.SecureParameter.md
+++ b/docs/en/rules/Azure.Deployment.SecureParameter.md
@@ -83,8 +83,11 @@ resource goodSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
 
 This rule uses a heuristics to determine if a parameter should use a secure type:
 
+- Parameters with the type `int` or `bool` are ignored regardless of how they are named.
 - Any parameter with a name containing `password`, `secret`, or `token` will be considered sensitive.
-  - Except parameter names containing `passwordlength`, `secretname`, `secreturl`, `secreturi`, or `tokenname`.
+  - Except parameter names containing any of the following:
+    `passwordlength`, `secretname`, `secreturl`, `secreturi`, `secretrotation`, `secretinterval`, `secretprovider`,
+    `secretsprovider`, `secretref`, `secretid`, `disablepassword`, `sync*passwords`, or `tokenname`.
 - Any parameter with a name ending in `key` or `keys` will be considered sensitive.
   - Except parameter names ending in `publickey` or `publickeys`.
 

--- a/src/PSRule.Rules.Azure/rules/Azure.Deployment.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Deployment.Rule.ps1
@@ -80,8 +80,18 @@ function global:GetSecureParameter {
                     $parameter.Name -notLike '*secreturl*' -and
                     $parameter.Name -notLike '*secreturi*' -and
                     $parameter.Name -notLike '*tokenname*' -and
+                    $parameter.Name -notLike '*secretrotation*' -and
+                    $parameter.Name -notLike '*secretinterval*' -and
+                    $parameter.Name -notLike '*secretprovider*' -and
+                    $parameter.Name -notLike '*secretsprovider*' -and
+                    $parameter.Name -notLike '*secretref*' -and
+                    $parameter.Name -notLike '*secretid*' -and
+                    $parameter.Name -notLike '*disablepassword*' -and
+                    $parameter.Name -notLike '*sync*passwords*' -and
                     $Assert.NotIn($parameter, 'Name', $Configuration.GetStringValues('AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES')).Result -and
-                    $Null -ne $parameter.Value.type
+                    $Null -ne $parameter.Value.type -and
+                    $parameter.Value.type -ne 'bool' -and
+                    $parameter.Value.type -ne 'int'
                 ) {
                     $count++
                     $Assert.In($parameter.Value.type, '.', @('secureString', 'secureObject')).ReasonFrom($parameter.Name, $LocalizedData.InsecureParameterType, $parameter.Name, $parameter.Value.type);

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Deployments.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Deployments.json
@@ -305,6 +305,18 @@
           },
           "notSecret": {
             "type": "string"
+          },
+          "verysecret": {
+            "type": "bool"
+          },
+          "secretinterval": {
+            "type": "string"
+          },
+          "secretreferenceid": {
+            "type": "string"
+          },
+          "verysecretint": {
+            "type": "int"
           }
         },
         "variables": {},


### PR DESCRIPTION
## PR Summary

- Fixed additional false positives of `Azure.Deployment.SecureParameter`.

Fixes #2556 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
