### PR TITLE
Fixed regression when handing ambiguous mock array outputs #2801

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.35.1:
+
+- Bug fixes:
+  - Fixed regression when handing ambiguous mock array outputs by @BernieWhite.
+    [#2801](https://github.com/Azure/PSRule.Rules.Azure/issues/2801)
+
 ## v1.35.1
 
 What's changed since v1.35.0:

--- a/src/PSRule.Rules.Azure/Data/Template/Mocks.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Mocks.cs
@@ -215,7 +215,7 @@ namespace PSRule.Rules.Azure.Data.Template
 
             public JToken GetValue(TypePrimitive type)
             {
-                return type == TypePrimitive.Array ? this : null;
+                return type == TypePrimitive.None || type == TypePrimitive.Array ? this : null;
             }
 
             public JToken GetValue(object key)

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -239,6 +239,9 @@
     <None Update="Tests.Bicep.35.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Tests.Bicep.36.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Tests.Bicep.4.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -1101,7 +1101,7 @@ namespace PSRule.Rules.Azure
         [Fact]
         public void ProcessTemplate_WhenIndexIntoMock_ShouldReturnMock()
         {
-            var resources = ProcessTemplate(GetSourcePath("Tests.Bicep.35.json"), null, out _);
+            ProcessTemplate(GetSourcePath("Tests.Bicep.35.json"), null, out _);
         }
 
         /// <summary>
@@ -1114,6 +1114,23 @@ namespace PSRule.Rules.Azure
 
             var actual = resources.FirstOrDefault(r => r["type"].Value<string>() == "Microsoft.Storage/storageAccounts");
             Assert.Equal("Standard_LRS", actual["sku"]["name"].Value<string>());
+        }
+
+        /// <summary>
+        /// Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/2801.
+        /// </summary>
+        [Fact]
+        public void ProcessTemplate_WhenMockArrayOutputAndTypeIsUnknown_ShouldReturnArray()
+        {
+            ProcessTemplate(GetSourcePath("Tests.Bicep.36.json"), null, out var templateContext);
+
+            Assert.True(templateContext.RootDeployment.TryOutput("items", out JObject result));
+            var items = result["value"][0]["items"].Value<JArray>();
+
+            Assert.Single(items);
+            var actual = items[0].Value<JObject>();
+            Assert.Equal("name1", actual["name"].Value<string>());
+            Assert.Equal("value1", actual["value"].Value<string>());
         }
 
         #region Helper methods

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.36.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.36.bicep
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/2801.
+
+module child 'Tests.Bicep.36.child.bicep' = {
+  name: 'child'
+}
+
+output items array = [
+  {
+    items: child.outputs.items
+  }
+]

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.36.child.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.36.child.bicep
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+output items array = concat(
+  [],
+  [
+    {
+      name: 'name1'
+      value: 'value1'
+    }
+  ]
+)

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.36.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.36.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.26.54.24096",
+      "templateHash": "12279334207887669240"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "child",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.26.54.24096",
+              "templateHash": "14837468981850150943"
+            }
+          },
+          "resources": [],
+          "outputs": {
+            "items": {
+              "type": "array",
+              "value": "[concat(createArray(), createArray(createObject('name', 'name1', 'value', 'value1')))]"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "items": {
+      "type": "array",
+      "value": [
+        {
+          "items": "[reference(resourceId('Microsoft.Resources/deployments', 'child'), '2022-09-01').outputs.items.value]"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## PR Summary

- Fixed regression when handing ambiguous mock array outputs.

Fixes #2801

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
