### PR TITLE
Pre-release v1.32.0-B0099

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.32.0-B0099 (pre-release)
+
 What's changed since pre-release v1.32.0-B0053:
 
 - New features:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.32.0-B0053:

- New features:
  - Added December 2023 baselines `Azure.GA_2023_12` and `Azure.Preview_2023_12` by @BernieWhite.
    [#2580](https://github.com/Azure/PSRule.Rules.Azure/issues/2580)
    - Includes rules released before or during December 2023.
    - Marked `Azure.GA_2023_09` and `Azure.Preview_2023_09` baselines as obsolete.
- Updated rules:
  - App Configuration:
    - Promoted `Azure.AppConfig.GeoReplica` to GA rule set by @BernieWhite.
      [#2592](https://github.com/Azure/PSRule.Rules.Azure/issues/2592)
    - API Management:
      - Promoted `Azure.APIM.DefenderCloud` to GA rule set by @BernieWhite.
        [#2591](https://github.com/Azure/PSRule.Rules.Azure/issues/2591)
  - Azure Kubernetes Service:
    - Updated `Azure.AKS.Version` to use latest stable version `1.27.7` by @BernieWhite.
      [#2581](https://github.com/Azure/PSRule.Rules.Azure/issues/2581)
  - Defender for Cloud:
    - Promoted `Azure.Defender.Api` to GA rule set by @BernieWhite.
      [#2591](https://github.com/Azure/PSRule.Rules.Azure/issues/2591)
- General improvements:
  - Improved reporting of null argument in length function by @BernieWhite.
    [#2597](https://github.com/Azure/PSRule.Rules.Azure/issues/2597)
- Engineering:
  - Updated resource providers and policy aliases.
    [#2579](https://github.com/Azure/PSRule.Rules.Azure/pull/2579)
  - Bump Microsoft.SourceLink.GitHub to v8.0.0.
    [#2538](https://github.com/Azure/PSRule.Rules.Azure/pull/2538)
  - Bump BenchmarkDotNet.Diagnostics.Windows and BenchmarkDotNet to v0.13.11.
    [#2575](https://github.com/Azure/PSRule.Rules.Azure/pull/2575)
  - Bump Microsoft.CodeAnalysis.NetAnalyzers to v8.0.0.
    [#2568](https://github.com/Azure/PSRule.Rules.Azure/pull/2568)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
