### PR TITLE
Pre-release v1.38.0-B0034

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.38.0-B0034 (pre-release)
+
 What's changed since pre-release v1.38.0-B0011:
 
 - New rules:

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -40,11 +40,11 @@ What's changed since pre-release v1.38.0-B0011:
   - Azure Virtual Desktop:
     - Added check for scheduled agent updates on host pools by @BernieWhite.
       [#2946](https://github.com/Azure/PSRule.Rules.Azure/issues/2946)
-- Virtual Machine Scale Sets:
-  - Verify that virtual machine scale sets have best-effort zone balance configured by @BenjaminEngeset.
-    [#2901](https://github.com/Azure/PSRule.Rules.Azure/issues/2901)
-  - Verify that virtual machine scale sets have availability zones configured by @BenjaminEngeset.
-    [#2902](https://github.com/Azure/PSRule.Rules.Azure/issues/2902)
+  - Virtual Machine Scale Sets:
+    - Verify that virtual machine scale sets have best-effort zone balance configured by @BenjaminEngeset.
+      [#2901](https://github.com/Azure/PSRule.Rules.Azure/issues/2901)
+    - Verify that virtual machine scale sets have availability zones configured by @BenjaminEngeset.
+      [#2902](https://github.com/Azure/PSRule.Rules.Azure/issues/2902)
 - Engineering:
   - Quality updates to rule documentation by @BernieWhite.
     [#2570](https://github.com/Azure/PSRule.Rules.Azure/issues/2570)


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.38.0-B0011:

- New rules:
  - Azure Kubernetes Service:
    - Added check to automatically upgrade AKS cluster node image by @sharmilamusunuru.
      [#2445](https://github.com/Azure/PSRule.Rules.Azure/issues/2445)
  - Azure Virtual Desktop:
    - Added check for scheduled agent updates on host pools by @BernieWhite.
      [#2946](https://github.com/Azure/PSRule.Rules.Azure/issues/2946)
  - Virtual Machine Scale Sets:
    - Verify that virtual machine scale sets have best-effort zone balance configured by @BenjaminEngeset.
      [#2901](https://github.com/Azure/PSRule.Rules.Azure/issues/2901)
    - Verify that virtual machine scale sets have availability zones configured by @BenjaminEngeset.
      [#2902](https://github.com/Azure/PSRule.Rules.Azure/issues/2902)
- Engineering:
  - Quality updates to rule documentation by @BernieWhite.
    [#2570](https://github.com/Azure/PSRule.Rules.Azure/issues/2570)
- Bug fixes:
  - Fixed failed to expand with direct outputs reference by @BernieWhite.
    [#2935](https://github.com/Azure/PSRule.Rules.Azure/issues/2935)
  - Fixed identification of `list*` function false positive with resource by @BernieWhite.
    [#2919](https://github.com/Azure/PSRule.Rules.Azure/issues/2919)
  - Fixed documentation bugs for container apps by @BernieWhite.
    [#2876](https://github.com/Azure/PSRule.Rules.Azure/issues/2876)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
