### PR TITLE
Pre-release v1.39.0-B0009

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,10 +29,7 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
-- New rules:
-  - Service Bus:
-    - Verify that service bus namespaces have geo-replication configured by @BenjaminEngeset.
-      [#2988](https://github.com/Azure/PSRule.Rules.Azure/issues/2988)
+## v1.39.0-B0009 (pre-release)
 
 What's changed since v1.38.0:
 
@@ -49,6 +46,9 @@ What's changed since v1.38.0:
   - Azure SQL Managed Instance:
     - Verify that Azure SQL Managed Instances have a customer-controlled maintenance window configured by @BenjaminEngeset.
       [#2979](https://github.com/Azure/PSRule.Rules.Azure/issues/2979)
+  - Service Bus:
+    - Verify that service bus namespaces have geo-replication configured by @BenjaminEngeset.
+      [#2988](https://github.com/Azure/PSRule.Rules.Azure/issues/2988)
 - Engineering:
   - Bump xunit to v2.9.0.
     [#2982](https://github.com/Azure/PSRule.Rules.Azure/pull/2982)


### PR DESCRIPTION
## PR Summary

What's changed since v1.38.0:

- New rules:
  - App Service:
    - Verify that app service plans have availability zones configured by @BenjaminEngeset.
      [#2964](https://github.com/Azure/PSRule.Rules.Azure/issues/2964)
  - App Service Environment:
    - Verify that app service environments have availability zones configured by @BenjaminEngeset.
      [#2964](https://github.com/Azure/PSRule.Rules.Azure/issues/2964)
  - Azure SQL Database:
    - Verify that Azure SQL databases have a customer-controlled maintenance window configured by @BenjaminEngeset.
      [#2956](https://github.com/Azure/PSRule.Rules.Azure/issues/2956)
  - Azure SQL Managed Instance:
    - Verify that Azure SQL Managed Instances have a customer-controlled maintenance window configured by @BenjaminEngeset.
      [#2979](https://github.com/Azure/PSRule.Rules.Azure/issues/2979)
  - Service Bus:
    - Verify that service bus namespaces have geo-replication configured by @BenjaminEngeset.
      [#2988](https://github.com/Azure/PSRule.Rules.Azure/issues/2988)
- Engineering:
  - Bump xunit to v2.9.0.
    [#2982](https://github.com/Azure/PSRule.Rules.Azure/pull/2982)
  - Bump xunit.runner.visualstudio to v2.8.2.
    [#2982](https://github.com/Azure/PSRule.Rules.Azure/pull/2982)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**

