### PR TITLE
feat: Updated Azure.AppGwWAF.RuleGroups to use the rule sets

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+ Updated rules:
+  - Azure Web Application Firewall (WAF):
+    - Updated `Azure.AppGwWAF.RuleGroups` to use the latest bot manager rule set `1.0` by @BenjaminEngeset.
+      [#2404](https://github.com/Azure/PSRule.Rules.Azure/issues/2404)
+
 What's changed since v1.32.1:
 
 - Updated rules:

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,11 +32,6 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
- Updated rules:
-  - Azure Web Application Firewall (WAF):
-    - Updated `Azure.AppGwWAF.RuleGroups` to use the latest bot manager rule set `1.0` by @BenjaminEngeset.
-      [#2404](https://github.com/Azure/PSRule.Rules.Azure/issues/2404)
-
 What's changed since v1.32.1:
 
 - Updated rules:
@@ -51,6 +46,11 @@ What's changed since v1.32.1:
     - Added option for excluding subnets to `Azure.VNET.UseNSGs` by @BernieWhite.
       [#2572](https://github.com/Azure/PSRule.Rules.Azure/issues/2572)
       - To add a subnet exclusion, set the `AZURE_VNET_SUBNET_EXCLUDED_FROM_NSG` option.
+  - Azure Web Application Firewall (WAF):
+    - Updated `Azure.AppGwWAF.RuleGroups` to use the rule sets by @BenjaminEngeset.
+      [#2404](https://github.com/Azure/PSRule.Rules.Azure/issues/2404)
+      - The latest Bot Manager rule set is now `1.0`.
+      - The latest OWASP rule set is now `3.2`.
 - General improvements:
   - Quality updates to rules and documentation by @BernieWhite.
     [#1772](https://github.com/Azure/PSRule.Rules.Azure/issues/1772)

--- a/docs/en/rules/Azure.AppGwWAF.RuleGroups.md
+++ b/docs/en/rules/Azure.AppGwWAF.RuleGroups.md
@@ -1,5 +1,5 @@
 ---
-reviewed: 2022-09-20
+reviewed: 2024-01-04
 severity: Critical
 pillar: Security
 category: Network security and containment
@@ -29,7 +29,7 @@ Consider configuring Application Gateway WAF policy to use the recommended rule 
 ## LINKS
 
 - [Best practices for endpoint security on Azure](https://learn.microsoft.com/azure/architecture/framework/security/design-network-endpoints)
-- [Securing PaaS deployments](https://docs.microsoft.com/azure/security/fundamentals/paas-deployments#install-a-web-application-firewall)
-- [Web Application Firewall CRS rule groups and rules](https://docs.microsoft.com/azure/web-application-firewall/ag/application-gateway-crs-rulegroups-rules)
-- [Bot protection overview](https://docs.microsoft.com/azure/web-application-firewall/afds/waf-front-door-policy-configure-bot-protection)
-- [Web Application Firewall best practices](https://docs.microsoft.com/azure/web-application-firewall/ag/best-practices)
+- [Securing PaaS deployments](https://learn.microsoft.com/azure/security/fundamentals/paas-deployments#install-a-web-application-firewall)
+- [Web Application Firewall CRS rule groups and rules](https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-crs-rulegroups-rules)
+- [Bot protection overview](https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-policy-configure-bot-protection)
+- [Web Application Firewall best practices](https://learn.microsoft.com/azure/web-application-firewall/ag/best-practices)

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -409,7 +409,7 @@ task BuildRuleDocs Build, Dependencies, {
             Recommendation = $_.Info.Recommendation
             Pillar = $_.Tag.'Azure.WAF/pillar'
             Control = $_.Tag.'Azure.MCSB.v1/control'
-            Source = "https://github.com/Azure/PSRule.Rules.Azure/blob/main/src/PSRule.Rules.Azure/rules/$(($_.Source.Path -split '/', '\')[-1])"
+            Source = "https://github.com/Azure/PSRule.Rules.Azure/blob/main/src/PSRule.Rules.Azure/rules/$(($_.Source.Path -split @('/', '\'))[-1])"
         }
     }
     $metadata | ConvertTo-Json -Depth 5 | Set-Content -Path ./docs/es/rules/metadata.json -Force;

--- a/src/PSRule.Rules.Azure/rules/Azure.AppGwWAF.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppGwWAF.Rule.yaml
@@ -87,7 +87,7 @@ spec:
   - Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies
   condition:
     allOf:
-    # WAF policy has at least two rule groups. OWASP 3.1 is the minimum. Microsoft_BotManagerRuleSet 0.1 is the minimum.
+    # WAF policy has at least two rule groups. OWASP 3.1 is the minimum. Microsoft_BotManagerRuleSet 1.0 is the minimum.
     - field: Properties.managedRules.managedRuleSets
       greaterOrEquals: 2
     - field: Properties.managedRules.managedRuleSets[0].ruleSetType
@@ -97,7 +97,7 @@ spec:
     - field: Properties.managedRules.managedRuleSets[1].ruleSetType
       equals: Microsoft_BotManagerRuleSet
     - field: Properties.managedRules.managedRuleSets[1].ruleSetVersion
-      version: '^0.1'
+      version: '^1.0'
 
 
 #endregion Rules

--- a/src/PSRule.Rules.Azure/rules/Azure.AppGwWAF.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppGwWAF.Rule.yaml
@@ -80,24 +80,23 @@ metadata:
   ref: AZR-000304
   tags:
     release: GA
-    ruleSet: 2022_09
+    ruleSet: 2024_03
     Azure.WAF/pillar: Security
 spec:
   type:
   - Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies
   condition:
     allOf:
-    # WAF policy has at least two rule groups. OWASP 3.1 is the minimum. Microsoft_BotManagerRuleSet 1.0 is the minimum.
+    # WAF policy has at least two rule groups. OWASP 3.2 is the minimum. Microsoft_BotManagerRuleSet 1.0 is the minimum.
     - field: Properties.managedRules.managedRuleSets
       greaterOrEquals: 2
     - field: Properties.managedRules.managedRuleSets[0].ruleSetType
       equals: OWASP 
     - field: Properties.managedRules.managedRuleSets[0].ruleSetVersion
-      version: '^3.1'
+      version: '>=3.2'
     - field: Properties.managedRules.managedRuleSets[1].ruleSetType
       equals: Microsoft_BotManagerRuleSet
     - field: Properties.managedRules.managedRuleSets[1].ruleSetVersion
-      version: '^1.0'
-
+      version: '>=1.0'
 
 #endregion Rules

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppGwWAF.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppGwWAF.Tests.ps1
@@ -87,13 +87,11 @@ Describe 'Azure.AppGWWAF' -Tag 'Network', 'AppGwWAF' {
 
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
-            $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
             $ruleResult.TargetName | Should -Be 'appgwwaf-A', 'appgwwaf-B';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
-            $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'appgwwaf-C';
         }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppGwWAF.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppGwWAF.Tests.ps1
@@ -88,14 +88,14 @@ Describe 'Azure.AppGWWAF' -Tag 'Network', 'AppGwWAF' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'appgwwaf-C';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'appgwwaf-A', 'appgwwaf-B';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'appgwwaf-A', 'appgwwaf-B';
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'appgwwaf-C';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
@@ -150,7 +150,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2022_09' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 303;
+            $filteredResult.Length | Should -Be 302;
         }
 
         It 'With Azure.Preview_2022_09' {
@@ -164,7 +164,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2022_12' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 341;
+            $filteredResult.Length | Should -Be 340;
         }
 
         It 'With Azure.Preview_2022_12' {
@@ -178,7 +178,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2023_03' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 361;
+            $filteredResult.Length | Should -Be 360;
         }
 
         It 'With Azure.Preview_2023_03' {
@@ -192,7 +192,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2023_06' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 376;
+            $filteredResult.Length | Should -Be 375;
         }
 
         It 'With Azure.Preview_2023_06' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
@@ -206,7 +206,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2023_09' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 387;
+            $filteredResult.Length | Should -Be 386;
         }
 
         It 'With Azure.Preview_2023_09' {
@@ -220,7 +220,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2023_12' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 396;
+            $filteredResult.Length | Should -Be 395;
         }
 
         It 'With Azure.Preview_2023_12' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AppGwWAF.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AppGwWAF.json
@@ -18,7 +18,7 @@
         "managedRuleSets": [
           {
             "ruleSetType": "OWASP",
-            "ruleSetVersion": "2.2.9",
+            "ruleSetVersion": "3.2",
             "ruleGroupOverrides": []
           },
           {
@@ -55,12 +55,12 @@
         "managedRuleSets": [
           {
             "ruleSetType": "OWASP",
-            "ruleSetVersion": "3.2",
+            "ruleSetVersion": "3.1",
             "ruleGroupOverrides": []
           },
           {
             "ruleSetType": "Microsoft_BotManagerRuleSet",
-            "ruleSetVersion": "0.1",
+            "ruleSetVersion": "1.0",
             "ruleGroupOverrides": []
           }
         ]

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AppGwWAF.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AppGwWAF.json
@@ -18,7 +18,7 @@
         "managedRuleSets": [
           {
             "ruleSetType": "OWASP",
-            "ruleSetVersion": "3.2",
+            "ruleSetVersion": "2.2.9",
             "ruleGroupOverrides": []
           },
           {
@@ -91,12 +91,12 @@
         "managedRuleSets": [
           {
             "ruleSetType": "OWASP",
-            "ruleSetVersion": "3.0",
+            "ruleSetVersion": "3.2",
             "ruleGroupOverrides": []
           },
           {
             "ruleSetType": "Microsoft_BotManagerRuleSet",
-            "ruleSetVersion": "0.1",
+            "ruleSetVersion": "1.0",
             "ruleGroupOverrides": []
           }
         ],


### PR DESCRIPTION
Fixes #2629

Updated `Azure.AppGwWAF.RuleGroups` to use the rule sets:
  - The latest Bot Manager rule set is now `1.0`.
  - The latest OWASP rule set is now `3.2`.

## PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
