### PR TITLE
Pre-release v1.32.0-B0053

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.32.0-B0053 (pre-release)
+
 What's changed since pre-release v1.32.0-B0021:
 
 - Updated rules:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.32.0-B0021:

- Updated rules:
  - Network Interface:
    - **Important change**: Renamed NIC rules to reflect current usage by @BernieWhite.
      [#2574](https://github.com/Azure/PSRule.Rules.Azure/issues/2574)
      - Rename `Azure.VM.NICAttached` to `Azure.NIC.Attached`.
      - Rename `Azure.VM.NICName` to `Azure.NIC.Name`.
      - Rename `Azure.VM.UniqueDns` to `Azure.NIC.UniqueDns`.
      - Added aliases to reference the old names for suppression and exclusion.
      - Old names will be removed from v2.
    - Added support for private link services to `Azure.VM.NICAttached` by @BernieWhite.
      [#2563](https://github.com/Azure/PSRule.Rules.Azure/issues/2563)
- General improvements:
  - Quality updates to documentation by @BernieWhite.
    [#2570](https://github.com/Azure/PSRule.Rules.Azure/issues/2570)
    [#1772](https://github.com/Azure/PSRule.Rules.Azure/issues/1772)
- Engineering:
  - Bump xunit.runner.visualstudio to v2.5.4.
    [#2567](https://github.com/Azure/PSRule.Rules.Azure/pull/2567)
- Bug fixes:
  - Fixed dependency ordered is incorrect by @BernieWhite.
    [#2578](https://github.com/Azure/PSRule.Rules.Azure/issues/2578)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
