### PR TITLE
Fixes Azure.AKS.AuthorizedIPs for private cluster #2677

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.33.0:
+
+- Bug fixes:
+  - Fixed `Azure.AKS.AuthorizedIPs` is not valid for a private cluster by @BernieWhite.
+    [#2677](https://github.com/Azure/PSRule.Rules.Azure/issues/2677)
+
 ## v1.33.0
 
 What's changed since v1.32.1:

--- a/docs/en/rules/Azure.AKS.AuthorizedIPs.md
+++ b/docs/en/rules/Azure.AKS.AuthorizedIPs.md
@@ -1,7 +1,8 @@
 ---
+reviewed: 2024-02-07
 severity: Important
 pillar: Security
-category: Design
+category: SE:06 Network controls
 resource: Azure Kubernetes Service
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AKS.AuthorizedIPs/
 ---
@@ -20,20 +21,168 @@ Access to the API server is required by various cluster functions as well as all
 All activities performed against the cluster require authorization.
 To improve cluster security, the API server can be restricted to a limited set of IP address ranges.
 
-Restricting authorized IP addresses for the API server as the following limitations:
+Restricting authorized IP addresses for the API server has the following limitations:
 
 - Requires AKS clusters configured with a Standard Load Balancer SKU.
 - This feature is not compatible with clusters that use Public IP per Node.
+- This feature is not compatible with AKS private clusters.
 
-When configuring this feature you must specify the IP address ranges that will be authorized.
+When configuring this feature, you must specify the IP address ranges that will be authorized.
 To allow only the outbound public IP of the Standard SKU load balancer, use `0.0.0.0/32`.
+
+You should add these ranges to the allow list:
+
+- Include output IP addresses for cluster nodes
+- Any range where administration will connect to the API server, including CI/CD systems, monitoring, and management systems.
 
 ## RECOMMENDATION
 
 Consider restricting network traffic to the API server endpoints to trusted IP addresses.
-Include output IP addresses for cluster nodes and any range where administration will occur from.
 
 ## EXAMPLES
+
+### Configure with Azure template
+
+To deploy clusters that pass this rule:
+
+- Set the `properties.apiServerAccessProfile.authorizedIPRanges` property to a list of authorized IP ranges.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.ContainerService/managedClusters",
+  "apiVersion": "2023-11-01",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "identity": {
+    "type": "UserAssigned",
+    "userAssignedIdentities": {
+      "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')))]": {}
+    }
+  },
+  "properties": {
+    "kubernetesVersion": "[parameters('kubernetesVersion')]",
+    "disableLocalAccounts": true,
+    "enableRBAC": true,
+    "dnsPrefix": "[parameters('dnsPrefix')]",
+    "agentPoolProfiles": "[variables('allPools')]",
+    "aadProfile": {
+      "managed": true,
+      "enableAzureRBAC": true,
+      "adminGroupObjectIDs": "[parameters('clusterAdmins')]",
+      "tenantID": "[subscription().tenantId]"
+    },
+    "networkProfile": {
+      "networkPlugin": "azure",
+      "networkPolicy": "azure",
+      "loadBalancerSku": "standard",
+      "serviceCidr": "[variables('serviceCidr')]",
+      "dnsServiceIP": "[variables('dnsServiceIP')]"
+    },
+    "apiServerAccessProfile": {
+      "authorizedIPRanges": [
+        "0.0.0.0/32"
+      ]
+    },
+    "autoUpgradeProfile": {
+      "upgradeChannel": "stable"
+    },
+    "oidcIssuerProfile": {
+      "enabled": true
+    },
+    "addonProfiles": {
+      "azurepolicy": {
+        "enabled": true
+      },
+      "omsagent": {
+        "enabled": true,
+        "config": {
+          "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
+        }
+      },
+      "azureKeyvaultSecretsProvider": {
+        "enabled": true,
+        "config": {
+          "enableSecretRotation": "true"
+        }
+      }
+    }
+  },
+  "dependsOn": [
+    "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
+  ]
+}
+```
+
+### Configure with Bicep
+
+To deploy resource that pass this rule:
+
+- Set the `properties.apiServerAccessProfile.authorizedIPRanges` property to a list of authorized IP ranges.
+
+For example:
+
+```bicep
+resource cluster 'Microsoft.ContainerService/managedClusters@2023-11-01' = {
+  location: location
+  name: name
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${identity.id}': {}
+    }
+  }
+  properties: {
+    kubernetesVersion: kubernetesVersion
+    disableLocalAccounts: true
+    enableRBAC: true
+    dnsPrefix: dnsPrefix
+    agentPoolProfiles: allPools
+    aadProfile: {
+      managed: true
+      enableAzureRBAC: true
+      adminGroupObjectIDs: clusterAdmins
+      tenantID: subscription().tenantId
+    }
+    networkProfile: {
+      networkPlugin: 'azure'
+      networkPolicy: 'azure'
+      loadBalancerSku: 'standard'
+      serviceCidr: serviceCidr
+      dnsServiceIP: dnsServiceIP
+    }
+    apiServerAccessProfile: {
+      authorizedIPRanges: [
+        '0.0.0.0/32'
+      ]
+    }
+    autoUpgradeProfile: {
+      upgradeChannel: 'stable'
+    }
+    oidcIssuerProfile: {
+      enabled: true
+    }
+    addonProfiles: {
+      azurepolicy: {
+        enabled: true
+      }
+      omsagent: {
+        enabled: true
+        config: {
+          logAnalyticsWorkspaceResourceID: workspaceId
+        }
+      }
+      azureKeyvaultSecretsProvider: {
+        enabled: true
+        config: {
+          enableSecretRotation: 'true'
+        }
+      }
+    }
+  }
+}
+```
 
 ### Configure with Azure CLI
 
@@ -41,9 +190,15 @@ Include output IP addresses for cluster nodes and any range where administration
 az aks update -n '<name>' -g '<resource_group>' --api-server-authorized-ip-ranges '0.0.0.0/32'
 ```
 
+### Configure with Azure PowerShell
+
+```powershell
+Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -ApiServerAccessAuthorizedIpRange '0.0.0.0/32'
+```
+
 ## LINKS
 
-- [Network security](https://learn.microsoft.com/azure/architecture/framework/security/design-network)
-- [Secure access to the API server using authorized IP address ranges in Azure Kubernetes Service (AKS)](https://docs.microsoft.com/azure/aks/api-server-authorized-ip-ranges)
-- [Best practices for cluster security and upgrades in Azure Kubernetes Service (AKS)](https://docs.microsoft.com/azure/aks/operator-best-practices-cluster-security#secure-access-to-the-api-server-and-cluster-nodes)
-- [Azure deployment reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters)
+- [SE:06 Network controls](https://learn.microsoft.com/azure/well-architected/security/networking)
+- [Secure access to the API server using authorized IP address ranges in Azure Kubernetes Service (AKS)](https://learn.microsoft.com/azure/aks/api-server-authorized-ip-ranges)
+- [Best practices for cluster security and upgrades in Azure Kubernetes Service (AKS)](https://learn.microsoft.com/azure/aks/operator-best-practices-cluster-security#secure-access-to-the-api-server-and-cluster-nodes)
+- [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.containerservice/managedclusters)

--- a/docs/examples-aks.json
+++ b/docs/examples-aks.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.21.1.54444",
-      "templateHash": "16848582474653805725"
+      "version": "0.25.3.34343",
+      "templateHash": "15286438717534282301"
     }
   },
   "parameters": {
@@ -178,7 +178,7 @@
     },
     {
       "type": "Microsoft.ContainerService/managedClusters",
-      "apiVersion": "2023-07-01",
+      "apiVersion": "2023-11-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "identity": {
@@ -205,6 +205,11 @@
           "loadBalancerSku": "standard",
           "serviceCidr": "[variables('serviceCidr')]",
           "dnsServiceIP": "[variables('dnsServiceIP')]"
+        },
+        "apiServerAccessProfile": {
+          "authorizedIPRanges": [
+            "0.0.0.0/32"
+          ]
         },
         "autoUpgradeProfile": {
           "upgradeChannel": "stable"
@@ -236,7 +241,7 @@
     },
     {
       "type": "Microsoft.ContainerService/managedClusters",
-      "apiVersion": "2023-07-01",
+      "apiVersion": "2023-11-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "identity": {
@@ -290,6 +295,100 @@
           "loadBalancerSku": "standard",
           "serviceCidr": "[variables('serviceCidr')]",
           "dnsServiceIP": "[variables('dnsServiceIP')]"
+        },
+        "apiServerAccessProfile": {
+          "authorizedIPRanges": [
+            "0.0.0.0/32"
+          ]
+        },
+        "autoUpgradeProfile": {
+          "upgradeChannel": "stable"
+        },
+        "oidcIssuerProfile": {
+          "enabled": true
+        },
+        "addonProfiles": {
+          "azurepolicy": {
+            "enabled": true
+          },
+          "omsagent": {
+            "enabled": true,
+            "config": {
+              "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
+            }
+          },
+          "azureKeyvaultSecretsProvider": {
+            "enabled": true,
+            "config": {
+              "enableSecretRotation": "true"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ContainerService/managedClusters",
+      "apiVersion": "2023-11-01",
+      "name": "[parameters('name')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName')))]": {}
+        }
+      },
+      "properties": {
+        "kubernetesVersion": "[parameters('kubernetesVersion')]",
+        "disableLocalAccounts": true,
+        "enableRBAC": true,
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": [
+          {
+            "name": "system",
+            "osDiskSizeGB": 0,
+            "minCount": 3,
+            "maxCount": 5,
+            "enableAutoScaling": true,
+            "maxPods": 50,
+            "vmSize": "Standard_D4s_v5",
+            "type": "VirtualMachineScaleSets",
+            "vnetSubnetID": "[parameters('clusterSubnetId')]",
+            "mode": "System",
+            "osDiskType": "Ephemeral"
+          },
+          {
+            "name": "user",
+            "osDiskSizeGB": 0,
+            "minCount": 3,
+            "maxCount": 20,
+            "enableAutoScaling": true,
+            "maxPods": 50,
+            "vmSize": "Standard_D4s_v5",
+            "type": "VirtualMachineScaleSets",
+            "vnetSubnetID": "[parameters('clusterSubnetId')]",
+            "mode": "User",
+            "osDiskType": "Ephemeral"
+          }
+        ],
+        "aadProfile": {
+          "managed": true,
+          "enableAzureRBAC": true,
+          "adminGroupObjectIDs": "[parameters('clusterAdmins')]",
+          "tenantID": "[subscription().tenantId]"
+        },
+        "networkProfile": {
+          "networkPlugin": "azure",
+          "networkPolicy": "azure",
+          "loadBalancerSku": "standard",
+          "serviceCidr": "[variables('serviceCidr')]",
+          "dnsServiceIP": "[variables('dnsServiceIP')]"
+        },
+        "apiServerAccessProfile": {
+          "enablePrivateCluster": true,
+          "enablePrivateClusterPublicFQDN": false
         },
         "autoUpgradeProfile": {
           "upgradeChannel": "stable"

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.yaml
@@ -139,10 +139,13 @@ metadata:
     ruleSet: 2021_06
     Azure.WAF/pillar: Security
   labels:
-    Azure.MCSB.v1/control: 'NS-1'
+    Azure.MCSB.v1/control: NS-1
 spec:
   type:
   - Microsoft.ContainerService/managedClusters
+  where:
+    field: properties.apiServerAccessProfile.enablePrivateCluster
+    notEquals: true
   condition:
     field: properties.apiServerAccessProfile.authorizedIPRanges
     greaterOrEquals: 1

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -33,7 +33,7 @@ Describe 'Azure.AKS' -Tag AKS {
                 ErrorAction   = 'Stop'
             }
             $dataPath = Join-Path -Path $here -ChildPath 'Resources.AKS.json';
-            $result = Invoke-PSRule @invokeParams -InputPath $dataPath;
+            $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All;
         }
 
         It 'Azure.AKS.MinNodeCount' {
@@ -274,14 +274,20 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 10;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J', 'cluster-K', 'cluster-L';
+            $ruleResult.Length | Should -Be 9;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D', 'cluster-G', 'cluster-H', 'cluster-I', 'cluster-J', 'cluster-K';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -BeIn 'cluster-F';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' -and $_.TargetType -eq 'Microsoft.ContainerService/managedClusters' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'cluster-L';
         }
 
         It 'Azure.AKS.LocalAccounts' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -1849,6 +1849,10 @@
       },
       "podIdentityProfile": {
         "enabled": true
+      },
+      "apiServerAccessProfile": {
+        "enablePrivateCluster": true,
+        "enablePrivateClusterPublicFQDN": false
       }
     },
     "identity": {


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.AKS.AuthorizedIPs` is not valid for a private cluster.

Fixes #2677

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section

