### PR TITLE
Added new Bicep language features from v0.27.1 #2859 #2860 #2885

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -31,6 +31,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v1.37.0-B0009:
 
+- New features:
+  - Added support for new Bicep language features introduced in v0.27.1 by @BernieWhite.
+    [#2860](https://github.com/Azure/PSRule.Rules.Azure/issues/2860)
+    [#2859](https://github.com/Azure/PSRule.Rules.Azure/issues/2859)
+    - Added support for `shallowMerge`, `groupBy`, `objectKeys`, and `mapValues`.
+    - Updated syntax for Bicep lambda usage of `map`, `reduce`, and `filter` which now support indices.
+    - Added support for spread operator.
 - New rules:
   - Application Gateway:
     - Check that WAF v2 doesn't use legacy WAF configuration by @BenjaminEngeset.
@@ -56,6 +63,9 @@ What's changed since pre-release v1.37.0-B0009:
 - General improvements:
   - Updated resource providers and policy aliases.
     [#2880](https://github.com/Azure/PSRule.Rules.Azure/pull/2880)
+- Bug fixed:
+  - Fixed `union` does not perform deep merge or keep property order by @BernieWhite.
+    [#2885](https://github.com/Azure/PSRule.Rules.Azure/issues/2885)
 
 ## v1.37.0-B0009 (pre-release)
 

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -248,6 +248,9 @@
     <None Update="Tests.Bicep.38.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Tests.Bicep.39.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Tests.Bicep.4.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Rules.Azure.Tests/TestLengthObject.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TestLengthObject.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Rules.Azure
+{
+    internal sealed class TestLengthObject
+    {
+        public TestLengthObject()
+        {
+            propC = "three";
+            propD = new ChildObject();
+        }
+
+        internal sealed class ChildObject
+        {
+            public string prop1 => "sub";
+
+            public string prop2 => "sub";
+        }
+
+        public string propA => "one";
+
+        public string propB => "two";
+
+        public string propC { get; set; }
+
+        public ChildObject propD { get; set; }
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.39.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.39.bicep
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Test case for:
+// - https://github.com/Azure/PSRule.Rules.Azure/issues/2859
+// - https://github.com/Azure/PSRule.Rules.Azure/issues/2860
+
+// Basic array case
+var arrayA = [
+  1
+  2
+  3
+]
+
+var arrayB = [
+  4
+  5
+  6
+]
+
+output arrayResult int[] = [...arrayA, ...arrayB, 10]
+
+// Basic object case
+var objectA = {
+  a: 1
+  b: 2
+  c: 3
+}
+
+var objectB = {
+  d: 4
+  e: 5
+  f: 6
+}
+
+output objectResult object = { ...objectA, ...objectB, g: 10 }
+
+// Detailed cases
+
+var arrA = [2, 3]
+output example1 int[] = [1, ...arrA, 4] // equivalent to [ 1, 2, 3, 4 ]
+
+var objA = { bar: 'bar' }
+output example2 object = { foo: 'foo', ...objA } // equivalent to { foo: 'foo', bar: 'bar' }
+
+// Object keys
+
+output example3 string[] = objectKeys({ a: 1, b: 2 }) // returns [ 'a', 'b' ]
+output example3a string[] = objectKeys({}) // returns []
+output example3b string[] = objectKeys({ b: 2, a: 1 }) // returns [ 'a', 'b' ]
+output example3c string[] = objectKeys({ A: 2, a: 1 }) // returns [ 'A', 'a' ]
+output example3d string[] = objectKeys({ a: 2, A: 1 }) // returns [ 'a', 'A' ]
+
+// Map values
+
+output example4 object = mapValues({ foo: 'foo' }, val => toUpper(val)) // returns { foo: 'FOO' }
+
+// Group by
+
+output example5 object = groupBy(['foo', 'bar', 'baz'], x => substring(x, 0, 1)) // returns { f: [ 'foo' ], b: [ 'bar', 'baz' ]
+
+// Shallow merge
+
+output example6 object = shallowMerge([{ foo: 'foo' }, { bar: 'bar' }]) // returns { foo: 'foo', bar: 'bar' }
+
+// Map
+
+output example7 object[] = map(['a', 'b'], (x, i) => { index: i, val: x }) // returns [ { index: 0, val: 'a' }, { index: 1, val: 'b' } ]
+
+// Reduce
+
+output example8 int = reduce([2, 3, 7], 0, (cur, next, i) => (i % 2 == 0) ? cur + next : cur) // returns 9
+
+// Filter
+
+output example9 string[] = filter(['foo', 'bar', 'baz'], (val, i) => i < 2 && substring(val, 0, 1) == 'b') // returns [ 'bar' ]

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.39.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.39.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.27.1.19265",
+      "templateHash": "16337921613414975184"
+    }
+  },
+  "variables": {
+    "arrayA": [
+      1,
+      2,
+      3
+    ],
+    "arrayB": [
+      4,
+      5,
+      6
+    ],
+    "objectA": {
+      "a": 1,
+      "b": 2,
+      "c": 3
+    },
+    "objectB": {
+      "d": 4,
+      "e": 5,
+      "f": 6
+    },
+    "arrA": [
+      2,
+      3
+    ],
+    "objA": {
+      "bar": "bar"
+    }
+  },
+  "resources": {},
+  "outputs": {
+    "arrayResult": {
+      "type": "array",
+      "items": {
+        "type": "int"
+      },
+      "value": "[flatten(createArray(variables('arrayA'), variables('arrayB'), createArray(10)))]"
+    },
+    "objectResult": {
+      "type": "object",
+      "value": "[shallowMerge(createArray(variables('objectA'), variables('objectB'), createObject('g', 10)))]"
+    },
+    "example1": {
+      "type": "array",
+      "items": {
+        "type": "int"
+      },
+      "value": "[flatten(createArray(createArray(1), variables('arrA'), createArray(4)))]"
+    },
+    "example2": {
+      "type": "object",
+      "value": "[shallowMerge(createArray(createObject('foo', 'foo'), variables('objA')))]"
+    },
+    "example3": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "value": "[objectKeys(createObject('a', 1, 'b', 2))]"
+    },
+    "example3a": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "value": "[objectKeys(createObject())]"
+    },
+    "example3b": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "value": "[objectKeys(createObject('b', 2, 'a', 1))]"
+    },
+    "example3c": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "value": "[objectKeys(createObject('A', 2, 'a', 1))]"
+    },
+    "example3d": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "value": "[objectKeys(createObject('a', 2, 'A', 1))]"
+    },
+    "example4": {
+      "type": "object",
+      "value": "[mapValues(createObject('foo', 'foo'), lambda('val', toUpper(lambdaVariables('val'))))]"
+    },
+    "example5": {
+      "type": "object",
+      "value": "[groupBy(createArray('foo', 'bar', 'baz'), lambda('x', substring(lambdaVariables('x'), 0, 1)))]"
+    },
+    "example6": {
+      "type": "object",
+      "value": "[shallowMerge(createArray(createObject('foo', 'foo'), createObject('bar', 'bar')))]"
+    },
+    "example7": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "value": "[map(createArray('a', 'b'), lambda('x', 'i', createObject('index', lambdaVariables('i'), 'val', lambdaVariables('x'))))]"
+    },
+    "example8": {
+      "type": "int",
+      "value": "[reduce(createArray(2, 3, 7), 0, lambda('cur', 'next', 'i', if(equals(mod(lambdaVariables('i'), 2), 0), add(lambdaVariables('cur'), lambdaVariables('next')), lambdaVariables('cur'))))]"
+    },
+    "example9": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "value": "[filter(createArray('foo', 'bar', 'baz'), lambda('val', 'i', and(less(lambdaVariables('i'), 2), equals(substring(lambdaVariables('val'), 0, 1), 'b'))))]"
+    }
+  }
+}


### PR DESCRIPTION
## PR Summary

- Added support for new Bicep language features introduced in v0.27.1.
  - Added support for `shallowMerge`, `groupBy`, `objectKeys`, and `mapValues`.
  - Updated syntax for Bicep lambda usage of `map`, `reduce`, and `filter` which now support indices.
  - Added support for spread operator.
- Fixed `union` does not perform deep merge or keep property order.

Fixes #2859 
Fixes #2860 
Fixes #2885

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
