### PR TITLE
Release v1.33.1

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.33.1
+
 What's changed since v1.33.0:
 
 - Bug fixes:


### PR DESCRIPTION
## PR Summary

What's changed since v1.33.0:

- Bug fixes:
  - Fixed `Azure.AKS.AuthorizedIPs` is not valid for a private cluster by @BernieWhite.
    [#2677](https://github.com/Azure/PSRule.Rules.Azure/issues/2677)
  - Fixed generating rule for VM extensions from policy is incorrect by @BernieWhite.
    [#2608](https://github.com/Azure/PSRule.Rules.Azure/issues/2608)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
