### PR TITLE
Pre-release v1.33.0-B0169

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.33.0-B0169 (pre-release)
+
 What's changed since pre-release v1.33.0-B0126:
 
 - New features:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.33.0-B0126:

- New features:
  - Exporting policy as rules also generates a baseline by @BernieWhite.
    [#2482](https://github.com/Azure/PSRule.Rules.Azure/issues/2482)
    - A baseline is automatically generated that includes for all rules exported.
      If a policy rule has been replaced by a built-in rule, the baseline will include the built-in rule instead.
    - The baseline is named `<Prefix>.PolicyBaseline.All`. i.e. `Azure.PolicyBaseline.All` by default.
    - For details see [Policy as rules](./concepts/policy-as-rules.md#generated-baseline).
- General improvements:
  - Rules that are ignored during exporting policy as rules are now generate a verbose logs by @BernieWhite.
    [#2482](https://github.com/Azure/PSRule.Rules.Azure/issues/2482)
    - This is to improve transparency of why rules are not exported.
    - To see details on why a rule is ignored, enable verbose logging with `-Verbose`.
  - Policies that duplicate built-in rules can now be exported by using the `-KeepDuplicates` parameter by @BernieWhite.
    [#2482](https://github.com/Azure/PSRule.Rules.Azure/issues/2482)
    - For details see [Policy as rules](./concepts/policy-as-rules.md#duplicate-policies).
- Bug fixes:
  - Fixed inconclusive result reported for `Azure.ACR.Usage` by @BernieWhite.
    [#2494](https://github.com/Azure/PSRule.Rules.Azure/issues/2494)
  - Fixed export of Front Door resource data is incomplete by @BernieWhite.
    [#2668](https://github.com/Azure/PSRule.Rules.Azure/issues/2668)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
