### PR TITLE
Updated Azure.AKS.Version to use 1.28.9 #2930

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -49,6 +49,8 @@ What's changed since v1.37.0:
     - Updated `Azure.VM.MaintenanceConfig` to align to the reliability pillar by @BernieWhite.
       [#2925](https://github.com/Azure/PSRule.Rules.Azure/issues/2925)
       - Promoted to GA and bumped rule set to `2024_06`.
+  - Updated `Azure.AKS.Version` to use `1.28.9` as the minimum version by @BernieWhite.
+    [#2930](https://github.com/Azure/PSRule.Rules.Azure/issues/2930)
 
 ## v1.37.0
 

--- a/docs/en/rules/Azure.AKS.Version.md
+++ b/docs/en/rules/Azure.AKS.Version.md
@@ -67,7 +67,7 @@ For example:
         }
     },
     "properties": {
-        "kubernetesVersion": "1.27.9",
+        "kubernetesVersion": "1.28.9",
         "enableRBAC": true,
         "dnsPrefix": "[parameters('dnsPrefix')]",
         "agentPoolProfiles": "[variables('allPools')]",
@@ -145,7 +145,7 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2023-07-01' = {
     }
   }
   properties: {
-    kubernetesVersion: '1.27.9'
+    kubernetesVersion: '1.28.9'
     enableRBAC: true
     dnsPrefix: dnsPrefix
     agentPoolProfiles: allPools
@@ -207,13 +207,13 @@ az aks update -n '<name>' -g '<resource_group>' --auto-upgrade-channel 'stable'
 ```
 
 ```bash
-az aks upgrade -n '<name>' -g '<resource_group>' --kubernetes-version '1.27.9'
+az aks upgrade -n '<name>' -g '<resource_group>' --kubernetes-version '1.28.9'
 ```
 
 ### Configure with Azure PowerShell
 
 ```powershell
-Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -KubernetesVersion '1.27.9'
+Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -KubernetesVersion '1.28.9'
 ```
 
 ## NOTES

--- a/docs/examples-aks.bicep
+++ b/docs/examples-aks.bicep
@@ -46,7 +46,7 @@ param systemPoolMin int
 param systemPoolMax int = 3
 
 @description('The version of Kubernetes.')
-param kubernetesVersion string = '1.27.9'
+param kubernetesVersion string = '1.28.9'
 
 @description('Maximum number of pods that can run on nodes in the system pool.')
 @minValue(30)

--- a/docs/examples-aks.json
+++ b/docs/examples-aks.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "2536331348365960823"
+      "version": "0.28.1.47646",
+      "templateHash": "5111879364998616708"
     }
   },
   "parameters": {
@@ -73,7 +73,7 @@
     },
     "kubernetesVersion": {
       "type": "string",
-      "defaultValue": "1.27.9",
+      "defaultValue": "1.28.9",
       "metadata": {
         "description": "The version of Kubernetes."
       }

--- a/docs/setup/configuring-options.md
+++ b/docs/setup/configuring-options.md
@@ -52,7 +52,7 @@ Use comments to add context.
       AZURE_BICEP_MINIMUM_VERSION: '0.16.2'
 
       # Configure the minimum AKS cluster version.
-      AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.27.9'
+      AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.28.9'
 
     rule:
       # Enable custom rules that don't exist in the baseline

--- a/docs/setup/configuring-rules.md
+++ b/docs/setup/configuring-rules.md
@@ -66,7 +66,7 @@ Default:
 ```yaml title="ps-rule.yaml"
 # YAML: The default AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option
 configuration:
-  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.27.9
+  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.28.9
 ```
 
 Example:

--- a/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
@@ -40,7 +40,7 @@ spec:
     AZURE_BICEP_CHECK_TOOL: false
 
     # Configure minimum AKS cluster version.
-    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.27.9'
+    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.28.9'
 
     # Configures the minimum number of nodes across all system node pools.
     AZURE_AKS_CLUSTER_MINIMUM_SYSTEM_NODES: 3

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -81,7 +81,7 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult.TargetName | Should -BeIn 'cluster-B';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[0].Reason | Should -BeExactly "Path Properties.kubernetesVersion: The version '1.13.8' does not match the constraint '>=1.27.9'.";
+            $ruleResult[0].Reason | Should -BeExactly "Path Properties.kubernetesVersion: The version '1.13.8' does not match the constraint '>=1.28.9'.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -50,7 +50,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.27.9",
+                "kubernetesVersion": "1.28.9",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -210,7 +210,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.27.9",
+                "kubernetesVersion": "1.28.9",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -395,7 +395,7 @@
                 "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-03')]",
                 "maxPods": 50,
                 "type": "VirtualMachineScaleSets",
-                "orchestratorVersion": "1.27.9",
+                "orchestratorVersion": "1.28.9",
                 "osType": "Linux",
                 "enableAutoScaling": false
             }
@@ -427,7 +427,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.27.9",
+                "kubernetesVersion": "1.28.9",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -628,7 +628,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.27.9",
+                "kubernetesVersion": "1.28.9",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName5'))]",
                 "agentPoolProfiles": [
                     {
@@ -831,7 +831,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.27.9",
+                "kubernetesVersion": "1.28.9",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName6'))]",
                 "agentPoolProfiles": [
                     {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -6,7 +6,7 @@
     "ResourceName": "cluster-A",
     "Name": "cluster-A",
     "Properties": {
-      "kubernetesVersion": "1.27.9",
+      "kubernetesVersion": "1.28.9",
       "dnsPrefix": "cluster-A",
       "fqdn": "cluster-A-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -18,7 +18,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "AvailabilitySet",
-          "orchestratorVersion": "1.27.9",
+          "orchestratorVersion": "1.28.9",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -172,7 +172,7 @@
     "ParentResource": null,
     "Properties": {
       "provisioningState": "Succeeded",
-      "kubernetesVersion": "1.27.9",
+      "kubernetesVersion": "1.28.9",
       "dnsPrefix": "cluster-C",
       "fqdn": "cluster-C-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -186,7 +186,7 @@
           "maxPods": 50,
           "type": "VirtualMachineScaleSets",
           "provisioningState": "Succeeded",
-          "orchestratorVersion": "1.27.9",
+          "orchestratorVersion": "1.28.9",
           "osType": "Linux",
           "enableAutoScaling": false
         }
@@ -300,7 +300,7 @@
     "Plan": null,
     "Properties": {
       "provisioningState": "Succeeded",
-      "kubernetesVersion": "1.27.9",
+      "kubernetesVersion": "1.28.9",
       "dnsPrefix": "cluster-D",
       "fqdn": "cluster-D-nnnnnnnn.hcp.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -313,7 +313,7 @@
           "maxPods": 50,
           "type": "VirtualMachineScaleSets",
           "provisioningState": "Succeeded",
-          "orchestratorVersion": "1.27.9",
+          "orchestratorVersion": "1.28.9",
           "nodeLabels": {},
           "mode": "System",
           "osType": "Linux",
@@ -495,7 +495,7 @@
       "powerState": {
         "code": "Running"
       },
-      "orchestratorVersion": "1.27.9",
+      "orchestratorVersion": "1.28.9",
       "nodeLabels": {},
       "mode": "System",
       "osType": "Linux",
@@ -565,7 +565,7 @@
       "powerState": {
         "code": "Running"
       },
-      "kubernetesVersion": "1.27.9",
+      "kubernetesVersion": "1.28.9",
       "dnsPrefix": "cluster-F",
       "fqdn": "cluster-F-00000000.hcp.region.azmk8s.io",
       "azurePortalFQDN": "cluster-F-00000000.portal.hcp.region.azmk8s.io",
@@ -586,7 +586,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.27.9",
+          "orchestratorVersion": "1.28.9",
           "nodeLabels": {},
           "mode": "System",
           "osType": "Linux",
@@ -793,7 +793,7 @@
     "ResourceName": "cluster-G",
     "Name": "cluster-G",
     "Properties": {
-      "kubernetesVersion": "1.27.9",
+      "kubernetesVersion": "1.28.9",
       "dnsPrefix": "cluster-G",
       "fqdn": "cluster-G-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -805,7 +805,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.27.9",
+          "orchestratorVersion": "1.28.9",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -968,7 +968,7 @@
     "ResourceName": "cluster-H",
     "Name": "cluster-H",
     "Properties": {
-      "kubernetesVersion": "1.27.9",
+      "kubernetesVersion": "1.28.9",
       "dnsPrefix": "cluster-H",
       "fqdn": "cluster-H-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -980,7 +980,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.27.9",
+          "orchestratorVersion": "1.28.9",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": []
@@ -1147,7 +1147,7 @@
     "ResourceName": "cluster-I",
     "Name": "cluster-I",
     "Properties": {
-      "kubernetesVersion": "1.27.9",
+      "kubernetesVersion": "1.28.9",
       "dnsPrefix": "cluster-I",
       "fqdn": "cluster-I-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1165,7 +1165,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.27.9",
+          "orchestratorVersion": "1.28.9",
           "mode": "System",
           "osType": "Linux",
           "osSKU": "Ubuntu",
@@ -1188,7 +1188,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.27.9",
+          "orchestratorVersion": "1.28.9",
           "mode": "User",
           "osType": "Linux",
           "osSKU": "Ubuntu",
@@ -1357,7 +1357,7 @@
     "ResourceName": "cluster-J",
     "Name": "cluster-J",
     "Properties": {
-      "kubernetesVersion": "1.27.9",
+      "kubernetesVersion": "1.28.9",
       "dnsPrefix": "cluster-J",
       "fqdn": "cluster-J-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1369,7 +1369,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.27.9",
+          "orchestratorVersion": "1.28.9",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -1542,7 +1542,7 @@
       "powerState": {
         "code": "Running"
       },
-      "kubernetesVersion": "1.27.9",
+      "kubernetesVersion": "1.28.9",
       "dnsPrefix": "cluster-K",
       "fqdn": "cluster-K-00000000.hcp.eastus.azmk8s.io",
       "azurePortalFQDN": "cluster-K-00000000.portal.hcp.eastus.azmk8s.io",
@@ -1563,7 +1563,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.27.9",
+          "orchestratorVersion": "1.28.9",
           "mode": "System",
           "osType": "Linux",
           "osSKU": "Ubuntu",


### PR DESCRIPTION
## PR Summary

- Updated `Azure.AKS.Version` to use `1.28.9` as the minimum version.

Fixes #2930 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
