### PR TITLE
Fixes group by subscription casing #2957

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -37,7 +37,7 @@ What's changed since pre-release v1.38.0-B0034:
 - Bug fixes:
   - Fixed support for `references` function by @BernieWhite.
     [#2922](https://github.com/Azure/PSRule.Rules.Azure/issues/2922)
-  - Fixed group by subscription casing when exporting in-flight resource by @BernieWhite.
+  - Fixed group by subscription casing when exporting in-flight resources by @BernieWhite.
     [#2957](https://github.com/Azure/PSRule.Rules.Azure/issues/2957)
 
 ## v1.38.0-B0034 (pre-release)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -37,6 +37,8 @@ What's changed since pre-release v1.38.0-B0034:
 - Bug fixes:
   - Fixed support for `references` function by @BernieWhite.
     [#2922](https://github.com/Azure/PSRule.Rules.Azure/issues/2922)
+  - Fixed group by subscription casing when exporting in-flight resource by @BernieWhite.
+    [#2957](https://github.com/Azure/PSRule.Rules.Azure/issues/2957)
 
 ## v1.38.0-B0034 (pre-release)
 

--- a/src/PSRule.Rules.Azure/Pipeline/ResourceDataPipeline.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/ResourceDataPipeline.cs
@@ -95,7 +95,7 @@ namespace PSRule.Rules.Azure.Pipeline
             else
             {
                 // Group results into subscriptions a write each to a new file.
-                foreach (var group in output.GroupBy((r) => r[PROPERTY_SUBSCRIPTIONID]))
+                foreach (var group in output.GroupBy((r) => r[PROPERTY_SUBSCRIPTIONID].Value<string>().ToLowerInvariant()))
                 {
                     var filePath = Path.Combine(_OutputPath, string.Concat(group.Key, ".json"));
                     File.WriteAllText(filePath, JsonConvert.SerializeObject(group.ToArray()), Encoding.UTF8);


### PR DESCRIPTION
## PR Summary

- Fixed group by subscription casing when exporting in-flight resources.

Fixes #2957

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
