### PR TITLE
Fixed Azure.AppService.AvailabilityZone only detects premium by tier

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -35,6 +35,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
       [#432](https://github.com/Azure/PSRule.Rules.Azure/issues/432)
     - Verify that availability set members are in a backend pool by @BenjaminEngeset.
       [#67](https://github.com/Azure/PSRule.Rules.Azure/issues/67)
+- Bug fixed:
+  - Fixed `Azure.AppService.AvailabilityZone` only detects premium by tier property @BenjaminEngeset.
+    [#3034](https://github.com/Azure/PSRule.Rules.Azure/issues/3034)
 
 ## v1.39.0-B0055 (pre-release)
 

--- a/src/PSRule.Rules.Azure/rules/Azure.AppService.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppService.Rule.ps1
@@ -226,11 +226,13 @@ Rule 'Azure.AppService.AvailabilityZone' -Ref 'AZR-000442' -Type 'Microsoft.Web/
     }
 
     AnyOf {
-        $Assert.In($TargetObject, 'sku.name', $sku.name).Reason(
+        $Assert.In($TargetObject, 'sku.name', $sku.name).ReasonFrom(
+            'sku.name',
             $LocalizedData.AppServiceAvailabilityZoneSKU,
             $TargetObject.name
         )
-        $Assert.In($TargetObject, 'sku.tier', $sku.tier).Reason(
+        $Assert.In($TargetObject, 'sku.tier', $sku.tier).ReasonFrom(
+            'sku.tier',
             $LocalizedData.AppServiceAvailabilityZoneSKU,
             $TargetObject.name
         )

--- a/src/PSRule.Rules.Azure/rules/Azure.AppService.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppService.Rule.ps1
@@ -201,10 +201,40 @@ Rule 'Azure.AppService.AvailabilityZone' -Ref 'AZR-000442' -Type 'Microsoft.Web/
     }
 
     # Availability zones are only supported for these Premium SKUs.
-    $Assert.In($TargetObject, 'sku.tier', @('PremiumV2', 'PremiumV3', 'ElasticPremium')).Reason(
-        $LocalizedData.AppServiceAvailabilityZoneSKU,
-        $TargetObject.name
-    )
+    $sku = [PSCustomObject]@{
+        name = @(
+            'P1v3' 
+            'P1mv3'
+            'P2v3'   
+            'P2mv3' 
+            'P3v3'    
+            'P3mv3'
+            'P4mv3'
+            'P5mv3'
+            'P1v2'
+            'P2v2'
+            'P3v2'
+            'EP1'
+            'EP2'
+            'EP3'
+        )
+        tier = @(
+            'PremiumV3'
+            'PremiumV2'
+            'ElasticPremium'
+        )
+    }
+
+    AnyOf {
+        $Assert.In($TargetObject, 'sku.name', $sku.name).Reason(
+            $LocalizedData.AppServiceAvailabilityZoneSKU,
+            $TargetObject.name
+        )
+        $Assert.In($TargetObject, 'sku.tier', $sku.tier).Reason(
+            $LocalizedData.AppServiceAvailabilityZoneSKU,
+            $TargetObject.name
+        )
+    }
 
     $Assert.HasFieldValue($TargetObject, 'properties.zoneRedundant', $true)
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
@@ -265,8 +265,8 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             $ruleResult.TargetName | Should -Be 'plan-A', 'plan-D';
 
             $ruleResult[0].Reason | Should -BeExactly @(
-                "The app service plan (plan-A) is not deployed with a SKU that supports zone-redundancy."
-                "The app service plan (plan-A) is not deployed with a SKU that supports zone-redundancy."
+                "Path sku.name: The app service plan (plan-A) is not deployed with a SKU that supports zone-redundancy."
+                "Path sku.tier: The app service plan (plan-A) is not deployed with a SKU that supports zone-redundancy."
                 "Path properties.zoneRedundant: Does not exist."
             );
             $ruleResult[1].Reason | Should -BeExactly "Path properties.zoneRedundant: Is set to 'False'.";

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
@@ -266,6 +266,7 @@ Describe 'Azure.AppService' -Tag 'AppService' {
 
             $ruleResult[0].Reason | Should -BeExactly @(
                 "The app service plan (plan-A) is not deployed with a SKU that supports zone-redundancy."
+                "The app service plan (plan-A) is not deployed with a SKU that supports zone-redundancy."
                 "Path properties.zoneRedundant: Does not exist."
             );
             $ruleResult[1].Reason | Should -BeExactly "Path properties.zoneRedundant: Is set to 'False'.";

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AppService.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AppService.json
@@ -632,7 +632,6 @@
     },
     "Sku": {
       "name": "P1v3",
-      "tier": "PremiumV3",
       "size": "P1v3",
       "family": "Pv3",
       "capacity": 1


### PR DESCRIPTION
Fixes #3034

Fixed `Azure.AppService.AvailabilityZone` only detects premium by tier property.

## PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
