### PR TITLE
Pre-release v1.35.0-B0055

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.35.0-B0055 (pre-release)
+
 What's changed since pre-release v1.35.0-B0030:
 
 - Updated rules:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.35.0-B0030:

- Updated rules:
  - Updated `Azure.AppService.NETVersion` to detect out of date .NET versions including .NET 5/6/7 by @BernieWhite.
    [#2766](https://github.com/Azure/PSRule.Rules.Azure/issues/2766)
    - Bumped rule set to `2024_03`.
  - Updated `Azure.AppService.PHPVersion` to detect out of date PHP versions before 8.2 by @BernieWhite.
    [#2768](https://github.com/Azure/PSRule.Rules.Azure/issues/2768)
    - Fixed `Azure.AppService.PHPVersion` check fails when phpVersion is null.
    - Bumped rule set to `2024_03`.
  - Updated `Azure.AKS.Version` to use `1.27.9` as the minimum version by @BernieWhite.
    [#2771](https://github.com/Azure/PSRule.Rules.Azure/issues/2771)
- General improvements:
  - Quality updates to rule documentation by @BernieWhite.
    [#2570](https://github.com/Azure/PSRule.Rules.Azure/issues/2570)
  - Additional policies added to default ignore list by @BernieWhite.
    [#1731](https://github.com/Azure/PSRule.Rules.Azure/issues/1731)
- Bug fixes:
  - Fixed failed to expand JObject value with invalid key by @BernieWhite.
    [#2751](https://github.com/Azure/PSRule.Rules.Azure/issues/2751)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
