### PR TITLE
Promote defender for APIs rules to GA #2591

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -43,9 +43,15 @@ What's changed since pre-release v1.32.0-B0053:
   - App Configuration:
     - Promoted `Azure.AppConfig.GeoReplica` to GA rule set by @BernieWhite.
       [#2592](https://github.com/Azure/PSRule.Rules.Azure/issues/2592)
+    - API Management:
+      - Promoted `Azure.APIM.DefenderCloud` to GA rule set by @BernieWhite.
+        [#2591](https://github.com/Azure/PSRule.Rules.Azure/issues/2591)
   - Azure Kubernetes Service:
     - Updated `Azure.AKS.Version` to use latest stable version `1.27.7` by @BernieWhite.
       [#2581](https://github.com/Azure/PSRule.Rules.Azure/issues/2581)
+  - Defender for Cloud:
+    - Promoted `Azure.Defender.Api` to GA rule set by @BernieWhite.
+      [#2591](https://github.com/Azure/PSRule.Rules.Azure/issues/2591)
 - General improvements:
   - Improved reporting of null argument in length function by @BernieWhite.
     [#2597](https://github.com/Azure/PSRule.Rules.Azure/issues/2597)

--- a/docs/en/rules/Azure.APIM.DefenderCloud.md
+++ b/docs/en/rules/Azure.APIM.DefenderCloud.md
@@ -1,7 +1,7 @@
 ---
 severity: Critical
 pillar: Security
-category: Security operations
+category: SE:10 Monitoring and threat detection
 resource: API Management
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.APIM.DefenderCloud/
 ---
@@ -74,7 +74,7 @@ resource onboardDefender 'Microsoft.Security/apiCollections@2022-11-20-preview' 
 
 ## NOTES
 
-Microsoft Defender for APIs is a preview feature and has the following limitations:
+Microsoft Defender for APIs has the following limitations:
 
 - Not all regions are supported.
 - Only REST APIs published through Azure API Management are supported.
@@ -85,7 +85,7 @@ This rule may currently generate false positive results for APIs only hosted on 
 
 ## LINKS
 
-- [Security operations in Azure](https://learn.microsoft.com/azure/architecture/framework/security/monitor-security-operations)
+- [SE:10 Monitoring and threat detection](https://learn.microsoft.com/azure/well-architected/security/monitor-threats)
 - [What is Microsoft Defender for Cloud?](https://learn.microsoft.com/azure/defender-for-cloud/defender-for-cloud-introduction)
 - [Overview of Microsoft Defender for APIs](https://learn.microsoft.com/azure/defender-for-cloud/defender-for-apis-introduction)
 - [Support and prerequisites for Defender for APIs](https://learn.microsoft.com/azure/defender-for-cloud/defender-for-apis-prepare)

--- a/docs/en/rules/Azure.Defender.Api.md
+++ b/docs/en/rules/Azure.Defender.Api.md
@@ -1,7 +1,7 @@
 ---
 severity: Critical
 pillar: Security
-category: Security operations
+category: SE:10 Monitoring and threat detection
 resource: Microsoft Defender for Cloud
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Defender.Api/
 ---
@@ -35,35 +35,41 @@ Consider using Microsoft Defender for APIs to provide additional security for AP
 
 ### Configure with Azure template
 
-To enable Microsoft Defender for APIs:
+To deploy and enable Defender for APIs configurations that pass this rule:
 
-- Set the `Standard` pricing tier for Microsoft Defender for APIs.
+- Set the `properties.pricingTier` property to to `Standard`.
+- Set the `properties.subPlan` property to a plan such as `P1`.
+  Other plans are available, currently these are: `P1`, `P2`, `P3`, `P4`, and `P5`.
 
 For example:
 
 ```json
 {
-    "type": "Microsoft.Security/pricings",
-    "apiVersion": "2022-03-01",
-    "name": "Api",
-    "properties": {
-        "pricingTier": "Standard"
-    }
+  "type": "Microsoft.Security/pricings",
+  "apiVersion": "2023-01-01",
+  "name": "Api",
+  "properties": {
+    "subPlan": "P1",
+    "pricingTier": "Standard"
+  }
 }
 ```
 
 ### Configure with Bicep
 
-To enable Microsoft Defender for APIs:
+To deploy and enable Defender for APIs configurations that pass this rule:
 
-- Set the `Standard` pricing tier for Microsoft Defender for APIs.
+- Set the `properties.pricingTier` property to to `Standard`.
+- Set the `properties.subPlan` property to a plan such as `P1`.
+  Other plans are available, currently these are: `P1`, `P2`, `P3`, `P4`, and `P5`.
 
 For example:
 
 ```bicep
-resource defenderForApi 'Microsoft.Security/pricings@2022-03-01' = {
+resource defenderForApi 'Microsoft.Security/pricings@2023-01-01' = {
   name: 'Api'
   properties: {
+    subPlan: 'P1'
     pricingTier: 'Standard'
   }
 }
@@ -78,7 +84,7 @@ To enable Microsoft Defender for APIs:
 For example:
 
 ```bash
-az security pricing create -n 'Api' --tier 'standard'
+az security pricing create -n Api --tier standard --subplan P1
 ```
 
 ### Configure with Azure PowerShell
@@ -90,17 +96,16 @@ To enable Microsoft Defender for APIs:
 For example:
 
 ```powershell
-Set-AzSecurityPricing -Name 'Api' -PricingTier 'Standard'
+Set-AzSecurityPricing -Name 'Api' -PricingTier 'Standard' -SubPlan 'P1'
 ```
 
 ## NOTES
 
-Microsoft Defender for APIs is a preview feature.
 Currently only REST APIs published in Azure API Management is supported. Not all regions are supported.
 
 ## LINKS
 
-- [Security operations in Azure](https://learn.microsoft.com/azure/architecture/framework/security/monitor-security-operations)
+- [SE:10 Monitoring and threat detection](https://learn.microsoft.com/azure/well-architected/security/monitor-threats)
 - [What is Microsoft Defender for Cloud?](https://learn.microsoft.com/azure/defender-for-cloud/defender-for-cloud-introduction)
 - [Overview of Microsoft Defender for APIs](https://learn.microsoft.com/azure/defender-for-cloud/defender-for-apis-introduction)
 - [Support and prerequisites for Defender for APIs](https://learn.microsoft.com/azure/defender-for-cloud/defender-for-apis-prepare)

--- a/docs/examples-defender.bicep
+++ b/docs/examples-defender.bicep
@@ -133,3 +133,12 @@ resource defenderForCloudPosture 'Microsoft.Security/pricings@2023-01-01' = {
     pricingTier: 'Standard'
   }
 }
+
+// Configure Microsoft Defender for APIs
+resource defenderForApi 'Microsoft.Security/pricings@2023-01-01' = {
+  name: 'Api'
+  properties: {
+    subPlan: 'P1'
+    pricingTier: 'Standard'
+  }
+}

--- a/docs/examples-defender.json
+++ b/docs/examples-defender.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.22.6.54827",
-      "templateHash": "9622669481012103945"
+      "version": "0.23.1.45101",
+      "templateHash": "6320102656796608467"
     }
   },
   "resources": [
@@ -135,6 +135,15 @@
       "apiVersion": "2023-01-01",
       "name": "CloudPosture",
       "properties": {
+        "pricingTier": "Standard"
+      }
+    },
+    {
+      "type": "Microsoft.Security/pricings",
+      "apiVersion": "2023-01-01",
+      "name": "Api",
+      "properties": {
+        "subPlan": "P1",
         "pricingTier": "Standard"
       }
     }

--- a/src/PSRule.Rules.Azure/rules/Azure.APIM.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.APIM.Rule.ps1
@@ -325,7 +325,7 @@ Rule 'Azure.APIM.PolicyBase' -Ref 'AZR-000371' -Type 'Microsoft.ApiManagement/se
 }
 
 # Synopsis: APIs published in Azure API Management should be onboarded to Microsoft Defender for APIs.
-Rule 'Azure.APIM.DefenderCloud' -Ref 'AZR-000387' -Type 'Microsoft.ApiManagement/service' -If { HasRestApi } -Tag @{ release = 'Preview'; ruleSet = '2023_06'; 'Azure.WAF/pillar' = 'Security'; } -Labels @{ 'Azure.MCSB.v1/control' = 'LT-1' } {
+Rule 'Azure.APIM.DefenderCloud' -Ref 'AZR-000387' -Type 'Microsoft.ApiManagement/service' -If { HasRestApi } -Tag @{ release = 'GA'; ruleSet = '2023_12'; 'Azure.WAF/pillar' = 'Security'; } -Labels @{ 'Azure.MCSB.v1/control' = 'LT-1' } {
     $apis = @(GetSubResources -ResourceType 'Microsoft.ApiManagement/service/apis' |
     Where-Object { $Assert.HasDefaultValue($_, 'properties.apiType', 'http').Result })
     $defenderConfigs = @(GetSubResources -ResourceType 'Microsoft.Security/apiCollections')

--- a/src/PSRule.Rules.Azure/rules/Azure.Defender.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.Defender.Rule.yaml
@@ -261,8 +261,8 @@ metadata:
   name: Azure.Defender.Api
   ref: AZR-000377
   tags:
-    release: Preview
-    ruleSet: 2023_06
+    release: GA
+    ruleSet: 2023_12
     Azure.WAF/pillar: Security
   labels:
     Azure.MCSB.v1/control: LT-1
@@ -274,8 +274,11 @@ spec:
   type:
   - Microsoft.Security/pricings
   condition:
-    field: properties.pricingTier
-    equals: Standard
+    allOf:
+      - field: properties.pricingTier
+        equals: Standard
+      - field: properties.subPlan
+        hasValue: true
 
 ---
 # Synopsis: Enable Microsoft Defender for Azure Cosmos DB.

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
@@ -199,7 +199,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2023_06' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 12;
+            $filteredResult.Length | Should -Be 10;
         }
 
         It 'With Azure.GA_2023_09' {
@@ -213,21 +213,21 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2023_09' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 13;
+            $filteredResult.Length | Should -Be 11;
         }
 
         It 'With Azure.GA_2023_12' {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2023_12' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 394;
+            $filteredResult.Length | Should -Be 396;
         }
 
         It 'With Azure.Preview_2023_12' {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2023_12' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 13;
+            $filteredResult.Length | Should -Be 11;
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Defender.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Defender.json
@@ -222,7 +222,8 @@
     "ResourceType": "Microsoft.Security/pricings",
     "SubscriptionId": "00000000-0000-0000-0000-000000000000",
     "Properties": {
-      "pricingTier": "Standard"
+      "pricingTier": "Standard",
+      "subPlan": "P1"
     }
   },
   {


### PR DESCRIPTION
## PR Summary

  - API Management:
    - Promoted `Azure.APIM.DefenderCloud` to GA rule set.
- Defender for Cloud:
  - Promoted `Azure.Defender.Api` to GA rule set.

Fixes #2591 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
