### PR TITLE
Policy as rule baseline and ignore options #2482

### DIFF
--- a/.vscode/policy-ignore.schema.json
+++ b/.vscode/policy-ignore.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Policy as Code Ignore",
   "description": "Policy ignore identifies policies that will be ignored by PSRule for generating rules during export of policies.",
   "type": "array",

--- a/.vscode/policy-ignore.schema.json
+++ b/.vscode/policy-ignore.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Policy as Code Ignore",
+  "description": "Policy ignore identifies policies that will be ignored by PSRule for generating rules during export of policies.",
+  "type": "array",
+  "items": {
+    "properties": {
+      "policyDefinitionIds": {
+        "type": "array",
+        "title": "Policy definition IDs",
+        "description": "The resource IDs of built-in policies to ignore.",
+        "minItems": 1,
+        "uniqueItems": true,
+        "items": {
+          "type": "string"
+        }
+      },
+      "reason": {
+        "type": "string",
+        "title": "The reason why the policy definition is ignored.",
+        "enum": [
+          "Duplicate",
+          "NotApplicable"
+        ],
+        "default": "Duplicate"
+      },
+      "value": {
+        "type": "string",
+        "title": "Value",
+        "description": "An additional relating to the reason the policy definition was ignored."
+      }
+    },
+    "additionalProperties": false,
+    "examples": [
+      {
+        "policyDefinitionIds": [],
+        "reason": "Duplicate",
+        "value": ""
+      }
+    ]
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -133,6 +133,14 @@
     "yaml",
     "yml"
   ],
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "**/data/policy-ignore.json"
+      ],
+      "url": "./.vscode/policy-ignore.schema.json"
+    }
+  ],
   "omnisharp.organizeImportsOnFormat": true,
   "omnisharp.enableEditorConfigSupport": true,
   "omnisharp.enableRoslynAnalyzers": true,

--- a/data/policy-ignore.json
+++ b/data/policy-ignore.json
@@ -75,7 +75,7 @@
       "/providers/Microsoft.Authorization/policyDefinitions/0b60c0b2-2dc2-4e1c-b5c9-abbed971de53"
     ],
     "reason": "Duplicate",
-    "value": "Azure.KeyVault.SoftDelete"
+    "value": "Azure.KeyVault.PurgeProtect"
   },
   {
     "policyDefinitionIds": [
@@ -119,5 +119,12 @@
     ],
     "reason": "Duplicate",
     "value": "Azure.KeyVault.SoftDelete"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/12d4fa5e-1f9f-4c21-97a9-b99b3c6611b5"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.KeyVault.RBAC"
   }
 ]

--- a/data/policy-ignore.json
+++ b/data/policy-ignore.json
@@ -1,36 +1,123 @@
 [
-  // Azure.ACR.AdminUser
-  "/providers/Microsoft.Authorization/policyDefinitions/dc921057-6b28-4fbe-9b83-f7bec05db6c2",
-  "/providers/Microsoft.Authorization/policyDefinitions/79fdfe03-ffcb-4e55-b4d0-b925b8241759",
-  // Azure.SQL.AAD
-  "/providers/Microsoft.Authorization/policyDefinitions/1f314764-cb73-4fc9-b863-8eca98ac36e9",
-  // Azure.ServiceFabric.AAD
-  "/providers/Microsoft.Authorization/policyDefinitions/b54ed75b-3e1a-44ac-a333-05ba39b99ff0",
-  // Azure.Redis.NonSslPort
-  "/providers/Microsoft.Authorization/policyDefinitions/22bee202-a82f-4305-9a2a-6d7f44d4dedb",
-  // Azure.Automation.EncryptVariables
-  "/providers/Microsoft.Authorization/policyDefinitions/3657f5a0-770e-44a3-b44e-9431ba1e9735",
-  // Azure.AKS.UseRBAC
-  "/providers/Microsoft.Authorization/policyDefinitions/ac4a19c2-fa67-49b4-8ae5-0b2e78c49457",
-  // Azure.AKS.AzurePolicyAddOn
-  "/providers/Microsoft.Authorization/policyDefinitions/0a15ec92-a229-4763-bb14-0ea34a568f8d",
-  // Azure.Storage.BlobPublicAccess
-  "/providers/Microsoft.Authorization/policyDefinitions/4fa4b6c0-31ca-4c0d-b10d-24b96f62a751",
-  // Azure.PostgreSQL.UseSSL
-  "/providers/Microsoft.Authorization/policyDefinitions/d158790f-bfb0-486c-8631-2dc6b4e8e6af",
-  // Azure.MySQL.UseSSL
-  "/providers/Microsoft.Authorization/policyDefinitions/e802a67a-daf5-4436-9ea6-f6d821dd0c5d",
-  // Azure.KeyVault.SoftDelete
-  "/providers/Microsoft.Authorization/policyDefinitions/0b60c0b2-2dc2-4e1c-b5c9-abbed971de53",
-  // Checking for Network Watcher in a resource group is not enforcable by code.
-  "/providers/Microsoft.Authorization/policyDefinitions/b6e2945c-0b7b-40f5-9233-7a5323b5cdc6",
-  // Azure.AKS.LocalAccounts
-  "/providers/Microsoft.Authorization/policyDefinitions/993c2fcd-2b29-49d2-9eb0-df2c3a730c32",
-  // Azure.Cognitive.DisableLocalAuth
-  "/providers/Microsoft.Authorization/policyDefinitions/71ef260a-8f18-47b7-abcb-62d0673d94dc",
-  "/providers/Microsoft.Authorization/policyDefinitions/14de9e63-1b31-492e-a5a3-c3f7fd57f555",
-  // Azure.Cognitive.ManagedIdentity
-  "/providers/Microsoft.Authorization/policyDefinitions/fe3fd216-4f83-4fc1-8984-2bbec80a3418",
-  // Azure.VM.UseManagedDisks
-  "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d"
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/dc921057-6b28-4fbe-9b83-f7bec05db6c2",
+      "/providers/Microsoft.Authorization/policyDefinitions/79fdfe03-ffcb-4e55-b4d0-b925b8241759"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.ACR.AdminUser"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/1f314764-cb73-4fc9-b863-8eca98ac36e9"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.SQL.AAD"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/b54ed75b-3e1a-44ac-a333-05ba39b99ff0"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.ServiceFabric.AAD"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/22bee202-a82f-4305-9a2a-6d7f44d4dedb"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.Redis.NonSslPort"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/3657f5a0-770e-44a3-b44e-9431ba1e9735"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.Automation.EncryptVariables"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/ac4a19c2-fa67-49b4-8ae5-0b2e78c49457"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.AKS.UseRBAC"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/0a15ec92-a229-4763-bb14-0ea34a568f8d"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.AKS.AzurePolicyAddOn"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/4fa4b6c0-31ca-4c0d-b10d-24b96f62a751"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.Storage.BlobPublicAccess"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/d158790f-bfb0-486c-8631-2dc6b4e8e6af"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.PostgreSQL.UseSSL"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/e802a67a-daf5-4436-9ea6-f6d821dd0c5d"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.MySQL.UseSSL"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/0b60c0b2-2dc2-4e1c-b5c9-abbed971de53"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.KeyVault.SoftDelete"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/b6e2945c-0b7b-40f5-9233-7a5323b5cdc6"
+    ],
+    "reason": "NotApplicable",
+    "value": "Checking for Network Watcher in a resource group is not enforcable by code."
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/993c2fcd-2b29-49d2-9eb0-df2c3a730c32"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.AKS.LocalAccounts"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/71ef260a-8f18-47b7-abcb-62d0673d94dc",
+      "/providers/Microsoft.Authorization/policyDefinitions/14de9e63-1b31-492e-a5a3-c3f7fd57f555"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.Cognitive.DisableLocalAuth"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/fe3fd216-4f83-4fc1-8984-2bbec80a3418"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.Cognitive.ManagedIdentity"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.VM.UseManagedDisks"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.KeyVault.SoftDelete"
+  }
 ]

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,24 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.33.0-B0126:
+
+- New features:
+  - Exporting policy as rules also generates a baseline by @BernieWhite.
+    [#2482](https://github.com/Azure/PSRule.Rules.Azure/issues/2482)
+    - A baseline is automatically generated that includes for all rules exported.
+      If a policy rule has been replaced by a built-in rule, the baseline will include the built-in rule instead.
+    - The baseline is named `<Prefix>.PolicyBaseline.All`. i.e. `Azure.PolicyBaseline.All` by default.
+    - For details see [Policy as rules](./concepts/policy-as-rules.md#generated-baseline).
+- General improvements:
+  - Rules that are ignored during exporting policy as rules are now generate a verbose logs by @BernieWhite.
+    [#2482](https://github.com/Azure/PSRule.Rules.Azure/issues/2482)
+    - This is to improve transparency of why rules are not exported.
+    - To see details on why a rule is ignored, enable verbose logging with `-Verbose`.
+  - Policies that duplicate built-in rules can now be exported by using the `-KeepDuplicates` parameter by @BernieWhite.
+    [#2482](https://github.com/Azure/PSRule.Rules.Azure/issues/2482)
+    - For details see [Policy as rules](./concepts/policy-as-rules.md#duplicate-policies).
+
 ## v1.33.0-B0126 (pre-release)
 
 What's changed since pre-release v1.33.0-B0088:

--- a/docs/commands/Export-AzPolicyAssignmentRuleData.md
+++ b/docs/commands/Export-AzPolicyAssignmentRuleData.md
@@ -16,7 +16,7 @@ Export JSON based rules from policy assignment data.
 ```text
 Export-AzPolicyAssignmentRuleData [-Name <String>] -AssignmentFile <String>
  [-ResourceGroup <ResourceGroupReference>] [-Subscription <SubscriptionReference>] [-OutputPath <String>]
- [-RulePrefix <String>] [-PassThru] [<CommonParameters>]
+ [-RulePrefix <String>] [-PassThru] [-KeepDuplicates] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -200,7 +200,26 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -KeepDuplicates
+
+Determines if Azure policy definitions that duplicate existing built-in rules are exported.
+By default, duplicates are not exported.
+
+This only applies to built-in policy definitions.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/concepts/about_PSRule_Azure_Configuration.md
+++ b/docs/concepts/about_PSRule_Azure_Configuration.md
@@ -320,6 +320,7 @@ Example:
 
 ```yaml
 # YAML: Add a custom policy definition to ignore
+configuration:
   AZURE_POLICY_IGNORE_LIST:
   - '/providers/Microsoft.Authorization/policyDefinitions/1f314764-cb73-4fc9-b863-8eca98ac36e9'
   - '/providers/Microsoft.Authorization/policyDefinitions/b54ed75b-3e1a-44ac-a333-05ba39b99ff0'

--- a/docs/concepts/policy-as-rules.md
+++ b/docs/concepts/policy-as-rules.md
@@ -34,8 +34,6 @@ This feature does not support:
 - **Policies that check for assessment status** &mdash; Some policies use additional detection tools to check for compliance.
   Policies that check for assessment status are ignored.
 - **Importing rules** &mdash; Rules generated from policy assignments cannot be imported back into Azure Policy.
-- **Duplicate rules** &mdash; Currently, built-in Azure Policies that are duplicates of existing rules are ignored.
-  [#2482](https://github.com/Azure/PSRule.Rules.Azure/issues/2482)
 
 ## Using policy as rules
 
@@ -60,3 +58,61 @@ Run `Export-AzPolicyAssignmentRuleData` to convert assignments to rules.
 To run this command an `-AssignmentFile` parameter with the path to the assignment JSON file generated in the previous step.
 
 After the command completes a new file `*.Rule.jsonc` should be generated containing generated rules.
+
+## Customizing the generated rules
+
+PSRule for Azure allows you to:
+
+- **Set a name prefix** &mdash; to help identify generated rules.
+  By default, generated rules and baselines are prefixed with `Azure`.
+  To change the prefix:
+  - Use the `-RulePrefix` parameter when running `Export-AzPolicyAssignmentRuleData`. _OR_
+  - Set the `AZURE_POLICY_RULE_PREFIX` configuration option in `ps-rule.yaml`.
+- **Exclude specific policies** &mdash; by setting the `AZURE_POLICY_IGNORE_LIST` configuration option in `ps-rule.yaml`.
+  This option allows you to prevent specific policies from being exported as rules.
+
+For example:
+
+```yaml title="ps-rule.yaml"
+configuration:
+  AZURE_POLICY_RULE_PREFIX: MyOrg
+  AZURE_POLICY_IGNORE_LIST:
+  - /providers/Microsoft.Authorization/policyDefinitions/1f314764-cb73-4fc9-b863-8eca98ac36e9
+  - /providers/Microsoft.Authorization/policyDefinitions/b54ed75b-3e1a-44ac-a333-05ba39b99ff0
+```
+
+## Generated baseline
+
+<!-- module:version v1.33.0 -->
+
+When exporting policies, PSRule for Azure will automatically generate a baseline including any generated rules.
+By default, this baseline is called `Azure.PolicyBaseline.All`.
+If you change the prefix of generated rules the baseline will be named `<Prefix>.PolicyBaseline.All`.
+
+See [Using baselines](../working-with-baselines.md#using-baselines) for examples on how to use a baseline in a run.
+
+## Duplicate policies
+
+<!-- module:version v1.33.0 -->
+
+When exporting policies, you may encounter definitions that are duplicates of existing rules shipped with PSRule for Azure.
+By default, built-in Azure policies that are duplicates of existing rules are ignored.
+Additionally, PSRule for Azure will automatically switch in existing rules into the generated baseline.
+
+!!! Note
+    This only applies to built-in Azure policies that are duplicates of existing rules.
+    Custom policies are not effected.
+
+    The list of built-in policies that are duplicates can be viewed [here][3].
+    If you believe a policy is missing from this list, please [open an issue][4].
+
+    [3]: https://github.com/Azure/PSRule.Rules.Azure/blob/main/data/policy-ignore.json
+    [4]: https://github.com/Azure/PSRule.Rules.Azure/issues/new/choose
+
+This allows you to:
+
+- Focus on policies that are unique to your environment and not already covered by PSRule for Azure.
+- Benefit from the additional references and examples provided by PSRule for Azure.
+- Reduce noise reporting the same issue multiple times.
+
+To override this behavior use the `-KeepDuplicates` parameter switch when running `Export-AzPolicyAssignmentRuleData`.

--- a/src/PSRule.Rules.Azure.BuildTool/Models.cs
+++ b/src/PSRule.Rules.Azure.BuildTool/Models.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace PSRule.Rules.Azure.BuildTool
 {
@@ -16,6 +17,9 @@ namespace PSRule.Rules.Azure.BuildTool
         public int Index { get; set; }
     }
 
+    /// <summary>
+    /// This is the full class for deserializing un-minified resource type data.
+    /// </summary>
     internal sealed class ResourceTypeEntry
     {
         public ResourceTypeEntry()
@@ -56,9 +60,9 @@ namespace PSRule.Rules.Azure.BuildTool
     {
         private readonly ResourceTypeEntry _Expanded;
 
-        public ResourceTypeMin(ResourceTypeEntry resourceType)
+        public ResourceTypeMin(ResourceTypeEntry entry)
         {
-            _Expanded = resourceType;
+            _Expanded = entry;
         }
 
         [JsonProperty(PropertyName = "a")]
@@ -93,5 +97,55 @@ namespace PSRule.Rules.Azure.BuildTool
 
         [JsonProperty(PropertyName = "z")]
         public string[] Zones { get; set; }
+    }
+
+    internal enum PolicyIgnoreReason
+    {
+        Duplicate = 1,
+
+        NotApplicable = 2,
+    }
+
+    internal sealed class PolicyIgnoreEntry
+    {
+        public PolicyIgnoreEntry()
+        {
+            Min = new PolicyIgnoreMin(this);
+        }
+
+        [JsonProperty(PropertyName = "policyDefinitionIds")]
+        public string[] PolicyDefinitionIds { get; set; }
+
+        [JsonProperty(PropertyName = "reason")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public PolicyIgnoreReason Reason { get; set; }
+
+        [JsonProperty(PropertyName = "value")]
+        public string Value { get; set; }
+
+        [JsonIgnore]
+        public PolicyIgnoreMin Min { get; }
+    }
+
+    /// <summary>
+    /// A wrapper class for JSON minification.
+    /// </summary>
+    internal sealed class PolicyIgnoreMin
+    {
+        private readonly PolicyIgnoreEntry _Expanded;
+
+        public PolicyIgnoreMin(PolicyIgnoreEntry entry)
+        {
+            _Expanded = entry;
+        }
+
+        [JsonProperty("i")]
+        public string[] PolicyDefinitionIds => _Expanded.PolicyDefinitionIds;
+
+        [JsonProperty("r")]
+        public PolicyIgnoreReason Reason => _Expanded.Reason;
+
+        [JsonProperty("v", NullValueHandling = NullValueHandling.Ignore)]
+        public string Value => _Expanded.Reason == PolicyIgnoreReason.Duplicate ? _Expanded.Value : null;
     }
 }

--- a/src/PSRule.Rules.Azure.BuildTool/ProviderResource.cs
+++ b/src/PSRule.Rules.Azure.BuildTool/ProviderResource.cs
@@ -47,8 +47,8 @@ namespace PSRule.Rules.Azure.BuildTool
         private static void MinifyPolicyIgnore(ProviderResourceOption options)
         {
             Console.WriteLine("BuildTool -- Minify policy-ignore");
-            var policyIgnore = ReadFile<string[]>(GetSourcePath("./data/policy-ignore.json"));
-            WriteFile(GetSourcePath("./data/policy-ignore.min.json"), policyIgnore);
+            var entries = ReadFile<PolicyIgnoreEntry[]>(GetSourcePath("./data/policy-ignore.json"));
+            WriteFile(GetSourcePath("./data/policy-ignore.min.json"), entries.Select(e => e.Min));
         }
 
         private static void MinifyTypes(ProviderResourceOption options)
@@ -58,7 +58,7 @@ namespace PSRule.Rules.Azure.BuildTool
             foreach (var provider in GetProviders(GetSourcePath("./data/providers")))
             {
                 var entries = ReadFile<ResourceTypeEntry[]>(provider);
-                WriteMinified(provider, entries.Select(e => e.Min));
+                WriteMinifiedResourceType(provider, entries.Select(e => e.Min));
                 count++;
             }
             Console.WriteLine($"BuildTool -- {count} providers processed");
@@ -88,7 +88,7 @@ namespace PSRule.Rules.Azure.BuildTool
             Console.WriteLine($"BuildTool -- {count} providers processed");
         }
 
-        private static void WriteMinified(string provider, IEnumerable<ResourceTypeMin> entries)
+        private static void WriteMinifiedResourceType(string provider, IEnumerable<ResourceTypeMin> entries)
         {
             var file = provider.Replace("types.json", "types.min.json");
             WriteFile(file, entries);
@@ -124,7 +124,7 @@ namespace PSRule.Rules.Azure.BuildTool
                 var d = new JsonSerializer();
                 return d.Deserialize<T>(reader);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Console.WriteLine($"ERROR - Failed to read file: {path}");
                 throw;

--- a/src/PSRule.Rules.Azure/Common/JsonConverters.cs
+++ b/src/PSRule.Rules.Azure/Common/JsonConverters.cs
@@ -244,4 +244,83 @@ namespace PSRule.Rules.Azure
             throw new NotImplementedException();
         }
     }
+
+    internal sealed class PolicyBaselineConverter : JsonConverter
+    {
+        private const string SYNOPSIS_COMMENT = "Synopsis: ";
+        private const string PROPERTY_APIVERSION = "apiVersion";
+        private const string APIVERSION_VALUE = "github.com/microsoft/PSRule/v1";
+        private const string PROPERTY_KIND = "kind";
+        private const string KIND_VALUE = "Baseline";
+        private const string PROPERTY_METADATA = "metadata";
+        private const string PROPERTY_NAME = "name";
+        private const string PROPERTY_SPEC = "spec";
+        private const string PROPERTY_RULE = "rule";
+        private const string PROPERTY_INCLUDE = "include";
+
+        public override bool CanConvert(Type objectType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool CanWrite => true;
+
+        public override bool CanRead => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            Map(writer, serializer, value as PolicyBaseline);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static void Map(JsonWriter writer, JsonSerializer serializer, PolicyBaseline baseline)
+        {
+            writer.WriteStartObject();
+
+            // Synopsis
+            writer.WriteComment(string.Concat(SYNOPSIS_COMMENT, baseline.Description));
+
+            // Api Version
+            writer.WritePropertyName(PROPERTY_APIVERSION);
+            writer.WriteValue(APIVERSION_VALUE);
+
+            // Kind
+            writer.WritePropertyName(PROPERTY_KIND);
+            writer.WriteValue(KIND_VALUE);
+
+            // Metadata
+            writer.WritePropertyName(PROPERTY_METADATA);
+            writer.WriteStartObject();
+            writer.WritePropertyName(PROPERTY_NAME);
+            writer.WriteValue(baseline.Name);
+            writer.WriteEndObject();
+
+            // Spec
+            writer.WritePropertyName(PROPERTY_SPEC);
+            writer.WriteStartObject();
+            WriteRule(writer, serializer, baseline);
+
+            writer.WriteEndObject();
+        }
+
+        private static void WriteRule(JsonWriter writer, JsonSerializer serializer, PolicyBaseline baseline)
+        {
+            if (baseline.Include == null || baseline.Include.Length == 0)
+                return;
+
+            var types = new HashSet<string>(baseline.Include, StringComparer.OrdinalIgnoreCase);
+            writer.WritePropertyName(PROPERTY_RULE);
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(PROPERTY_INCLUDE);
+            serializer.Serialize(writer, types);
+            writer.WriteEndObject();
+
+            writer.WriteEndObject();
+        }
+    }
 }

--- a/src/PSRule.Rules.Azure/Data/Policy/LoggerExtensions.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/LoggerExtensions.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Rules.Azure.Pipeline;
+using PSRule.Rules.Azure.Resources;
+
+namespace PSRule.Rules.Azure.Data.Policy
+{
+    internal static class LoggerExtensions
+    {
+        /// <summary>
+        /// Policy definition has been ignored based on configuration: {0}
+        /// </summary>
+        /// <param name="logger">A logger instance.</param>
+        /// <param name="definitionId">The policy definition ID.</param>
+        public static void VerbosePolicyIgnoreConfigured(this ILogger logger, string definitionId)
+        {
+            logger.WriteVerbose(PSRuleResources.PolicyIgnoreConfigured, definitionId);
+        }
+
+        /// <summary>
+        /// Policy definition has been ignored because it is not applicable to Infrastructure as Code: {0}
+        /// </summary>
+        /// <param name="logger">A logger instance.</param>
+        /// <param name="definitionId">The policy definition ID.</param>
+        public static void VerbosePolicyIgnoreNotApplicable(this ILogger logger, string definitionId)
+        {
+            logger.WriteVerbose(PSRuleResources.PolicyIgnoreNotApplicable, definitionId);
+        }
+
+        /// <summary>
+        /// Policy definition has been ignored because a similar built-in rule already exists ({1}): {0}
+        /// </summary>
+        /// <param name="logger">A logger instance.</param>
+        /// <param name="definitionId">The policy definition ID.</param>
+        /// <param name="ruleName">The name of the built-in rule.</param>
+        public static void VerbosePolicyIgnoreDuplicate(this ILogger logger, string definitionId, string ruleName)
+        {
+            logger.WriteVerbose(PSRuleResources.PolicyIgnoreDuplicate, definitionId, ruleName);
+        }
+
+        /// <summary>
+        /// Policy definition has been ignored because it is disabled: {0}
+        /// </summary>
+        /// <param name="logger">A logger instance.</param>
+        /// <param name="definitionId">The policy definition ID.</param>
+        public static void VerbosePolicyIgnoreDisabled(this ILogger logger, string definitionId)
+        {
+            logger.WriteVerbose(PSRuleResources.PolicyIgnoreDisabled, definitionId);
+        }
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Policy/Models.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/Models.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
@@ -175,5 +176,27 @@ namespace PSRule.Rules.Azure.Data.Policy
             }
             return _Value;
         }
+    }
+
+    [JsonConverter(typeof(PolicyBaselineConverter))]
+    internal sealed class PolicyBaseline
+    {
+        public PolicyBaseline(string name, string description, IEnumerable<string> definitionRuleNames, IEnumerable<string> replacedRuleNames)
+        {
+            Name = name;
+            Description = description;
+            Include = Union(definitionRuleNames ?? Array.Empty<string>(), replacedRuleNames ?? Array.Empty<string>());
+        }
+
+        private static string[] Union(IEnumerable<string> definitionRuleNames, IEnumerable<string> replacedRuleNames)
+        {
+            return definitionRuleNames.Union(replacedRuleNames).ToArray();
+        }
+
+        public string Name { get; }
+
+        public string Description { get; }
+
+        public string[] Include { get; }
     }
 }

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentHelper.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentHelper.cs
@@ -17,10 +17,12 @@ namespace PSRule.Rules.Azure.Data.Policy
     internal sealed class PolicyAssignmentHelper
     {
         private readonly PipelineContext _PipelineContext;
+        private readonly bool _KeepDuplicates;
 
-        public PolicyAssignmentHelper(PipelineContext pipelineContext)
+        public PolicyAssignmentHelper(PipelineContext pipelineContext, bool keepDuplicates)
         {
             _PipelineContext = pipelineContext;
+            _KeepDuplicates = keepDuplicates;
         }
 
         internal PolicyDefinition[] ProcessAssignment(string assignmentFile, out PolicyAssignmentVisitor.PolicyAssignmentContext context)
@@ -35,7 +37,7 @@ namespace PSRule.Rules.Azure.Data.Policy
                     rootedAssignmentFile);
 
             var visitor = new PolicyAssignmentDataExportVisitor();
-            context = new PolicyAssignmentVisitor.PolicyAssignmentContext(_PipelineContext);
+            context = new PolicyAssignmentVisitor.PolicyAssignmentContext(_PipelineContext, _KeepDuplicates);
             context.SetSource(assignmentFile);
 
             try
@@ -66,7 +68,9 @@ namespace PSRule.Rules.Azure.Data.Policy
                     inner,
                     rootedAssignmentFile);
             }
-            return context.GetDefinitions();
+            var definitions = context.GetDefinitions();
+            var baseline = context.GenerateBaseline();
+            return definitions;
         }
 
         private static JObject[] ReadFileArray(string path)

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentHelper.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentHelper.cs
@@ -23,9 +23,12 @@ namespace PSRule.Rules.Azure.Data.Policy
         {
             _PipelineContext = pipelineContext;
             _KeepDuplicates = keepDuplicates;
+            Context = new PolicyAssignmentVisitor.PolicyAssignmentContext(_PipelineContext, _KeepDuplicates);
         }
 
-        internal PolicyDefinition[] ProcessAssignment(string assignmentFile, out PolicyAssignmentVisitor.PolicyAssignmentContext context)
+        public PolicyAssignmentVisitor.PolicyAssignmentContext Context { get; }
+
+        internal void ProcessAssignment(string assignmentFile)
         {
             var rootedAssignmentFile = PSRuleOption.GetRootedPath(assignmentFile);
             if (!File.Exists(rootedAssignmentFile))
@@ -37,8 +40,7 @@ namespace PSRule.Rules.Azure.Data.Policy
                     rootedAssignmentFile);
 
             var visitor = new PolicyAssignmentDataExportVisitor();
-            context = new PolicyAssignmentVisitor.PolicyAssignmentContext(_PipelineContext, _KeepDuplicates);
-            context.SetSource(assignmentFile);
+            Context.SetSource(assignmentFile);
 
             try
             {
@@ -49,7 +51,7 @@ namespace PSRule.Rules.Azure.Data.Policy
                 {
                     try
                     {
-                        visitor.Visit(context, assignment);
+                        visitor.Visit(Context, assignment);
                     }
                     catch (Exception inner)
                     {
@@ -68,9 +70,6 @@ namespace PSRule.Rules.Azure.Data.Policy
                     inner,
                     rootedAssignmentFile);
             }
-            var definitions = context.GetDefinitions();
-            var baseline = context.GenerateBaseline();
-            return definitions;
         }
 
         private static JObject[] ReadFileArray(string path)

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
@@ -255,11 +255,6 @@ namespace PSRule.Rules.Azure.Data.Policy
                 }
             }
 
-            internal void ClearDefaultResourceType()
-            {
-                _PolicyAliasProviderHelper.ClearDefaultResourceType();
-            }
-
             internal void SetDefinitionParameterAssignment(PolicyDefinition definition, JProperty parameter)
             {
                 var type = GetParameterType(parameter.Value);

--- a/src/PSRule.Rules.Azure/Data/PolicyIgnore.cs
+++ b/src/PSRule.Rules.Azure/Data/PolicyIgnore.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace PSRule.Rules.Azure.Data
+{
+    internal sealed class PolicyIgnoreResult
+    {
+        public PolicyIgnoreReason Reason { get; set; }
+
+        public string Value { get; set; }
+    }
+
+    internal sealed class PolicyIgnoreEntry
+    {
+        [JsonProperty("i")]
+        public string[] PolicyDefinitionIds { get; set; }
+
+        [JsonProperty("r")]
+        public PolicyIgnoreReason Reason { get; set; }
+
+        [JsonProperty("v", NullValueHandling = NullValueHandling.Ignore)]
+        public string Value { get; set; }
+    }
+
+    internal enum PolicyIgnoreReason
+    {
+        /// <summary>
+        /// The policy is excluded because it was duplicated with an existing rule.
+        /// </summary>
+        Duplicate = 1,
+
+        /// <summary>
+        /// The policy is excluded because it is not testable or not applicable for IaC.
+        /// </summary>
+        NotApplicable = 2,
+
+        /// <summary>
+        /// An exclusion configured by the user.
+        /// </summary>
+        Configured = 3
+    }
+
+    internal sealed class PolicyIgnoreResultConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Dictionary<string, PolicyIgnoreResult>);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType != JsonToken.StartArray)
+                return null;
+
+            reader.Read();
+            var result = new Dictionary<string, PolicyIgnoreResult>(StringComparer.OrdinalIgnoreCase);
+
+            while (reader.TokenType != JsonToken.EndArray)
+            {
+                var entry = serializer.Deserialize<PolicyIgnoreEntry>(reader);
+                for (var i = 0; i < entry.PolicyDefinitionIds.Length; i++)
+                {
+                    result[entry.PolicyDefinitionIds[i]] = new PolicyIgnoreResult
+                    {
+                        Reason = entry.Reason,
+                        Value = entry.Value,
+                    };
+                }
+                reader.Read();
+            }
+            return result;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/PolicyIgnoreData.cs
+++ b/src/PSRule.Rules.Azure/Data/PolicyIgnoreData.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using PSRule.Rules.Azure.Resources;
@@ -19,20 +18,20 @@ namespace PSRule.Rules.Azure.Data
         {
             Converters = new List<JsonConverter>
             {
-                new HashSetConverter(StringComparer.OrdinalIgnoreCase),
+                new PolicyIgnoreResultConverter(),
             }
         };
-        private HashSet<string> _Index;
+        private Dictionary<string, PolicyIgnoreResult> _Index;
 
-        internal HashSet<string> GetIndex()
+        internal Dictionary<string, PolicyIgnoreResult> GetIndex()
         {
             _Index ??= ReadIndex(GetContent(RESOURCE_PATH));
             return _Index;
         }
 
-        private static HashSet<string> ReadIndex(string content)
+        private static Dictionary<string, PolicyIgnoreResult> ReadIndex(string content)
         {
-            return JsonConvert.DeserializeObject<HashSet<string>>(content, _Settings) ?? throw new JsonException(PSRuleResources.PolicyIgnoreInvalid);
+            return JsonConvert.DeserializeObject<Dictionary<string, PolicyIgnoreResult>>(content, _Settings) ?? throw new JsonException(PSRuleResources.PolicyIgnoreInvalid);
         }
     }
 }

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionStream.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionStream.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1
@@ -459,7 +459,10 @@ function Export-AzPolicyAssignmentRuleData {
         [String]$RulePrefix,
 
         [Parameter(Mandatory = $False)]
-        [Switch]$PassThru = $False
+        [Switch]$PassThru = $False,
+
+        [Parameter(Mandatory = $False)]
+        [Switch]$KeepDuplicates = $False
     )
     begin {
         Write-Verbose -Message '[Export-AzPolicyAssignmentRuleData] BEGIN::';
@@ -475,6 +478,7 @@ function Export-AzPolicyAssignmentRuleData {
         $builder = [PSRule.Rules.Azure.Pipeline.PipelineBuilder]::Assignment($option);
         $builder.Assignment($Name);
         $builder.PassThru($PassThru);
+        $builder.KeepDuplicates($KeepDuplicates);
 
         # Bind to subscription context
         if ($PSBoundParameters.ContainsKey('Subscription')) {

--- a/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentPipeline.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentPipeline.cs
@@ -25,6 +25,13 @@ namespace PSRule.Rules.Azure.Pipeline
             ProcessCatch(source.AssignmentFile);
         }
 
+        public override void End()
+        {
+            Context.Writer.WriteObject(_PolicyAssignmentHelper.Context.GetDefinitions(), true);
+            Context.Writer.WriteObject(_PolicyAssignmentHelper.Context.GenerateBaseline(), false);
+            base.End();
+        }
+
         private void ProcessCatch(string assignmentFile)
         {
             try
@@ -47,8 +54,7 @@ namespace PSRule.Rules.Azure.Pipeline
 
         private void ProcessAssignment(string assignmentFile)
         {
-            Context.Writer.WriteObject(_PolicyAssignmentHelper.ProcessAssignment(assignmentFile, out var context), true);
-            Context.Writer.WriteObject(context.GenerateBaseline(), false);
+            _PolicyAssignmentHelper.ProcessAssignment(assignmentFile);
         }
     }
 }

--- a/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentPipeline.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentPipeline.cs
@@ -10,10 +10,10 @@ namespace PSRule.Rules.Azure.Pipeline
     {
         private readonly PolicyAssignmentHelper _PolicyAssignmentHelper;
 
-        internal PolicyAssignmentPipeline(PipelineContext context)
+        internal PolicyAssignmentPipeline(PipelineContext context, bool keepDuplicates)
             : base(context)
         {
-            _PolicyAssignmentHelper = new PolicyAssignmentHelper(context);
+            _PolicyAssignmentHelper = new PolicyAssignmentHelper(context, keepDuplicates);
         }
 
         /// <inheritdoc/>
@@ -29,7 +29,7 @@ namespace PSRule.Rules.Azure.Pipeline
         {
             try
             {
-                Context.Writer.WriteObject(ProcessAssignment(assignmentFile), true);
+                ProcessAssignment(assignmentFile);
             }
             catch (PipelineException ex)
             {
@@ -45,9 +45,10 @@ namespace PSRule.Rules.Azure.Pipeline
             }
         }
 
-        internal PolicyDefinition[] ProcessAssignment(string assignmentFile)
+        private void ProcessAssignment(string assignmentFile)
         {
-            return _PolicyAssignmentHelper.ProcessAssignment(assignmentFile, out _);
+            Context.Writer.WriteObject(_PolicyAssignmentHelper.ProcessAssignment(assignmentFile, out var context), true);
+            Context.Writer.WriteObject(context.GenerateBaseline(), false);
         }
     }
 }

--- a/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentPipelineBuilder.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PolicyAssignmentPipelineBuilder.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-
 using System;
 using PSRule.Rules.Azure.Configuration;
 using PSRule.Rules.Azure.Pipeline.Output;
@@ -18,11 +17,18 @@ namespace PSRule.Rules.Azure.Pipeline
         /// </summary>
         /// <param name="passThru">Enable pass-through.</param>
         void PassThru(bool passThru);
+
+        /// <summary>
+        /// Determines if policy definitions that duplicate existing built-in rules are exported.
+        /// </summary>
+        /// <param name="keepDuplicates">Enable exporting duplicates.</param>
+        void KeepDuplicates(bool keepDuplicates);
     }
 
     internal sealed class PolicyAssignmentPipelineBuilder : PipelineBuilderBase, IPolicyAssignmentPipelineBuilder
     {
         private bool _PassThru;
+        private bool _KeepDuplicates;
         private const string OUTPUTFILE_PREFIX = "definitions-";
         private const string OUTPUTFILE_EXTENSION = ".Rule.jsonc";
         private const string ASSIGNMENTNAME_PREFIX = "export-";
@@ -64,6 +70,12 @@ namespace PSRule.Rules.Azure.Pipeline
             _PassThru = passThru;
         }
 
+        /// <inheritdoc/>
+        public void KeepDuplicates(bool keepDuplicates)
+        {
+            _KeepDuplicates = keepDuplicates;
+        }
+
         protected override PipelineWriter GetOutput()
         {
             // Redirect to file instead
@@ -87,7 +99,7 @@ namespace PSRule.Rules.Azure.Pipeline
         /// <inheritdoc/>
         public override IPipeline Build()
         {
-            return new PolicyAssignmentPipeline(PrepareContext());
+            return new PolicyAssignmentPipeline(PrepareContext(), _KeepDuplicates);
         }
     }
 }

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
@@ -367,11 +367,47 @@ namespace PSRule.Rules.Azure.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Policy definition has been ignored based on configuration: {0}.
+        /// </summary>
+        internal static string PolicyIgnoreConfigured {
+            get {
+                return ResourceManager.GetString("PolicyIgnoreConfigured", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Policy definition has been ignored because it is disabled: {0}.
+        /// </summary>
+        internal static string PolicyIgnoreDisabled {
+            get {
+                return ResourceManager.GetString("PolicyIgnoreDisabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Policy definition has been ignored because a similar built-in rule already exists ({1}): {0}.
+        /// </summary>
+        internal static string PolicyIgnoreDuplicate {
+            get {
+                return ResourceManager.GetString("PolicyIgnoreDuplicate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to the policy ignore content..
         /// </summary>
         internal static string PolicyIgnoreInvalid {
             get {
                 return ResourceManager.GetString("PolicyIgnoreInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Policy definition has been ignored because it is not applicable to Infrastructure as Code: {0}.
+        /// </summary>
+        internal static string PolicyIgnoreNotApplicable {
+            get {
+                return ResourceManager.GetString("PolicyIgnoreNotApplicable", resourceCulture);
             }
         }
         

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
@@ -226,8 +226,20 @@
     <value>The template file '{0}' must be within the current working directory.</value>
     <comment>Occurs when the template file is outside of the current working path.</comment>
   </data>
+  <data name="PolicyIgnoreConfigured" xml:space="preserve">
+    <value>Policy definition has been ignored based on configuration: {0}</value>
+  </data>
+  <data name="PolicyIgnoreDisabled" xml:space="preserve">
+    <value>Policy definition has been ignored because it is disabled: {0}</value>
+  </data>
+  <data name="PolicyIgnoreDuplicate" xml:space="preserve">
+    <value>Policy definition has been ignored because a similar built-in rule already exists ({1}): {0}</value>
+  </data>
   <data name="PolicyIgnoreInvalid" xml:space="preserve">
     <value>Failed to the policy ignore content.</value>
+  </data>
+  <data name="PolicyIgnoreNotApplicable" xml:space="preserve">
+    <value>Policy definition has been ignored because it is not applicable to Infrastructure as Code: {0}</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
     <value>The language expression property '{0}' doesn't exist.</value>

--- a/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
@@ -573,7 +573,7 @@ Describe 'Export-AzPolicyAssignmentRuleData' -Tag 'Cmdlet', 'Export-AzPolicyAssi
         $filename = Split-Path -Path $result.FullName -Leaf;
         $filename | Should -BeExactly "definitions-$Name.Rule.jsonc";
         $resultJson = ((Get-Content -Path $result.FullName) -replace '^\s*//.*') | ConvertFrom-Json;
-        $compressedResult = $resultJson | ConvertTo-Json -Depth 100 -Compress;
+        $compressedResult = $resultJson[0] | ConvertTo-Json -Depth 100 -Compress;
         $compressedExpected = $jsonRulesData[$Index] | ConvertTo-Json -Depth 100 -Compress;
         $compressedResult | Should -BeExactly $compressedExpected;
     }
@@ -586,7 +586,7 @@ Describe 'Export-AzPolicyAssignmentRuleData' -Tag 'Cmdlet', 'Export-AzPolicyAssi
         $filename = Split-Path -Path $result.FullName -Leaf;
         $filename | Should -BeExactly "definitions-test12.Rule.jsonc";
         $resultJson = ((Get-Content -Path $result.FullName) -replace '^\s*//.*') | ConvertFrom-Json;
-        $compressedResult = $resultJson | ConvertTo-Json -Depth 100 -Compress;
+        $compressedResult = $resultJson[0] | ConvertTo-Json -Depth 100 -Compress;
         $compressedExpected = $jsonRulesPrefixData | ConvertTo-Json -Depth 100 -Compress;
         $compressedResult | Should -BeExactly $compressedExpected;
     }

--- a/tests/PSRule.Rules.Azure.Tests/PolicyBaselineConverterTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/PolicyBaselineConverterTests.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+using PSRule.Rules.Azure.Data.Policy;
+using Xunit;
+
+namespace PSRule.Rules.Azure
+{
+    public sealed class PolicyBaselineConverterTests
+    {
+        [Fact]
+        public void WriteJson()
+        {
+            var baseline = new PolicyBaseline("Baseline1", "Generated automatically when exporting Azure Policy rules.", new string[] { "Policy1" }, new string[] { "Rule1" });
+            var json = JsonConvert.SerializeObject(baseline);
+            Assert.Equal(@"{/*Synopsis: Generated automatically when exporting Azure Policy rules.*/""apiVersion"":""github.com/microsoft/PSRule/v1"",""kind"":""Baseline"",""metadata"":{""name"":""Baseline1""},""spec"":{""rule"":{""include"":[""Policy1"",""Rule1""]}}}", json);
+        }
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesData.jsonc
+++ b/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesData.jsonc
@@ -33,13 +33,13 @@
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "Rule",
     "metadata": {
-      "name": "Azure.Policy.d49c9ce3b804",
+      "name": "Azure.Policy.dda024fdd4b3",
       "displayName": "Deploy Log Analytics extension for Linux VMs",
       "tags": {
         "Azure.Policy/category": "Monitoring"
       },
       "annotations": {
-        "Azure.Policy/id": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
+        "Azure.Policy/id": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000002",
         "Azure.Policy/version": "2.0.1"
       }
     },
@@ -332,13 +332,13 @@
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "Rule",
     "metadata": {
-      "name": "Azure.Policy.eeb7e34479ef",
+      "name": "Azure.Policy.d56db8a16bcd",
       "displayName": "FunctionAppPullFromSpecifiedRegistry",
       "tags": {
         "Azure.Policy/category": "App Service"
       },
       "annotations": {
-        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/0000000000-0000-0000-0000-000000000000",
+        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/0000000000-0000-0000-0000-000000000003",
         "Azure.Policy/version": "1.0.0"
       }
     },
@@ -390,10 +390,10 @@
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "Rule",
     "metadata": {
-      "name": "Azure.Policy.48eab4644919",
+      "name": "Azure.Policy.5236dec1a570",
       "displayName": "DisableLBRuleSNAT",
       "annotations": {
-        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000004"
       }
     },
     "spec": {
@@ -421,10 +421,10 @@
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "Rule",
     "metadata": {
-      "name": "Azure.Policy.dd003b6a0803",
+      "name": "Azure.Policy.956f4a31128a",
       "displayName": "EnsureAtleastOneLBRule",
       "annotations": {
-        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000005"
       }
     },
     "spec": {
@@ -447,10 +447,10 @@
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "Rule",
     "metadata": {
-      "name": "Azure.Policy.6ce831b6b744",
+      "name": "Azure.Policy.f95588f22a92",
       "displayName": "UniqueDescriptionNSG",
       "annotations": {
-        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000006"
       }
     },
     "spec": {
@@ -478,10 +478,10 @@
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "Rule",
     "metadata": {
-      "name": "Azure.Policy.09175cf78e7c",
+      "name": "Azure.Policy.9aefa39d26cc",
       "displayName": "DenyNSGRDPInboundPort",
       "annotations": {
-        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000007"
       }
     },
     "spec": {
@@ -517,10 +517,10 @@
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "Rule",
     "metadata": {
-      "name": "Azure.Policy.9b51258eff45",
+      "name": "Azure.Policy.2d46ae1952d5",
       "displayName": "DenyPortsNSG",
       "annotations": {
-        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000008"
       }
     },
     "spec": {
@@ -603,10 +603,10 @@
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "Rule",
     "metadata": {
-      "name": "Azure.Policy.b54abd1594e6",
+      "name": "Azure.Policy.eac8effcedc0",
       "displayName": "PreventSubnetsWithoutNSG",
       "annotations": {
-        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000009"
       }
     },
     "spec": {
@@ -677,10 +677,10 @@
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "Rule",
     "metadata": {
-      "name": "Azure.Policy.fe294bf42b80",
+      "name": "Azure.Policy.6e7a9b50e524",
       "displayName": "DenyPrivateEndpointSpecificSubnet",
       "annotations": {
-        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "Azure.Policy/id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000010"
       }
     },
     "spec": {
@@ -723,13 +723,13 @@
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "Rule",
     "metadata": {
-      "name": "Azure.Policy.237646e7bc12",
+      "name": "Azure.Policy.55eedf5a41fd",
       "displayName": "View and configure system diagnostic data",
       "tags": {
         "Azure.Policy/category": "Regulatory Compliance"
       },
       "annotations": {
-        "Azure.Policy/id": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
+        "Azure.Policy/id": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000011-A",
         "Azure.Policy/version": "1.0.0"
       }
     },
@@ -744,6 +744,61 @@
       "condition": {
         "value": "Manual",
         "equals": false
+      }
+    }
+  },
+  {
+    // Synopsis: View and configure system diagnostic data
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Rule",
+    "metadata": {
+      "name": "Azure.Policy.1cc127cf387a",
+      "displayName": "View and configure system diagnostic data",
+      "tags": {
+        "Azure.Policy/category": "Regulatory Compliance"
+      },
+      "annotations": {
+        "Azure.Policy/id": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000011-B",
+        "Azure.Policy/version": "1.0.0"
+      }
+    },
+    "spec": {
+      "recommend": "View and configure system diagnostic data",
+      "type": [
+        "Microsoft.Resources/subscriptions"
+      ],
+      "with": [
+        "PSRule.Rules.Azure\\Azure.Policy.All"
+      ],
+      "condition": {
+        "value": "Manual",
+        "equals": false
+      }
+    }
+  },
+  {
+    // Synopsis: Generated automatically when exporting Azure Policy rules.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Baseline",
+    "metadata": {
+      "name": "Azure.PolicyBaseline.All"
+    },
+    "spec": {
+      "rule": {
+        "include": [
+          "Azure.Policy.65db1c629a22",
+          "Azure.Policy.dda024fdd4b3",
+          "Azure.Policy.d56db8a16bcd",
+          "Azure.Policy.5236dec1a570",
+          "Azure.Policy.956f4a31128a",
+          "Azure.Policy.f95588f22a92",
+          "Azure.Policy.9aefa39d26cc",
+          "Azure.Policy.2d46ae1952d5",
+          "Azure.Policy.eac8effcedc0",
+          "Azure.Policy.6e7a9b50e524",
+          "Azure.Policy.55eedf5a41fd",
+          "Azure.Policy.1cc127cf387a"
+        ]
       }
     }
   }

--- a/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesPrefixData.jsonc
+++ b/tests/PSRule.Rules.Azure.Tests/emittedJsonRulesPrefixData.jsonc
@@ -4,13 +4,13 @@
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "Rule",
     "metadata": {
-      "name": "AzureCustomPrefix.Policy.61bca30d0de3",
+      "name": "AzureCustomPrefix.Policy.6546bdb3e190",
       "displayName": "Allowed locations",
       "tags": {
         "Azure.Policy/category": "General"
       },
       "annotations": {
-        "Azure.Policy/id": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
+        "Azure.Policy/id": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000012",
         "Azure.Policy/version": "1.0.0"
       }
     },

--- a/tests/PSRule.Rules.Azure.Tests/test.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test.assignment.json
@@ -1,102 +1,101 @@
 [
-    {
-      "Identity": null,
-      "Location": null,
-      "Name": "000000000000000000000000",
-      "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PolicyRG/providers/Microsoft.Authorization/policyAssignments/000000000000000000000000",
-      "ResourceName": "000000000000000000000000",
-      "ResourceGroupName": "PolicyRG",
-      "ResourceType": "Microsoft.Authorization/policyAssignments",
-      "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-      "Sku": null,
-      "PolicyAssignmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PolicyRG/providers/Microsoft.Authorization/policyAssignments/000000000000000000000000",
-      "Properties": {
-        "Scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PolicyRG",
-        "NotScopes": [],
-        "DisplayName": "Deny Storage Account Not Using Minumum TLS version",
-        "Description": null,
-        "Metadata": {
-          "assignedBy": "Armaan Dhaliwal-McLeod",
-          "parameterScopes": {},
-          "createdBy": "00000000-0000-0000-0000-000000000000",
-          "createdOn": "2022-03-22T12:58:35.4594114Z",
-          "updatedBy": null,
-          "updatedOn": null
-        },
-        "EnforcementMode": 0,
-        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/Deny-Storage-Account-Not-Using-Minimum-TLS-Version",
-        "Parameters": {},
-        "NonComplianceMessages": []
+  {
+    "Identity": null,
+    "Location": null,
+    "Name": "000000000000000000000000",
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PolicyRG/providers/Microsoft.Authorization/policyAssignments/000000000000000000000000",
+    "ResourceName": "000000000000000000000000",
+    "ResourceGroupName": "PolicyRG",
+    "ResourceType": "Microsoft.Authorization/policyAssignments",
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "Sku": null,
+    "PolicyAssignmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PolicyRG/providers/Microsoft.Authorization/policyAssignments/000000000000000000000000",
+    "Properties": {
+      "Scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PolicyRG",
+      "NotScopes": [],
+      "DisplayName": "Deny Storage Account Not Using Minumum TLS version",
+      "Description": null,
+      "Metadata": {
+        "assignedBy": "Armaan Dhaliwal-McLeod",
+        "parameterScopes": {},
+        "createdBy": "00000000-0000-0000-0000-000000000000",
+        "createdOn": "2022-03-22T12:58:35.4594114Z",
+        "updatedBy": null,
+        "updatedOn": null
       },
-      "PolicyDefinitions": [
-        {
-          "Name": "Deny-Storage-Account-Not-Using-TLS1-2",
-          "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/Deny-Storage-Account-Not-Using-Minimum-TLS-Version",
-          "ResourceName": "Deny-Storage-Account-Not-Using-TLS1-2",
-          "ResourceType": "Microsoft.Authorization/policyDefinitions",
-          "SubscriptionId": "00000000-0000-0000-0000-000000000000",
-          "Properties": {
-            "Description": "Minmum TLS version must be used on Storage accounts",
-            "DisplayName": "Deny Storage Account Not Using Minumum TLS version",
-            "Metadata": {
-              "version": "1.0.0",
-              "category": "Storage",
-              "createdBy": "00000000-0000-0000-0000-000000000000",
-              "createdOn": "2021-06-07T03:21:16.6955366Z",
-              "updatedBy": "00000000-0000-0000-0000-000000000000",
-              "updatedOn": "2022-03-22T12:58:04.8841964Z"
-            },
-            "Mode": "Indexed",
-            "Parameters": {
-              "effect": {
-                "type": "String",
-                "metadata": {
-                  "displayName": "Effect",
-                  "description": "Enable or disable the execution of the policy"
-                },
-                "allowedValues": [
-                  "Audit",
-                  "Deny",
-                  "Disabled"
-                ],
-                "defaultValue": "Deny"
-              },
-              "minimumTlsVersion": {
-                "type": "String",
-                "metadata": {
-                  "displayName": "TLS Version",
-                  "description": "Minimum TLS Version Required for Storage Accounts"
-                },
-                "allowedValues": [
-                  "TLS1_0",
-                  "TLS1_1",
-                  "TLS1_2"
-                ],
-                "defaultValue": "TLS1_2"
-              }
-            },
-            "PolicyRule": {
-              "if": {
-                "allOf": [
-                  {
-                    "field": "type",
-                    "equals": "Microsoft.Storage/storageAccounts"
-                  },
-                  {
-                    "field": "Microsoft.Storage/storageAccounts/minimumTlsVersion",
-                    "notEquals": "[parameters('minimumTlsVersion')]"
-                  }
-                ]
-              },
-              "then": {
-                "effect": "[parameters('effect')]"
-              }
-            },
-            "PolicyType": 1
+      "EnforcementMode": 0,
+      "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/Deny-Storage-Account-Not-Using-Minimum-TLS-Version",
+      "Parameters": {},
+      "NonComplianceMessages": []
+    },
+    "PolicyDefinitions": [
+      {
+        "Name": "Deny-Storage-Account-Not-Using-TLS1-2",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/Deny-Storage-Account-Not-Using-Minimum-TLS-Version",
+        "ResourceName": "Deny-Storage-Account-Not-Using-TLS1-2",
+        "ResourceType": "Microsoft.Authorization/policyDefinitions",
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "Properties": {
+          "Description": "Minmum TLS version must be used on Storage accounts",
+          "DisplayName": "Deny Storage Account Not Using Minumum TLS version",
+          "Metadata": {
+            "version": "1.0.0",
+            "category": "Storage",
+            "createdBy": "00000000-0000-0000-0000-000000000000",
+            "createdOn": "2021-06-07T03:21:16.6955366Z",
+            "updatedBy": "00000000-0000-0000-0000-000000000000",
+            "updatedOn": "2022-03-22T12:58:04.8841964Z"
           },
-          "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/Deny-Storage-Account-Not-Using-Minimum-TLS-Version"
-        }
-      ]
-    }
-  ]
-  
+          "Mode": "Indexed",
+          "Parameters": {
+            "effect": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Effect",
+                "description": "Enable or disable the execution of the policy"
+              },
+              "allowedValues": [
+                "Audit",
+                "Deny",
+                "Disabled"
+              ],
+              "defaultValue": "Deny"
+            },
+            "minimumTlsVersion": {
+              "type": "String",
+              "metadata": {
+                "displayName": "TLS Version",
+                "description": "Minimum TLS Version Required for Storage Accounts"
+              },
+              "allowedValues": [
+                "TLS1_0",
+                "TLS1_1",
+                "TLS1_2"
+              ],
+              "defaultValue": "TLS1_2"
+            }
+          },
+          "PolicyRule": {
+            "if": {
+              "allOf": [
+                {
+                  "field": "type",
+                  "equals": "Microsoft.Storage/storageAccounts"
+                },
+                {
+                  "field": "Microsoft.Storage/storageAccounts/minimumTlsVersion",
+                  "notEquals": "[parameters('minimumTlsVersion')]"
+                }
+              ]
+            },
+            "then": {
+              "effect": "[parameters('effect')]"
+            }
+          },
+          "PolicyType": 1
+        },
+        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/Deny-Storage-Account-Not-Using-Minimum-TLS-Version"
+      }
+    ]
+  }
+]

--- a/tests/PSRule.Rules.Azure.Tests/test10.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test10.assignment.json
@@ -40,9 +40,9 @@
     },
     "PolicyDefinitions": [
       {
-        "Name": "00000000-0000-0000-0000-000000000000",
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
-        "ResourceName": "00000000-0000-0000-0000-000000000000",
+        "Name": "00000000-0000-0000-0000-000000000010",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000010",
+        "ResourceName": "00000000-0000-0000-0000-000000000010",
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
         "Properties": {
@@ -100,7 +100,7 @@
           },
           "PolicyType": 1
         },
-        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000010"
       }
     ]
   }

--- a/tests/PSRule.Rules.Azure.Tests/test11.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test11.assignment.json
@@ -30,9 +30,9 @@
     },
     "PolicyDefinitions": [
       {
-        "Name": "00000000-0000-0000-0000-000000000000",
-        "ResourceId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
-        "ResourceName": "00000000-0000-0000-0000-000000000000",
+        "Name": "00000000-0000-0000-0000-000000000011-A",
+        "ResourceId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000011-A",
+        "ResourceName": "00000000-0000-0000-0000-000000000011-A",
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": null,
         "Properties": {
@@ -71,12 +71,12 @@
           },
           "PolicyType": 2
         },
-        "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000011-A"
       },
       {
-        "Name": "00000000-0000-0000-0000-000000000000",
-        "ResourceId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
-        "ResourceName": "00000000-0000-0000-0000-000000000000",
+        "Name": "00000000-0000-0000-0000-000000000011-B",
+        "ResourceId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000011-B",
+        "ResourceName": "00000000-0000-0000-0000-000000000011-B",
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": null,
         "Properties": {
@@ -115,7 +115,7 @@
           },
           "PolicyType": 2
         },
-        "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000011-B"
       }
     ]
   }

--- a/tests/PSRule.Rules.Azure.Tests/test12.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test12.assignment.json
@@ -39,9 +39,9 @@
     },
     "PolicyDefinitions": [
       {
-        "Name": "00000000-0000-0000-0000-000000000000",
-        "ResourceId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
-        "ResourceName": "00000000-0000-0000-0000-000000000000",
+        "Name": "00000000-0000-0000-0000-000000000012",
+        "ResourceId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000012",
+        "ResourceName": "00000000-0000-0000-0000-000000000012",
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": null,
         "Properties": {
@@ -85,7 +85,7 @@
           },
           "PolicyType": 2
         },
-        "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000012"
       }
     ]
   }

--- a/tests/PSRule.Rules.Azure.Tests/test2.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test2.assignment.json
@@ -46,9 +46,9 @@
     },
     "PolicyDefinitions": [
       {
-        "Name": "00000000-0000-0000-0000-000000000000",
-        "ResourceId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
-        "ResourceName": "00000000-0000-0000-0000-000000000000",
+        "Name": "00000000-0000-0000-0000-000000000002",
+        "ResourceId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000002",
+        "ResourceName": "00000000-0000-0000-0000-000000000002",
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": null,
         "Properties": {
@@ -426,7 +426,7 @@
           },
           "PolicyType": 2
         },
-        "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000002"
       }
     ]
   }

--- a/tests/PSRule.Rules.Azure.Tests/test3.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test3.assignment.json
@@ -39,9 +39,9 @@
     },
     "PolicyDefinitions": [
       {
-        "Name": "00000000-0000-0000-0000-000000000000",
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/0000000000-0000-0000-0000-000000000000",
-        "ResourceName": "0000000000-0000-0000-0000-000000000000",
+        "Name": "00000000-0000-0000-0000-000000000003",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/0000000000-0000-0000-0000-000000000003",
+        "ResourceName": "0000000000-0000-0000-0000-000000000003",
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
         "Properties": {
@@ -174,7 +174,7 @@
           },
           "PolicyType": 1
         },
-        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/0000000000-0000-0000-0000-000000000000"
+        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/0000000000-0000-0000-0000-000000000003"
       }
     ]
   }

--- a/tests/PSRule.Rules.Azure.Tests/test4.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test4.assignment.json
@@ -30,9 +30,9 @@
     },
     "PolicyDefinitions": [
       {
-        "Name": "00000000-0000-0000-0000-000000000000",
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
-        "ResourceName": "00000000-0000-0000-0000-000000000000",
+        "Name": "00000000-0000-0000-0000-000000000004",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000004",
+        "ResourceName": "00000000-0000-0000-0000-000000000004",
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
         "Properties": {
@@ -71,7 +71,7 @@
           },
           "PolicyType": 1
         },
-        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000004"
       }
     ]
   }

--- a/tests/PSRule.Rules.Azure.Tests/test5.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test5.assignment.json
@@ -30,9 +30,9 @@
     },
     "PolicyDefinitions": [
       {
-        "Name": "00000000-0000-0000-0000-000000000000",
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
-        "ResourceName": "00000000-0000-0000-0000-000000000000",
+        "Name": "00000000-0000-0000-0000-000000000005",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000005",
+        "ResourceName": "00000000-0000-0000-0000-000000000005",
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
         "Properties": {
@@ -67,7 +67,7 @@
           },
           "PolicyType": 1
         },
-        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000005"
       }
     ]
   }

--- a/tests/PSRule.Rules.Azure.Tests/test6.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test6.assignment.json
@@ -30,9 +30,9 @@
     },
     "PolicyDefinitions": [
       {
-        "Name": "00000000-0000-0000-0000-000000000000",
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
-        "ResourceName": "00000000-0000-0000-0000-000000000000",
+        "Name": "00000000-0000-0000-0000-000000000006",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000006",
+        "ResourceName": "00000000-0000-0000-0000-000000000006",
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
         "Properties": {
@@ -71,7 +71,7 @@
           },
           "PolicyType": 1
         },
-        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000006"
       }
     ]
   }

--- a/tests/PSRule.Rules.Azure.Tests/test7.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test7.assignment.json
@@ -30,9 +30,9 @@
     },
     "PolicyDefinitions": [
       {
-        "Name": "00000000-0000-0000-0000-000000000000",
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
-        "ResourceName": "00000000-0000-0000-0000-000000000000",
+        "Name": "00000000-0000-0000-0000-000000000007",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000007",
+        "ResourceName": "00000000-0000-0000-0000-000000000007",
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
         "Properties": {
@@ -92,7 +92,7 @@
           },
           "PolicyType": 1
         },
-        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000007"
       }
     ]
   }

--- a/tests/PSRule.Rules.Azure.Tests/test8.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test8.assignment.json
@@ -30,9 +30,9 @@
     },
     "PolicyDefinitions": [
       {
-        "Name": "00000000-0000-0000-0000-000000000000",
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
-        "ResourceName": "00000000-0000-0000-0000-000000000000",
+        "Name": "00000000-0000-0000-0000-000000000008",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000008",
+        "ResourceName": "00000000-0000-0000-0000-000000000008",
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
         "Properties": {
@@ -117,7 +117,7 @@
           },
           "PolicyType": 1
         },
-        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000008"
       }
     ]
   }

--- a/tests/PSRule.Rules.Azure.Tests/test9.assignment.json
+++ b/tests/PSRule.Rules.Azure.Tests/test9.assignment.json
@@ -30,9 +30,9 @@
     },
     "PolicyDefinitions": [
       {
-        "Name": "00000000-0000-0000-0000-000000000000",
-        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
-        "ResourceName": "00000000-0000-0000-0000-000000000000",
+        "Name": "00000000-0000-0000-0000-000000000009",
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000009",
+        "ResourceName": "00000000-0000-0000-0000-000000000009",
         "ResourceType": "Microsoft.Authorization/policyDefinitions",
         "SubscriptionId": "00000000-0000-0000-0000-000000000000",
         "Properties": {
@@ -105,7 +105,7 @@
           },
           "PolicyType": 1
         },
-        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000"
+        "PolicyDefinitionId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000009"
       }
     ]
   }


### PR DESCRIPTION
## PR Summary

- New features:
  - Exporting policy as rules also generates a baseline.
    - A baseline is automatically generated that includes for all rules exported.
      If a policy rule has been replaced by a built-in rule, the baseline will include the built-in rule instead.
    - The baseline is named `<Prefix>.PolicyBaseline.All`. i.e. `Azure.PolicyBaseline.All` by default.
- General improvements:
  - Rules that are ignored during exporting policy as rules are now generate a verbose logs.
    - This is to improve transparency of why rules are not exported.
    - To see details on why a rule is ignored, enable verbose logging with `-Verbose`.
  - Policies that duplicate built-in rules can now be exported by using the `-KeepDuplicates` parameter.

Fixes #2482 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
