### PR TITLE
Updated Azure.AppService.NETVersion .NET version #2766

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -34,6 +34,10 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v1.35.0-B0030:
 
+- Updated rules:
+  - Updated `Azure.AppService.NETVersion` to detect out of date .NET versions including .NET 5/6/7 by @BernieWhite.
+    [#2766](https://github.com/Azure/PSRule.Rules.Azure/issues/2766)
+    - Bumped rule set to `2024_03`.
 - General improvements:
   - Quality updates to rule documentation by @BernieWhite.
     [#2570](https://github.com/Azure/PSRule.Rules.Azure/issues/2570)

--- a/docs/en/rules/Azure.AppService.NETVersion.md
+++ b/docs/en/rules/Azure.AppService.NETVersion.md
@@ -1,5 +1,5 @@
 ---
-reviewed: 2024-03-19
+reviewed: 2024-03-21
 severity: Important
 pillar: Security
 category: SE:02 Secured development lifecycle
@@ -36,7 +36,7 @@ To deploy App Services that pass this rule:
   - Set the `properties.siteConfig.netFrameworkVersion` property to `v4.0` or `v8.0`.
 - For Linux-based plans:
   - Set the `properties.siteConfig.linuxFxVersion` property to `DOTNET|8.0`.
-    .NET Framework is not support on Linux-based plans.
+    .NET Framework is not supported on Linux-based plans.
 
 For example:
 
@@ -83,7 +83,7 @@ To deploy App Services that pass this rule:
   - Set the `properties.siteConfig.netFrameworkVersion` property to `v4.0` or `v8.0`.
 - For Linux-based plans:
   - Set the `properties.siteConfig.linuxFxVersion` property to `DOTNET|8.0`.
-    .NET Framework is not support on Linux-based plans.
+    .NET Framework is not supported on Linux-based plans.
 
 For example:
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
@@ -150,6 +150,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
+            $ruleResult[0].Reason | Should -BeExactly "Path resources[0].properties.netFrameworkVersion: The version '3.5.-1' does not match the constraint '4.0 || >=8.0'.";
+            $ruleResult[1].Reason | Should -BeExactly "Path resources[0].properties.netFrameworkVersion: The version '3.5.-1' does not match the constraint '4.0 || >=8.0'.";
             $ruleResult.TargetName | Should -Be 'site-B', 'site-B/staging';
             $ruleResult.Detail.Reason.Path | Should -BeIn 'properties.siteConfig.netFrameworkVersion', 'resources[0].properties.netFrameworkVersion';
 
@@ -301,8 +303,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c', 'app-d', 'app-e';
         }
 
         It 'Azure.AppService.RemoteDebug' {
@@ -315,8 +317,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c', 'app-d', 'app-e';
         }
 
         It 'Azure.AppService.NETVersion' {
@@ -324,13 +326,18 @@ Describe 'Azure.AppService' -Tag 'AppService' {
 
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
-            $ruleResult | Should -BeNullOrEmpty;
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            # $ruleResult.Length | Should -Be 3;
+            # $ruleResult[0].Reason | Should -BeExactly "Path properties.siteConfig.netFrameworkVersion: The version '6.0.-1' does not match the constraint '4.0 || >=8.0'.";
+            # $ruleResult[1].Reason | Should -BeExactly "Path properties.siteConfig.netFrameworkVersion: The version '6.0.-1' does not match the constraint '4.0 || >=8.0'.";
+            # $ruleResult[2].Reason | Should -BeExactly "Path properties.siteConfig.netFrameworkVersion: The version '6.0.-1' does not match the constraint '4.0 || >=8.0'.";
+            $ruleResult.TargetName | Should -BeIn 'app-c', 'app-d';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c';
+            # $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-e';
         }
 
         It 'Azure.AppService.PHPVersion' {
@@ -343,8 +350,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c', 'app-d', 'app-e';
         }
 
         It 'Azure.AppService.AlwaysOn' {
@@ -357,8 +364,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c', 'app-d', 'app-e';
         }
 
         It 'Azure.AppService.HTTP2' {
@@ -371,8 +378,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'app-a', 'app-b', 'app-c', 'app-d', 'app-e';
         }
 
         It 'Azure.AppService.ManagedIdentity' {
@@ -386,8 +393,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'app-b', 'app-c';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'app-b', 'app-c', 'app-d', 'app-e';
         }
 
         It 'Azure.AppService.WebProbe' {
@@ -401,8 +408,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'app-b', 'app-c';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'app-b', 'app-c', 'app-d', 'app-e';
         }
 
         It 'Azure.AppService.WebProbePath' {
@@ -416,8 +423,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'app-c';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'app-c', 'app-d', 'app-e';
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
@@ -73,28 +73,28 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2020_12' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 176;
+            $filteredResult.Length | Should -Be 175;
         }
 
         It 'With Azure.GA_2021_03' {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2021_03' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 191;
+            $filteredResult.Length | Should -Be 190;
         }
 
         It 'With Azure.GA_2021_06' {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2021_06' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 205;
+            $filteredResult.Length | Should -Be 204;
         }
 
         It 'With Azure.GA_2021_09' {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2021_09' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 224;
+            $filteredResult.Length | Should -Be 223;
         }
 
         It 'With Azure.Preview_2021_09' {
@@ -108,7 +108,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2021_12' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 250;
+            $filteredResult.Length | Should -Be 249;
         }
 
         It 'With Azure.Preview_2021_12' {
@@ -122,7 +122,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2022_03' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 266;
+            $filteredResult.Length | Should -Be 265;
         }
 
         It 'With Azure.Preview_2022_03' {
@@ -136,7 +136,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2022_06' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 270;
+            $filteredResult.Length | Should -Be 269;
         }
 
         It 'With Azure.Preview_2022_06' {
@@ -150,7 +150,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2022_09' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 301;
+            $filteredResult.Length | Should -Be 300;
         }
 
         It 'With Azure.Preview_2022_09' {
@@ -164,7 +164,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2022_12' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 339;
+            $filteredResult.Length | Should -Be 338;
         }
 
         It 'With Azure.Preview_2022_12' {
@@ -178,7 +178,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2023_03' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 359;
+            $filteredResult.Length | Should -Be 358;
         }
 
         It 'With Azure.Preview_2023_03' {
@@ -192,7 +192,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2023_06' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 374;
+            $filteredResult.Length | Should -Be 373;
         }
 
         It 'With Azure.Preview_2023_06' {
@@ -206,7 +206,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2023_09' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 385;
+            $filteredResult.Length | Should -Be 384;
         }
 
         It 'With Azure.Preview_2023_09' {
@@ -220,7 +220,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2023_12' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 394;
+            $filteredResult.Length | Should -Be 393;
         }
 
         It 'With Azure.Preview_2023_12' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AppService.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AppService.Template.json
@@ -92,7 +92,9 @@
         "planName3": "plan-c",
         "planName4": "plan-d",
         "appName2": "app-b",
-        "appName3": "app-c"
+        "appName3": "app-c",
+        "appName4": "app-d",
+        "appName5": "app-e"
     },
     "resources": [
         {
@@ -322,6 +324,68 @@
             "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
             "apiVersion": "2018-11-30",
             "location": "[parameters('location')]"
+        },
+        {
+            "apiVersion": "2022-03-01",
+            "name": "[variables('appName4')]",
+            "type": "Microsoft.Web/sites",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('tags')]",
+            "identity": {
+                "type": "SystemAssigned, UserAssigned",
+                "userAssignedIdentities": {
+                    "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('appName3'))]": {}
+                }
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Web/serverfarms/', variables('planName2'))]"
+            ],
+            "properties": {
+                "siteConfig": {
+                    "appSettings": [],
+                    "phpVersion": "OFF",
+                    "netFrameworkVersion": "",
+                    "alwaysOn": "[parameters('alwaysOn')]",
+                    "minTlsVersion": "1.2",
+                    "http20Enabled": true,
+                    "healthCheckPath": "/healthz",
+                    "linuxFxVersion": "DOTNETCORE|6.0"
+                },
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms/', variables('planName2'))]",
+                "clientAffinityEnabled": false,
+                "httpsOnly": true
+            }
+        },
+        {
+            "apiVersion": "2022-03-01",
+            "name": "[variables('appName5')]",
+            "type": "Microsoft.Web/sites",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('tags')]",
+            "identity": {
+                "type": "SystemAssigned, UserAssigned",
+                "userAssignedIdentities": {
+                    "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('appName3'))]": {}
+                }
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Web/serverfarms/', variables('planName2'))]"
+            ],
+            "properties": {
+                "siteConfig": {
+                    "appSettings": [],
+                    "phpVersion": "OFF",
+                    "netFrameworkVersion": "",
+                    "alwaysOn": "[parameters('alwaysOn')]",
+                    "minTlsVersion": "1.2",
+                    "http20Enabled": true,
+                    "healthCheckPath": "/healthz",
+                    "linuxFxVersion": "DOTNETCORE|8.0"
+                },
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms/', variables('planName2'))]",
+                "clientAffinityEnabled": false,
+                "httpsOnly": true
+            }
         }
     ],
     "outputs": {


### PR DESCRIPTION
## PR Summary

- Updated `Azure.AppService.NETVersion` to detect out of date .NET versions including .NET 5/6/7.

Fixes #2766

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
