### PR TITLE
Fixed false positive Azure.Resource.AllowedRegions #2687

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.33.1:
+
+- Bug fixes:
+  - Fixed false positive of `Azure.Resource.AllowedRegions` raised during assertion call by @BernieWhite.
+    [#2687](https://github.com/Azure/PSRule.Rules.Azure/issues/2687)
+
 ## v1.33.1
 
 What's changed since v1.33.0:

--- a/docs/en/rules/Azure.Resource.AllowedRegions.md
+++ b/docs/en/rules/Azure.Resource.AllowedRegions.md
@@ -1,8 +1,8 @@
 ---
-reviewed: 2023-09-10
+reviewed: 2024-02-17
 severity: Important
 pillar: Security
-category: Design
+category: SE:01 Security baseline
 resource: All resources
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Resource.AllowedRegions/
 ---
@@ -27,7 +27,7 @@ Some resources, particularly those related to preview services or features, may 
 ## RECOMMENDATION
 
 Consider deploying resources to allowed regions to align with your organizational requirements.
-Also consider using Azure Policy to enforce allowed regions.
+Also consider using Azure Policy to enforce allowed regions at runtime.
 
 ## EXAMPLES
 
@@ -35,7 +35,7 @@ Also consider using Azure Policy to enforce allowed regions.
 
 To deploy resources that pass this rule:
 
-- Set the `location` property to an allowed region. OR
+- Set the `location` property to an allowed region. _OR_
 - Instead of hard coding the location, use a parameter to allow the location to be specified at deployment time.
 
 For example:
@@ -67,7 +67,7 @@ For example:
 
 To deploy resources that pass this rule:
 
-- Set the `location` property to an allowed region. OR
+- Set the `location` property to an allowed region. _OR_
 - Instead of hard coding the location, use a parameter to allow the location to be specified at deployment time.
 
 For example:
@@ -101,6 +101,10 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
 This rule requires one or more allowed regions to be configured.
 By default, all regions are allowed.
 
+### Configuration
+
+<!-- module:config rule AZURE_RESOURCE_ALLOWED_LOCATIONS -->
+
 To configure this rule set the `AZURE_RESOURCE_ALLOWED_LOCATIONS` configuration value to a set of allowed regions.
 
 For example:
@@ -125,6 +129,6 @@ configuration:
 
 ## LINKS
 
-- [Regulatory compliance](https://learn.microsoft.com/azure/well-architected/security/design-regulatory-compliance)
+- [SE:01 Security baseline](https://learn.microsoft.com/azure/well-architected/security/establish-baseline)
 - [Data residency in Azure](https://azure.microsoft.com/explore/global-infrastructure/data-residency/#overview)
 - [Azure geographies](https://azure.microsoft.com/explore/global-infrastructure/geographies/#geographies)

--- a/src/PSRule.Rules.Azure/rules/Azure.Resource.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Resource.Rule.ps1
@@ -17,7 +17,7 @@ Rule 'Azure.Resource.UseTags' -Ref 'AZR-000166' -With 'Azure.Resource.SupportsTa
 Rule 'Azure.Resource.AllowedRegions' -Ref 'AZR-000167' -If { (SupportsRegions) -and $PSRule.TargetType -ne 'Microsoft.Resources/deployments' -and $Assert.HasFieldValue($TargetObject, 'location').Result } -Tag @{ release = 'GA'; ruleSet = '2020_06'; 'Azure.WAF/pillar' = 'Security'; } {
     $context = $PSRule.GetService('Azure.Context');
     $location = $TargetObject.location;
-    $Assert.Create($context.IsAllowedLocation($location), $LocalizedData.LocationNotAllowed, $location);
+    $Assert.Create('location', [bool]$context.IsAllowedLocation($location), $LocalizedData.LocationNotAllowed, @($location));
 }
 
 # Synopsis: Use Resource Group naming requirements

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Resource.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Resource.Tests.ps1
@@ -68,6 +68,8 @@ Describe 'Azure.Resource' -Tag 'Resource' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'registry-B';
+            $ruleResult[0].Reason | Should -BeExactly "Path location: The location 'region-B' is not in the allowed set of resource locations.";
+            $ruleResult[0].Detail.Reason.Path | Should -Be 'location';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -161,6 +163,12 @@ Describe 'Azure.Resource' -Tag 'Resource' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 5;
             $ruleResult.TargetName | Should -BeIn 'route-subnet1', 'route-subnet2', 'nsg-subnet1', 'nsg-subnet2', 'nsg-extra';
+            $ruleResult[0].Reason | Should -BeExactly "Path location: The location 'eastus' is not in the allowed set of resource locations.";
+            $ruleResult[1].Reason | Should -BeExactly "Path location: The location 'eastus' is not in the allowed set of resource locations.";
+            $ruleResult[2].Reason | Should -BeExactly "Path location: The location 'eastus' is not in the allowed set of resource locations.";
+            $ruleResult[3].Reason | Should -BeExactly "Path location: The location 'eastus' is not in the allowed set of resource locations.";
+            $ruleResult[4].Reason | Should -BeExactly "Path location: The location 'eastus' is not in the allowed set of resource locations.";
+            $ruleResult[0..4].Detail.Reason.Path | Should -BeIn @('location');
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });


### PR DESCRIPTION
## PR Summary

- Fixed false positive of `Azure.Resource.AllowedRegions` raised during assertion call.

Fixes #2687 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
