### PR TITLE
[Azure.Storage.UseReplication] Update rule to allow for ZRS

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.36.0-B0020:
+
+- Bug fixes:
+  - Fixed `Azure.Storage.UseReplication` to allow for zone-redundant replication by @sebassem.
+    [#2827](https://github.com/Azure/PSRule.Rules.Azure/issues/2827)
+
 ## v1.36.0-B0020 (pre-release)
 
 What's changed since v1.35.3:

--- a/docs/en/rules/Azure.Storage.UseReplication.md
+++ b/docs/en/rules/Azure.Storage.UseReplication.md
@@ -6,11 +6,11 @@ resource: Storage Account
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Storage.UseReplication/
 ---
 
-# Use geo-replicated storage
+# Use geo-replicated or zone-replicated storage
 
 ## SYNOPSIS
 
-Storage Accounts not using geo-replicated storage (GRS) may be at risk.
+Storage Accounts not using geo-replicated storage (GRS) or zone-redundant (ZRS) may be at risk.
 
 ## DESCRIPTION
 
@@ -19,12 +19,16 @@ Azure provides a number of geo-replicated options including;
 Geo-redundant storage and geo-zone-redundant storage.
 Geo-zone-redundant storage is only available in supported regions.
 
-The following geo-replicated options are available within Azure:
+The following geo-replicated and zone-replicated options are available within Azure:
 
 - `Standard_GRS`
 - `Standard_RAGRS`
 - `Standard_GZRS`
 - `Standard_RAGZRS`
+- `Premium_ZRS`
+- `Standard_GZRS`
+- `Standard_RAGZRS`
+- `Standard_ZRS`
 
 ## RECOMMENDATION
 

--- a/src/PSRule.Rules.Azure/rules/Azure.Storage.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Storage.Rule.ps1
@@ -5,13 +5,17 @@
 # Validation rules for Azure Storage Accounts
 #
 
-# Synopsis: Storage Accounts not using geo-replicated storage (GRS) may be at risk.
+# Synopsis: Storage Accounts not using geo-replicated storage (GRS) or zone-redundant (ZRS) may be at risk.
 Rule 'Azure.Storage.UseReplication' -Ref 'AZR-000195' -Type 'Microsoft.Storage/storageAccounts' -If { (ShouldStorageReplicate) } -Tag @{ release = 'GA'; ruleSet = '2020_06'; 'Azure.WAF/pillar' = 'Reliability'; } {
     $Assert.In($TargetObject, 'sku.name', @(
             'Standard_GRS'
             'Standard_RAGRS'
             'Standard_GZRS'
             'Standard_RAGZRS'
+            'Premium_ZRS'
+            'Standard_GZRS'
+            'Standard_RAGZRS'
+            'Standard_ZRS'
         ));
 }
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
@@ -47,8 +47,6 @@ Describe 'Azure.Storage' -Tag Storage {
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly 'Path sku.name: The field value ''Standard_LRS'' was not included in the set.';
-            $ruleResult[1].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[1].Reason | Should -BeExactly 'Path sku.name: The field value ''Standard_LRS'' was not included in the set.';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
@@ -42,8 +42,8 @@ Describe 'Azure.Storage' -Tag Storage {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'storage-B', 'storage-E';
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'storage-B';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
             $ruleResult[0].Reason | Should -BeExactly 'Path sku.name: The field value ''Standard_LRS'' was not included in the set.';
@@ -53,8 +53,8 @@ Describe 'Azure.Storage' -Tag Storage {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'storage-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'storage-A', 'storage-E';
 
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Storage.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Storage.json
@@ -436,7 +436,7 @@
     "ResourceType": "Microsoft.Storage/storageAccounts",
     "ExtensionResourceType": null,
     "Sku": {
-      "Name": "Standard_LRS",
+      "Name": "Standard_ZRS",
       "Tier": "Standard",
       "Size": null,
       "Family": null,


### PR DESCRIPTION
## PR Summary

WAF guidance is recommending either Geo or zone-redundant storage, I think we should allow for both to pass the test.

Fixes #2827 

## PR Checklist

- [X] PR has a meaningful title
- [X] Summarized changes
- [X] Change is not breaking
- [X] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [ ] Unit tests created/ updated
  - [X] Rule documentation created/ updated
  - [X] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
