### PR TITLE
Added december baselines #2580

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -34,6 +34,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v1.32.0-B0053:
 
+- New features:
+  - Added December 2023 baselines `Azure.GA_2023_12` and `Azure.Preview_2023_12` by @BernieWhite.
+    [#2580](https://github.com/Azure/PSRule.Rules.Azure/issues/2580)
+    - Includes rules released before or during December 2023.
+    - Marked `Azure.GA_2023_09` and `Azure.Preview_2023_09` baselines as obsolete.
 - Updated rules:
   - App Configuration:
     - Promoted `Azure.AppConfig.GeoReplica` to GA rule set by @BernieWhite.

--- a/src/PSRule.Rules.Azure/rules/Baseline.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Baseline.Rule.yaml
@@ -525,6 +525,8 @@ apiVersion: github.com/microsoft/PSRule/v1
 kind: Baseline
 metadata:
   name: Azure.GA_2023_09
+  annotations:
+    obsolete: true
 spec:
   configuration:
     # Configure minimum AKS cluster version
@@ -554,6 +556,8 @@ apiVersion: github.com/microsoft/PSRule/v1
 kind: Baseline
 metadata:
   name: Azure.Preview_2023_09
+  annotations:
+    obsolete: true
 spec:
   rule:
     tag:
@@ -573,3 +577,60 @@ spec:
       - '2023_03'
       - '2023_06'
       - '2023_09'
+
+---
+# Synopsis: Include rules released December 2023 or prior for Azure GA features.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Baseline
+metadata:
+  name: Azure.GA_2023_12
+spec:
+  configuration:
+    # Configure minimum AKS cluster version
+    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.27.7'
+  rule:
+    tag:
+      release: GA
+      ruleSet:
+      - '2020_06'
+      - '2020_09'
+      - '2020_12'
+      - '2021_03'
+      - '2021_06'
+      - '2021_09'
+      - '2021_12'
+      - '2022_03'
+      - '2022_06'
+      - '2022_09'
+      - '2022_12'
+      - '2023_03'
+      - '2023_06'
+      - '2023_09'
+      - '2023_12'
+
+---
+# Synopsis: Include rules released December 2023 or prior for Azure preview only features.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Baseline
+metadata:
+  name: Azure.Preview_2023_12
+spec:
+  rule:
+    tag:
+      release: preview
+      ruleSet:
+      - '2020_06'
+      - '2020_09'
+      - '2020_12'
+      - '2021_03'
+      - '2021_06'
+      - '2021_09'
+      - '2021_12'
+      - '2022_03'
+      - '2022_06'
+      - '2022_09'
+      - '2022_12'
+      - '2023_03'
+      - '2023_06'
+      - '2023_09'
+      - '2023_12'

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
@@ -215,5 +215,19 @@ Describe 'Baselines' -Tag Baseline {
             $filteredResult | Should -Not -BeNullOrEmpty;
             $filteredResult.Length | Should -Be 13;
         }
+
+        It 'With Azure.GA_2023_12' {
+            $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2023_12' -WarningAction Ignore);
+            $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
+            $filteredResult | Should -Not -BeNullOrEmpty;
+            $filteredResult.Length | Should -Be 394;
+        }
+
+        It 'With Azure.Preview_2023_12' {
+            $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2023_12' -WarningAction Ignore);
+            $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
+            $filteredResult | Should -Not -BeNullOrEmpty;
+            $filteredResult.Length | Should -Be 13;
+        }
     }
 }


### PR DESCRIPTION
## PR Summary

- Added December 2023 baselines `Azure.GA_2023_12` and `Azure.Preview_2023_12` by @BernieWhite.
  - Includes rules released before or during December 2023.
  - Marked `Azure.GA_2023_09` and `Azure.Preview_2023_09` baselines as obsolete.

Fixes #2580

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
