### PR TITLE
Fixes Azure.VM.DiskSizeAlignment disk sizes #2656

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -38,6 +38,9 @@ What's changed since pre-release v1.33.0-B0053:
   - Dev Box:
     - Check that projects limit the number of Dev Boxes per user by @BernieWhite.
       [#2654](https://github.com/Azure/PSRule.Rules.Azure/issues/2654)
+- Bug fixes:
+  - Fixed `Azure.VM.DiskSizeAlignment` does not handle smaller sizes and ultra disks by @BernieWhite.
+    [#2656](https://github.com/Azure/PSRule.Rules.Azure/issues/2656)
 
 ## v1.33.0-B0053 (pre-release)
 

--- a/docs/en/rules/Azure.VM.DiskSizeAlignment.md
+++ b/docs/en/rules/Azure.VM.DiskSizeAlignment.md
@@ -1,7 +1,8 @@
 ---
+reviewed: 2024-01-24
 severity: Awareness
 pillar: Cost Optimization
-category: Resource usage
+category: CO:06 Usage and billing increments
 resource: Virtual Machine
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VM.DiskSizeAlignment/
 ---
@@ -10,17 +11,95 @@ online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VM.Dis
 
 ## SYNOPSIS
 
-Align to the Managed Disk billing model to improve cost efficiency.
+Align to the Managed Disk billing increments to improve cost efficiency.
 
 ## DESCRIPTION
 
-Managed disk is smaller than SKU size.
+Azure managed disks are billed based on predefined size increments.
+The billing increments are based on the disk storage type.
+These include:
+
+- `Premium SSD` - 4/ 8/ 16/ 32/ 64/ 128/ 256/ 512/ 1024/ 2048/ 4096/ 8192/ 16384/ 32768 GiB.
+- `Standard SSD` - 4/ 8/ 16/ 32/ 64/ 128/ 256/ 512/ 1024/ 2048/ 4096/ 8192/ 16384/ 32768 GiB.
+- `Standard HDD` - 32/ 64/ 128/ 256/ 512/ 1024/ 2048/ 4096/ 8192/ 16384/ 32768 GiB.
+- `Ultra SSD` - 4/ 8/ 16/ 32/ 64/ 128/ 256/ 512 GiB, then 1 TiB increments to 64 TiB.
+
+If you provision a disk that is not aligned to the billing model, you will be billed for the next increment.
+For example, if a disk is provisioned at 33 GiB, the disk is billed as 64 GiB.
 
 ## RECOMMENDATION
 
-Consider resizing or optimizing storage to reduce waste by using disk sizes that align to the billing model for Managed Disks.
-Also consider, sizing and striping disks to optimize performance.
+Consider aligning provisioned disk sizes to the billing increments for Managed Disks to improve cost efficiency.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy managed disks that pass this rule:
+
+- Set the `properties.diskSizeGB` property to a value that aligns to the billing model of the disk storage type.
+  E.g. `32`.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.Compute/disks",
+  "apiVersion": "2023-04-02",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "sku": {
+    "name": "Premium_ZRS"
+  },
+  "properties": {
+    "creationData": {
+      "createOption": "Empty"
+    },
+    "diskSizeGB": 32
+  }
+}
+```
+
+### Configure with Bicep
+
+To deploy managed disks that pass this rule:
+
+- Set the `properties.diskSizeGB` property to a value that aligns to the billing model of the disk storage type.
+  E.g. `32`.
+
+For example:
+
+```bicep
+resource dataDisk 'Microsoft.Compute/disks@2023-04-02' = {
+  name: name
+  location: location
+  sku: {
+    name: 'Premium_ZRS'
+  }
+  properties: {
+    creationData: {
+      createOption: 'Empty'
+    }
+    diskSizeGB: 32
+  }
+}
+```
+
+## NOTES
+
+This rule has the following limitations:
+
+- This rule applies to managed disks using the following storage type: Ultra SSD, Premium SSD, and Standard SSD/ HDD disks.
+  - Premium v2 disks are billed per provisioned disk capacity based on 1 GiB increments.
+  - Unmanaged disks are ignored.
+- The rule does not fail if the disk size is within 5 GiB on the next size.
+  For example: A 30 GiB disk is not aligned to the billed size of 32 GiB, but is within 5 GiB.
+- Disks with a marketplace purchase plan are ignored.
+  These disks are predefined by the publisher are often unable to be reconfigured.
 
 ## LINKS
 
+- [CO:06 Usage and billing increments](https://learn.microsoft.com/azure/well-architected/cost-optimization/align-usage-to-billing-increments)
 - [Managed Disks pricing](https://azure.microsoft.com/pricing/details/managed-disks/)
+- [Azure managed disk types](https://learn.microsoft.com/azure/virtual-machines/disks-types)
+- [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.compute/disks)

--- a/docs/examples-vm.bicep
+++ b/docs/examples-vm.bicep
@@ -23,9 +23,6 @@ param sku string
 @description('A reference to the VNET subnet where the VM will be deployed.')
 param subnetId string
 
-@description('A reference to an additional data disk.')
-param dataDiskId string
-
 @description('A reference to a user-assigned managed identity used for monitoring.')
 param amaIdentityId string
 
@@ -65,7 +62,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2023-09-01' = {
           createOption: 'Attach'
           lun: 0
           managedDisk: {
-            id: dataDiskId
+            id: dataDisk.id
           }
         }
       ]
@@ -77,6 +74,21 @@ resource vm 'Microsoft.Compute/virtualMachines@2023-09-01' = {
         }
       ]
     }
+  }
+}
+
+// An example of a VM managed disk.
+resource dataDisk 'Microsoft.Compute/disks@2023-04-02' = {
+  name: name
+  location: location
+  sku: {
+    name: 'Premium_ZRS'
+  }
+  properties: {
+    creationData: {
+      createOption: 'Empty'
+    }
+    diskSizeGB: 32
   }
 }
 

--- a/docs/examples-vm.json
+++ b/docs/examples-vm.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.24.24.22086",
-      "templateHash": "10624006843579585769"
+      "templateHash": "15227880975941749724"
     }
   },
   "parameters": {
@@ -44,12 +44,6 @@
       "type": "string",
       "metadata": {
         "description": "A reference to the VNET subnet where the VM will be deployed."
-      }
-    },
-    "dataDiskId": {
-      "type": "string",
-      "metadata": {
-        "description": "A reference to an additional data disk."
       }
     },
     "amaIdentityId": {
@@ -105,7 +99,7 @@
               "createOption": "Attach",
               "lun": 0,
               "managedDisk": {
-                "id": "[parameters('dataDiskId')]"
+                "id": "[resourceId('Microsoft.Compute/disks', parameters('name'))]"
               }
             }
           ]
@@ -119,8 +113,24 @@
         }
       },
       "dependsOn": [
+        "[resourceId('Microsoft.Compute/disks', parameters('name'))]",
         "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
       ]
+    },
+    {
+      "type": "Microsoft.Compute/disks",
+      "apiVersion": "2023-04-02",
+      "name": "[parameters('name')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Premium_ZRS"
+      },
+      "properties": {
+        "creationData": {
+          "createOption": "Empty"
+        },
+        "diskSizeGB": 32
+      }
     },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",

--- a/src/PSRule.Rules.Azure/rules/Azure.VM.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.VM.Rule.yaml
@@ -135,4 +135,18 @@ spec:
       notIn:
       - MicrosoftWindowsDesktop
 
+---
+# Synopsis: Exclude disks that are deployed as part of a marketplace offering.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Azure.Disk.NonMarketplaceImage
+spec:
+  if:
+    allOf:
+      - type: .
+        equals: Microsoft.Compute/disks
+      - field: properties.purchasePlan.name
+        hasValue: false
+
 #endregion Selectors

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VM.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VM.Tests.ps1
@@ -201,8 +201,8 @@ Describe 'Azure.VM' -Tag 'VM' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'disk-B', 'disk-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'disk-B', 'disk-C', 'disk-D';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly "The resource is not associated.";
@@ -228,8 +228,8 @@ Describe 'Azure.VM' -Tag 'VM' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'disk-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'disk-A', 'disk-D';
         }
 
         It 'Azure.VM.UseHybridUseBenefit' {
@@ -381,8 +381,8 @@ Describe 'Azure.VM' -Tag 'VM' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'disk-B', 'disk-C', 'ReplicaVM_DataDisk_0-ASRReplica';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'disk-B', 'disk-C', 'ReplicaVM_DataDisk_0-ASRReplica', 'disk-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -484,8 +484,8 @@ Describe 'Azure.VM' -Tag 'VM' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'ReplicaVM_DataDisk_0-ASRReplica', 'disk-A', 'disk-B', 'disk-C';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'ReplicaVM_DataDisk_0-ASRReplica', 'disk-A', 'disk-B', 'disk-C', 'disk-D';
         }
 
         It 'Azure.VM.MigrateAMA' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualMachine.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualMachine.json
@@ -185,6 +185,41 @@
     "SubscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-D",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/disks/disk-D",
+    "Location": "region",
+    "ResourceName": "disk-D",
+    "Name": "disk-D",
+    "Properties": {
+      "creationData": {
+        "createOption": "Empty"
+      },
+      "diskSizeGB": 4,
+      "diskIOPSReadWrite": 500,
+      "diskMBpsReadWrite": 100,
+      "encryptionSettingsCollection": {
+        "enabled": false,
+        "encryptionSettings": [],
+        "encryptionSettingsVersion": "1.0"
+      },
+      "provisioningState": "Succeeded",
+      "diskState": "Unattached"
+    },
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.Compute/disks",
+    "ResourceType": "Microsoft.Compute/disks",
+    "Sku": {
+      "Name": "Premium_LRS",
+      "Tier": "Premium",
+      "Size": null,
+      "Family": null,
+      "Model": null,
+      "Capacity": null
+    },
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
     "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
     "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
     "Location": "region",


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.VM.DiskSizeAlignment` does not handle smaller sizes and ultra disks.

Fixes #2656 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
