### PR TITLE
Pre-release v1.38.0-B0068

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.38.0-B0068 (pre-release)
+
 What's changed since pre-release v1.38.0-B0034:
 
 - New features:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.38.0-B0034:

- New features:
  - Added March 2024 baselines `Azure.GA_2024_06` and `Azure.Preview_2024_06` by @BernieWhite.
    [#2961](https://github.com/Azure/PSRule.Rules.Azure/issues/2961)
    - Includes rules released before or during June 2024.
    - Marked `Azure.GA_2024_03` and `Azure.Preview_2024_03` baselines as obsolete.
- Engineering:
  - Quality updates to rule documentation by @BernieWhite.
    [#2570](https://github.com/Azure/PSRule.Rules.Azure/issues/2570)
- Bug fixes:
  - Fixed support for `references` function by @BernieWhite.
    [#2922](https://github.com/Azure/PSRule.Rules.Azure/issues/2922)
  - Fixed group by subscription casing when exporting in-flight resources by @BernieWhite.
    [#2957](https://github.com/Azure/PSRule.Rules.Azure/issues/2957)
  - Fixed install Az.Resources warning by @BernieWhite.
    [#2887](https://github.com/Azure/PSRule.Rules.Azure/issues/2887)
    - Added new configuration option set by environment variable to suppress the warning.
    - Set `PSRULE_AZURE_RESOURCE_MODULE_NOWARN` to `true` to suppress the warning.
  - Fixed `filter` on unknown runtime property by @BernieWhite.
    [#2966](https://github.com/Azure/PSRule.Rules.Azure/issues/2966)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
