### PR TITLE
Fixed parent not exists effect #2608

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -37,6 +37,8 @@ What's changed since v1.33.0:
 - Bug fixes:
   - Fixed `Azure.AKS.AuthorizedIPs` is not valid for a private cluster by @BernieWhite.
     [#2677](https://github.com/Azure/PSRule.Rules.Azure/issues/2677)
+  - Fixed generating rule for VM extensions from policy is incorrect by @BernieWhite.
+    [#2608](https://github.com/Azure/PSRule.Rules.Azure/issues/2608)
 
 ## v1.33.0
 

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -38,6 +38,9 @@
     <None Update="Policy.assignment.3.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Policy.assignment.4.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Policy.assignment.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Rules.Azure.Tests/Policy.assignment.4.json
+++ b/tests/PSRule.Rules.Azure.Tests/Policy.assignment.4.json
@@ -1,0 +1,101 @@
+[
+  {
+    "Identity": null,
+    "Location": null,
+    "Name": "assignment.4",
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/assignment.4",
+    "ResourceName": "assignment.4",
+    "ResourceGroupName": null,
+    "ResourceType": "Microsoft.Authorization/policyAssignments",
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "Sku": null,
+    "PolicyAssignmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyAssignments/assignment.4",
+    "Properties": {
+      "Scope": "/subscriptions/00000000-0000-0000-0000-000000000000",
+      "NotScopes": [],
+      "DisplayName": "Virtual machines' Guest Configuration extension should be deployed with system-assigned managed identity",
+      "Description": null,
+      "Metadata": {
+        "assignedBy": "",
+        "parameterScopes": {},
+        "createdBy": "",
+        "createdOn": "",
+        "updatedBy": null,
+        "updatedOn": null
+      },
+      "EnforcementMode": 1,
+      "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/d26f7642-7545-4e18-9b75-8c9bbdee3a9a",
+      "Parameters": {
+        "tagName": {
+          "value": "env"
+        }
+      },
+      "NonComplianceMessages": [
+        {
+          "Message": "Virtual machines' Guest Configuration extension should be deployed with system-assigned managed identity",
+          "PolicyDefinitionReferenceId": null
+        }
+      ]
+    },
+    "PolicyDefinitions": [
+      {
+        "Name": "d26f7642-7545-4e18-9b75-8c9bbdee3a9a",
+        "ResourceId": "/providers/Microsoft.Authorization/policyDefinitions/d26f7642-7545-4e18-9b75-8c9bbdee3a9a",
+        "ResourceName": "d26f7642-7545-4e18-9b75-8c9bbdee3a9a",
+        "ResourceType": "Microsoft.Authorization/policyDefinitions",
+        "SubscriptionId": null,
+        "Properties": {
+          "Description": "The Guest Configuration extension requires a system assigned managed identity. Azure virtual machines in the scope of this policy will be non-compliant when they have the Guest Configuration extension installed but do not have a system assigned managed identity. Learn more at https://aka.ms/gcpol",
+          "DisplayName": "Virtual machines' Guest Configuration extension should be deployed with system-assigned managed identity",
+          "Metadata": {
+            "version": "1.0.1",
+            "category": "Security Center"
+          },
+          "Mode": "Indexed",
+          "Parameters": {
+            "effect": {
+              "type": "String",
+              "metadata": {
+                "displayName": "Effect",
+                "description": "Enable or disable the execution of the policy"
+              },
+              "allowedValues": [
+                "AuditIfNotExists",
+                "Disabled"
+              ],
+              "defaultValue": "AuditIfNotExists"
+            }
+          },
+          "PolicyRule": {
+            "if": {
+              "allOf": [
+                {
+                  "field": "type",
+                  "equals": "Microsoft.Compute/virtualMachines/extensions"
+                },
+                {
+                  "field": "Microsoft.Compute/virtualMachines/extensions/publisher",
+                  "equals": "Microsoft.GuestConfiguration"
+                }
+              ]
+            },
+            "then": {
+              "effect": "[parameters('effect')]",
+              "details": {
+                "type": "Microsoft.Compute/virtualMachines",
+                "name": "[first(split(field('fullName'), '/'))]",
+                "existenceCondition": {
+                  "field": "identity.type",
+                  "contains": "SystemAssigned"
+                }
+              }
+            }
+          },
+          "PolicyType": 2
+        },
+        "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/d26f7642-7545-4e18-9b75-8c9bbdee3a9a"
+      }
+    ],
+    "exemptions": []
+  }
+]


### PR DESCRIPTION
## PR Summary

- Fixed generating rule for VM extensions from policy is incorrect.

Fixes #2608

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
