### PR TITLE
Update Azure.LB.Rule.ps1 for PIP Zones Condition

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,7 +32,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
-- Updated rule `Azure.LB.AvailabilityZone` to remove the passing assertion for null or an empty zones list for the property of `properties.frontendIPConfigurations[*].zones`
+- Bug fixes:
+  - Fixed rule `Azure.LB.AvailabilityZone` to remove the passing assertion for null or an empty zones list for the property of `properties.frontendIPConfigurations[*].zones` by @jtracey93.
+    [#2759](https://github.com/Azure/PSRule.Rules.Azure/issues/2759)
 
 ## v1.35.0-B0012 (pre-release)
 

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+- Updated rule `Azure.LB.AvailabilityZone` to remove the passing assertion for null or an empty zones list for the property of `properties.frontendIPConfigurations[*].zones`
+
 ## v1.35.0-B0012 (pre-release)
 
 What's changed since v1.34.2:

--- a/docs/en/rules/Azure.LB.AvailabilityZone.md
+++ b/docs/en/rules/Azure.LB.AvailabilityZone.md
@@ -27,7 +27,7 @@ Consider using zone-redundant load balancers deployed with Standard SKU.
 
 This rule applies when analyzing resources deployed to Azure using *pre-flight* and *in-flight* data.
 
-This rule fails when `"zones"` is constrained to a single(zonal) zone, and passes when set to `["1", "2", "3"]`.
+This rule fails when `"zones"` is constrained to a single(zonal) zone or is not configured, and passes when set to `["1", "2", "3"]`.
 
 ## EXAMPLES
 

--- a/docs/en/rules/Azure.LB.AvailabilityZone.md
+++ b/docs/en/rules/Azure.LB.AvailabilityZone.md
@@ -27,7 +27,7 @@ Consider using zone-redundant load balancers deployed with Standard SKU.
 
 This rule applies when analyzing resources deployed to Azure using *pre-flight* and *in-flight* data.
 
-This rule fails when `"zones"` is constrained to a single(zonal) zone, and passes when set to `null`, `[]` or `["1", "2", "3"]`.
+This rule fails when `"zones"` is constrained to a single(zonal) zone, and passes when set to `["1", "2", "3"]`.
 
 ## EXAMPLES
 

--- a/src/PSRule.Rules.Azure/rules/Azure.LB.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.LB.Rule.ps1
@@ -29,7 +29,6 @@ Rule 'Azure.LB.Probe' -Ref 'AZR-000126' -Type 'Microsoft.Network/loadBalancers' 
 Rule 'Azure.LB.AvailabilityZone' -Ref 'AZR-000127' -Type 'Microsoft.Network/loadBalancers' -If { IsStandardLoadBalancer } -Tag @{ release = 'GA'; ruleSet = '2021_09'; 'Azure.WAF/pillar' = 'Reliability'; } {
     foreach ($ipConfig in $TargetObject.Properties.frontendIPConfigurations) {
         $Assert.AnyOf(
-            $Assert.NullOrEmpty($ipConfig, 'zones'),
             $Assert.SetOf($ipConfig, 'zones', @('1', '2', '3'))
         ).Reason(
             $LocalizedData.LBAvailabilityZone,

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
@@ -1736,7 +1736,10 @@
               }
             ],
             "privateIPAddressVersion": "IPv4"
-          }
+          },
+          "zones": [
+            "3"
+          ]
         }
       ],
       "backendAddressPools": [

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
@@ -1560,7 +1560,12 @@
               }
             ],
             "privateIPAddressVersion": "IPv4"
-          }
+          },
+          "zones": [
+            "1",
+            "2",
+            "3"
+          ]
         }
       ],
       "backendAddressPools": [
@@ -1731,10 +1736,7 @@
               }
             ],
             "privateIPAddressVersion": "IPv4"
-          },
-          "zones": [
-            "3"
-          ]
+          }
         }
       ],
       "backendAddressPools": [

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
@@ -1533,7 +1533,7 @@
   {
     "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes",
     "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/kubernetes",
-    "Location": "region",
+    "Location": "eastus",
     "ManagedBy": null,
     "ResourceName": "kubernetes",
     "Name": "kubernetes",
@@ -1709,7 +1709,7 @@
   {
     "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A",
     "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-A",
-    "Location": "region",
+    "Location": "eastus",
     "ManagedBy": null,
     "ResourceName": "lb-A",
     "Name": "lb-A",
@@ -1880,7 +1880,7 @@
   {
     "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-B",
     "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-B",
-    "Location": "region",
+    "Location": "east US",
     "ManagedBy": null,
     "ResourceName": "lb-B",
     "Name": "lb-B",
@@ -2054,7 +2054,7 @@
   {
     "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-C",
     "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/loadBalancers/lb-C",
-    "Location": "region",
+    "Location": "notRegion",
     "ManagedBy": null,
     "ResourceName": "lb-C",
     "Name": "lb-C",
@@ -2081,12 +2081,7 @@
               }
             ],
             "privateIPAddressVersion": "IPv4"
-          },
-          "zones": [
-            "2",
-            "3",
-            "1"
-          ]
+          }
         }
       ],
       "backendAddressPools": [


### PR DESCRIPTION
## PR Summary

This pull request includes a change to the `Azure.LB.AvailabilityZone` rule in the `Azure.LB.Rule.ps1` file. The change removes the condition that checks if the `zones` property of the `ipConfig` object is null or empty. This means that the rule will now only assert if the `zones` property is a set of '1', '2', '3'.

This is what needs to be true for the LB to be truly zone redundant

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [ ] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
