### PR TITLE
Fixes dateTimeAdd default format string #2631

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -35,6 +35,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 What's changed since v1.32.1:
 
 - Updated rules:
+  - Application Gateway:
+    - Updated `Azure.AppGwWAF.RuleGroups` to use the rule sets by @BenjaminEngeset.
+      [#2629](https://github.com/Azure/PSRule.Rules.Azure/issues/2629)
+      - The latest Bot Manager rule set is now `1.0`.
+      - The latest OWASP rule set is now `3.2`.
   - Cognitive Services:
     - Relaxed `Azure.Cognitive.ManagedIdentity` to configurations that require managed identities by @BernieWhite.
       [#2559](https://github.com/Azure/PSRule.Rules.Azure/issues/2559)
@@ -46,11 +51,6 @@ What's changed since v1.32.1:
     - Added option for excluding subnets to `Azure.VNET.UseNSGs` by @BernieWhite.
       [#2572](https://github.com/Azure/PSRule.Rules.Azure/issues/2572)
       - To add a subnet exclusion, set the `AZURE_VNET_SUBNET_EXCLUDED_FROM_NSG` option.
-  - Azure Web Application Firewall (WAF):
-    - Updated `Azure.AppGwWAF.RuleGroups` to use the rule sets by @BenjaminEngeset.
-      [#2404](https://github.com/Azure/PSRule.Rules.Azure/issues/2404)
-      - The latest Bot Manager rule set is now `1.0`.
-      - The latest OWASP rule set is now `3.2`.
 - General improvements:
   - Quality updates to rules and documentation by @BernieWhite.
     [#1772](https://github.com/Azure/PSRule.Rules.Azure/issues/1772)
@@ -60,6 +60,9 @@ What's changed since v1.32.1:
     [#2618](https://github.com/Azure/PSRule.Rules.Azure/pull/2618)
   - Bump xunit.runner.visualstudio to v2.5.6.
     [#2619](https://github.com/Azure/PSRule.Rules.Azure/pull/2619)
+- Bug fixes:
+  - Fixed `dateTimeAdd` may fail with different localization by @BernieWhite.
+    [#2631](https://github.com/Azure/PSRule.Rules.Azure/issues/2631)
 
 ## v1.32.1
 

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -32,6 +32,7 @@ namespace PSRule.Rules.Azure.Data.Template
         private const string PROPERTY_OPERAND2 = "operand2";
         private const string PROPERTY_VALUETOCONVERT = "valueToConvert";
         private const string FORMAT_ISO8601 = "yyyy-MM-ddTHH:mm:ssZ";
+        private const string FORMAT_AZURE_DATETIME = "M/d/yyyy h:mm:ss tt";
 
         private const char SINGLE_QUOTE = '\'';
         private const char DOUBLE_QUOTE = '"';
@@ -1341,7 +1342,7 @@ namespace PSRule.Rules.Azure.Data.Template
 
             var timeToAdd = XmlConvert.ToTimeSpan(duration);
             var result = startTime.Add(timeToAdd);
-            return format == null ? result.ToString(AzureCulture) : result.ToString(format, AzureCulture);
+            return format == null ? result.ToString(FORMAT_AZURE_DATETIME, AzureCulture) : result.ToString(format, AzureCulture);
         }
 
         /// <summary>


### PR DESCRIPTION
## PR Summary

- Fixed `dateTimeAdd` may fail with different localization.

Fixes #2631

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
