### PR TITLE
Add min TLS check for Cosmos DB #2809

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -40,6 +40,9 @@ What's changed since v1.35.1:
       [#2790](https://github.com/Azure/PSRule.Rules.Azure/issues/2790)
     - Check that Container App environments are zone redundant by @BernieWhite.
       [#2791](https://github.com/Azure/PSRule.Rules.Azure/issues/2791)
+  - Cosmos DB:
+    - Check that database accounts only accept a minimum of TLS 1.2 by @BernieWhite.
+      [#2809](https://github.com/Azure/PSRule.Rules.Azure/issues/2809)
 - General improvements:
   - Quality updates to documentation by @lukemurraynz.
     [#2789](https://github.com/Azure/PSRule.Rules.Azure/pull/2789)

--- a/docs/en/rules/Azure.Cosmos.DefenderCloud.md
+++ b/docs/en/rules/Azure.Cosmos.DefenderCloud.md
@@ -1,7 +1,7 @@
 ---
 severity: Critical
 pillar: Security
-category: Security operations
+category: SE:10 Monitoring and threat detection
 resource: Cosmos DB
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Cosmos.DefenderCloud/
 ---
@@ -21,7 +21,8 @@ Which allows Microsoft Defender for Cloud to produce security alerts that are tr
 
 Security alerts for onboarded Cosmos DB accounts shows up in Defender for Cloud with details of the suspicious activity and recommendations on how to investigate and remediate the threats.
 
-Microsoft Defender for Cosmos DB can be enabled at the resource level, but the general recommandation is to enable it at the subscription level and by doing so ensures all Cosmos DB accounts in the subscription will be protected, including future ones. However, enabling it at resource level can be done to protect a specific Azure Cosmos DB account.
+Microsoft Defender for Cosmos DB can be enabled at the resource level, but the general recommendation is to enable it at the subscription level and by doing so ensures all Cosmos DB accounts in the subscription will be protected, including future ones.
+However, enabling it at resource level can be done to protect a specific Azure Cosmos DB account.
 
 ## RECOMMENDATION
 
@@ -74,11 +75,12 @@ resource defenderForCosmosDb 'Microsoft.Security/advancedThreatProtectionSetting
 
 ## NOTES
 
-Microsoft Defender for Azure Cosmos DB is currently available only for the NoSQL API. When Microsoft Defender for Cosmos DB is enabled at the subscription level, the resource level enablement has no effect as it will be handled by the plan at the subscription level.
+Microsoft Defender for Azure Cosmos DB is currently available only for the NoSQL API.
+When Microsoft Defender for Cosmos DB is enabled at the subscription level, the resource level enablement has no effect as it will be handled by the plan at the subscription level.
 
 ## LINKS
 
-- [Security operations in Azure](https://learn.microsoft.com/azure/architecture/framework/security/monitor-security-operations)
+- [SE:10 Monitoring and threat detection](https://learn.microsoft.com/azure/well-architected/security/monitor-threats)
 - [What is Microsoft Defender for Cloud?](https://learn.microsoft.com/azure/defender-for-cloud/defender-for-cloud-introduction)
 - [Overview of Microsoft Defender for Azure Cosmos DB](https://learn.microsoft.com/azure/defender-for-cloud/concept-defender-for-cosmos)
 - [Enable Microsoft Defender for Azure Cosmos DB](https://learn.microsoft.com/azure/defender-for-cloud/defender-for-databases-enable-cosmos-protections)

--- a/docs/en/rules/Azure.Cosmos.DisableMetadataWrite.md
+++ b/docs/en/rules/Azure.Cosmos.DisableMetadataWrite.md
@@ -1,7 +1,8 @@
 ---
+reviewed: 2024-04-09
 severity: Important
 pillar: Security
-category: Authentication
+category: SE:05 Identity and access management
 resource: Cosmos DB
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Cosmos.DisableMetadataWrite/
 ---
@@ -10,13 +11,13 @@ online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Cosmos
 
 ## SYNOPSIS
 
-Use Azure AD identities for management place operations in Azure Cosmos DB.
+Use Entra ID identities for management place operations in Azure Cosmos DB.
 
 ## DESCRIPTION
 
 Cosmos DB provides two authorization options for interacting with the database:
 
-- Azure Active Directory identity (Azure AD).
+- Entra ID identities (previously known as Azure AD).
   Can be used to authorize account and resource management operations.
 - Keys and resource tokens.
   Can be used to authorize resource management and data operations.
@@ -42,24 +43,24 @@ For example:
 
 ```json
 {
-    "type": "Microsoft.DocumentDB/databaseAccounts",
-    "apiVersion": "2021-06-15",
-    "name": "[parameters('dbAccountName')]",
-    "location": "[parameters('location')]",
-    "properties": {
-        "consistencyPolicy": {
-            "defaultConsistencyLevel": "Session"
-        },
-        "databaseAccountOfferType": "Standard",
-        "locations": [
-            {
-                "locationName": "[parameters('location')]",
-                "failoverPriority": 0,
-                "isZoneRedundant": false
-            }
-        ],
-        "disableKeyBasedMetadataWriteAccess": true
-    }
+  "type": "Microsoft.DocumentDB/databaseAccounts",
+  "apiVersion": "2023-04-15",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "properties": {
+    "consistencyPolicy": {
+      "defaultConsistencyLevel": "Session"
+    },
+    "databaseAccountOfferType": "Standard",
+    "locations": [
+      {
+        "locationName": "[parameters('location')]",
+        "failoverPriority": 0,
+        "isZoneRedundant": true
+      }
+    ],
+    "disableKeyBasedMetadataWriteAccess": true
+  }
 }
 ```
 
@@ -72,8 +73,8 @@ To deploy Cosmos DB accounts that pass this rule:
 For example:
 
 ```bicep
-resource dbAccount 'Microsoft.DocumentDB/databaseAccounts@2021-06-15' = {
-  name: dbAccountName
+resource account 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
+  name: name
   location: location
   properties: {
     consistencyPolicy: {
@@ -84,7 +85,7 @@ resource dbAccount 'Microsoft.DocumentDB/databaseAccounts@2021-06-15' = {
       {
         locationName: location
         failoverPriority: 0
-        isZoneRedundant: false
+        isZoneRedundant: true
       }
     ]
     disableKeyBasedMetadataWriteAccess: true
@@ -94,9 +95,9 @@ resource dbAccount 'Microsoft.DocumentDB/databaseAccounts@2021-06-15' = {
 
 ## LINKS
 
-- [Use identity-based authentication](https://learn.microsoft.com/azure/well-architected/security/design-identity-authentication#use-identity-based-authentication)
+- [SE:05 Identity and access management](https://learn.microsoft.com/azure/well-architected/security/identity-access)
 - [Restrict user access to data operations in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/how-to-restrict-user-data)
 - [Secure access to data in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/secure-access-to-data)
 - [How does Azure Cosmos DB secure my database?](https://learn.microsoft.com/azure/cosmos-db/database-security#how-does-azure-cosmos-db-secure-my-database)
 - [Access control in the Azure Cosmos DB SQL API](https://learn.microsoft.com/rest/api/cosmos-db/access-control-on-cosmosdb-resources)
-- [Azure resource template](https://learn.microsoft.com/azure/templates/microsoft.documentdb/databaseaccounts#databaseaccountcreateupdateproperties-object)
+- [Azure resource deployment](https://learn.microsoft.com/azure/templates/microsoft.documentdb/databaseaccounts)

--- a/docs/en/rules/Azure.Cosmos.MinTLS.md
+++ b/docs/en/rules/Azure.Cosmos.MinTLS.md
@@ -1,0 +1,100 @@
+---
+reviewed: 2024-04-09
+severity: Critical
+pillar: Security
+category: SE:07 Encryption
+resource: Cosmos DB
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Cosmos.MinTLS/
+---
+
+# Cosmos DB account minimum TLS version
+
+## SYNOPSIS
+
+Cosmos DB accounts should reject TLS versions older than 1.2.
+
+## DESCRIPTION
+
+The minimum version of TLS that Azure Cosmos DB accepts for client communication is configurable.
+Older TLS versions are no longer considered secure by industry standards, such as PCI DSS.
+
+Azure Cosmos DB lets you disable outdated protocols and enforce TLS 1.2.
+By default, TLS 1.0, TLS 1.1, and TLS 1.2 is accepted.
+
+## RECOMMENDATION
+
+Consider configuring the minimum supported TLS version to be 1.2.
+Also consider enforcing this setting using Azure Policy.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy database accounts that pass this rule:
+
+- Set the `properties.minimalTlsVersion` property to `Tls12`.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.DocumentDB/databaseAccounts",
+  "apiVersion": "2023-11-15",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "properties": {
+    "enableFreeTier": false,
+    "consistencyPolicy": {
+      "defaultConsistencyLevel": "Session"
+    },
+    "databaseAccountOfferType": "Standard",
+    "locations": [
+      {
+        "locationName": "[parameters('location')]",
+        "failoverPriority": 0,
+        "isZoneRedundant": true
+      }
+    ],
+    "disableKeyBasedMetadataWriteAccess": true,
+    "minimalTlsVersion": "Tls12"
+  }
+}
+```
+
+### Configure with Bicep
+
+To deploy database accounts that pass this rule:
+
+- Set the `properties.minimalTlsVersion` property to `Tls12`.
+
+For example:
+
+```bicep
+resource account 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' = {
+  name: name
+  location: location
+  properties: {
+    enableFreeTier: false
+    consistencyPolicy: {
+      defaultConsistencyLevel: 'Session'
+    }
+    databaseAccountOfferType: 'Standard'
+    locations: [
+      {
+        locationName: location
+        failoverPriority: 0
+        isZoneRedundant: true
+      }
+    ]
+    disableKeyBasedMetadataWriteAccess: true
+    minimalTlsVersion: 'Tls12'
+  }
+}
+```
+
+## LINKS
+
+- [SE:07 Encryption](https://learn.microsoft.com/azure/well-architected/security/encryption#data-in-transit)
+- [TLS encryption in Azure](https://learn.microsoft.com/azure/security/fundamentals/encryption-overview#tls-encryption-in-azure)
+- [Self-serve minimum TLS version enforcement in Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/self-serve-minimum-tls-enforcement)
+- [Azure resource deployment](https://learn.microsoft.com/azure/templates/microsoft.documentdb/databaseaccounts)

--- a/docs/examples-cosmos.bicep
+++ b/docs/examples-cosmos.bicep
@@ -4,16 +4,17 @@
 // Bicep documentation examples
 
 @description('The name of the Cosmos database account.')
-param dbAccountName string
+param name string
 
 @description('The location resources will be deployed.')
 param location string = resourceGroup().location
 
-// An example Cosmos DB account
-resource dbAccount 'Microsoft.DocumentDB/databaseAccounts@2021-06-15' = {
-  name: dbAccountName
+// An example Cosmos DB account using the NoSQL API.
+resource account 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' = {
+  name: name
   location: location
   properties: {
+    enableFreeTier: false
     consistencyPolicy: {
       defaultConsistencyLevel: 'Session'
     }
@@ -22,16 +23,17 @@ resource dbAccount 'Microsoft.DocumentDB/databaseAccounts@2021-06-15' = {
       {
         locationName: location
         failoverPriority: 0
-        isZoneRedundant: false
+        isZoneRedundant: true
       }
     ]
     disableKeyBasedMetadataWriteAccess: true
+    minimalTlsVersion: 'Tls12'
   }
 }
 
-resource accountName_databaseName 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2021-04-15' = {
+resource database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2023-11-15' = {
   name: 'sql-001'
-  parent: dbAccount
+  parent: account
   properties: {
     resource: {
       id: 'sql-001'

--- a/docs/examples-cosmos.json
+++ b/docs/examples-cosmos.json
@@ -4,12 +4,12 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.613.9944",
-      "templateHash": "13433916459456835935"
+      "version": "0.26.54.24096",
+      "templateHash": "12996554638761229869"
     }
   },
   "parameters": {
-    "dbAccountName": {
+    "name": {
       "type": "string",
       "metadata": {
         "description": "The name of the Cosmos database account."
@@ -23,14 +23,14 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.DocumentDB/databaseAccounts",
-      "apiVersion": "2021-06-15",
-      "name": "[parameters('dbAccountName')]",
+      "apiVersion": "2023-11-15",
+      "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "properties": {
+        "enableFreeTier": false,
         "consistencyPolicy": {
           "defaultConsistencyLevel": "Session"
         },
@@ -39,23 +39,24 @@
           {
             "locationName": "[parameters('location')]",
             "failoverPriority": 0,
-            "isZoneRedundant": false
+            "isZoneRedundant": true
           }
         ],
-        "disableKeyBasedMetadataWriteAccess": true
+        "disableKeyBasedMetadataWriteAccess": true,
+        "minimalTlsVersion": "Tls12"
       }
     },
     {
       "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
-      "apiVersion": "2021-04-15",
-      "name": "[format('{0}/{1}', parameters('dbAccountName'), 'sql-001')]",
+      "apiVersion": "2023-11-15",
+      "name": "[format('{0}/{1}', parameters('name'), 'sql-001')]",
       "properties": {
         "resource": {
           "id": "sql-001"
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('dbAccountName'))]"
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('name'))]"
       ]
     }
   ]

--- a/src/PSRule.Rules.Azure/rules/Azure.Cosmos.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.Cosmos.Rule.yaml
@@ -52,4 +52,22 @@ spec:
     - name: '.'
       match: '^[a-z0-9](-|[a-z0-9]){1,41}[a-z0-9]$'
 
+---
+# Synopsis: Cosmos DB accounts should reject TLS versions older than 1.2.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.Cosmos.MinTLS
+  ref: AZR-000415
+  tags:
+    release: GA
+    ruleSet: 2024_06
+    Azure.WAF/pillar: Security
+spec:
+  type:
+  - Microsoft.DocumentDb/databaseAccounts
+  condition:
+    field: properties.minimalTlsVersion
+    equals: Tls12
+
 #endregion Rules

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Cosmos.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Cosmos.Tests.ps1
@@ -49,6 +49,20 @@ Describe 'Azure.Cosmos' -Tag 'Cosmos', 'CosmosDB' {
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'graph-B';
         }
+
+        It 'Azure.Cosmos.MinTLS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Cosmos.MinTLS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -Be 'graph-B', 'nosql-A', 'nosql-B', 'nosql-C';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'graph-A';
+        }
     }
 
     Context 'Resource name - Azure.Cosmos.AccountName' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Cosmos.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Cosmos.json
@@ -33,6 +33,7 @@
       "databaseAccountOfferType": "Standard",
       "defaultIdentity": "FirstPartyIdentity",
       "networkAclBypass": "None",
+      "minimalTlsVersion": "Tls12",
       "consistencyPolicy": {
         "defaultConsistencyLevel": "Session",
         "maxIntervalInSeconds": 5,
@@ -263,7 +264,8 @@
         }
       ],
       "databaseAccountOfferType": "Standard",
-      "enableAutomaticFailover": true
+      "enableAutomaticFailover": true,
+      "minimalTlsVersion": "Tls"
     },
     "ResourceGroupName": "test-rg",
     "Type": "Microsoft.DocumentDB/databaseAccounts",


### PR DESCRIPTION
## PR Summary

- Check that database accounts only accept a minimum of TLS 1.2.

Fixes #2809

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
