### PR TITLE
Add AVM/BRM to about.md

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -39,6 +39,7 @@ We also give an quick overview of baselines, handling exceptions, and reporting 
 Several first-party repositories use PSRule for Azure.
 Here's a few you may be familiar with:
 
+- [Azure/bicep-registry-modules](https://aka.ms/brm) - Azure Verified Modules (AVM) (Bicep)
 - [Azure/ResourceModules](https://github.com/Azure/ResourceModules) - Common Azure Resource Modules Library
 - [Azure/ALZ-Bicep](https://github.com/Azure/ALZ-Bicep) - Azure Landing Zones (ALZ)
 - [Azure/AKS-Construction](https://github.com/Azure/AKS-Construction) - AKS Construction


### PR DESCRIPTION
## PR Summary

This pull request includes a minor change to the `docs/about.md` file. The change removes the reference to the `Azure/bicep-registry-modules` repository from the list of first-party repositories that use PSRule for Azure.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [ ] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
