### PR TITLE
Pre-release v1.39.0-B0072

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,12 +29,21 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.39.0-B0072 (pre-release)
+
+What's changed since pre-release v1.39.0-B0029:
+
 - New rules:
   - Virtual Machine:
+    - Verify that virtual machines does not have public IPs attached by @BenjaminEngeset.
+      [#11](https://github.com/Azure/PSRule.Rules.Azure/issues/11)
     - Verify that multi-tenant Hosting Rights are used for Windows client VMs by @BenjaminEngeset.
       [#432](https://github.com/Azure/PSRule.Rules.Azure/issues/432)
     - Verify that availability set members are in a backend pool by @BenjaminEngeset.
       [#67](https://github.com/Azure/PSRule.Rules.Azure/issues/67)
+  - Virtual Machine Scale Sets:
+    - Verify that virtual machine scale set instances does not have public IPs attached by @BenjaminEngeset.
+      [#3014](https://github.com/Azure/PSRule.Rules.Azure/issues/3014)
 - Updated rules:
   - Azure Kubernetes Service:
     - Updated `Azure.AKS.Version` to use `1.29.7` as the minimum version by @BernieWhite.
@@ -56,23 +65,6 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
     - If `Azure_MinimumCertificateLifetime` is set a warning will be generated until the configuration is removed.
     - Support for `Azure_MinimumCertificateLifetime` is deprecated and will be removed in v2.
     - See [upgrade notes][1] for details.
-- Bug fixed:
-  - Fixed `Azure.AppService.AvailabilityZone` only detects premium by tier property @BenjaminEngeset.
-    [#3034](https://github.com/Azure/PSRule.Rules.Azure/issues/3034)
-  - Fixed loading of expansion options from non-default options file @BernieWhite.
-    [#3033](https://github.com/Azure/PSRule.Rules.Azure/issues/3033)
-
-## v1.39.0-B0055 (pre-release)
-
-What's changed since pre-release v1.39.0-B0029:
-
-- New rules:
-  - Virtual Machine:
-    - Verify that virtual machines does not have public IPs attached by @BenjaminEngeset.
-      [#11](https://github.com/Azure/PSRule.Rules.Azure/issues/11)
-  - Virtual Machine Scale Sets:
-    - Verify that virtual machine scale set instances does not have public IPs attached by @BenjaminEngeset.
-      [#3014](https://github.com/Azure/PSRule.Rules.Azure/issues/3014)
 - Engineering:
   - Bump development tools to .NET 8.0 SDK by @BernieWhite.
     [#3017](https://github.com/Azure/PSRule.Rules.Azure/issues/3017)
@@ -81,6 +73,10 @@ What's changed since pre-release v1.39.0-B0029:
     [#3013](https://github.com/Azure/PSRule.Rules.Azure/issues/3013)
   - Fixed subscription aliases don't support tags by @BernieWhite.
     [#3021](https://github.com/Azure/PSRule.Rules.Azure/issues/3021)
+  - Fixed `Azure.AppService.AvailabilityZone` only detects premium by tier property @BenjaminEngeset.
+    [#3034](https://github.com/Azure/PSRule.Rules.Azure/issues/3034)
+  - Fixed loading of expansion options from non-default options file @BernieWhite.
+    [#3033](https://github.com/Azure/PSRule.Rules.Azure/issues/3033)
 
 ## v1.39.0-B0029 (pre-release)
 


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.39.0-B0029:

- New rules:
  - Virtual Machine:
    - Verify that virtual machines does not have public IPs attached by @BenjaminEngeset.
      [#11](https://github.com/Azure/PSRule.Rules.Azure/issues/11)
    - Verify that multi-tenant Hosting Rights are used for Windows client VMs by @BenjaminEngeset.
      [#432](https://github.com/Azure/PSRule.Rules.Azure/issues/432)
    - Verify that availability set members are in a backend pool by @BenjaminEngeset.
      [#67](https://github.com/Azure/PSRule.Rules.Azure/issues/67)
  - Virtual Machine Scale Sets:
    - Verify that virtual machine scale set instances does not have public IPs attached by @BenjaminEngeset.
      [#3014](https://github.com/Azure/PSRule.Rules.Azure/issues/3014)
- Updated rules:
  - Azure Kubernetes Service:
    - Updated `Azure.AKS.Version` to use `1.29.7` as the minimum version by @BernieWhite.
      [#3042](https://github.com/Azure/PSRule.Rules.Azure/issues/3042)
- General improvements:
  - **Important change:** Replaced the `Azure_AKSNodeMinimumMaxPods` option with `AZURE_AKS_POOL_MINIMUM_MAXPODS` by @BernieWhite.
    [#941](https://github.com/Azure/PSRule.Rules.Azure/issues/941)
    - For compatibility, if `Azure_AKSNodeMinimumMaxPods` is set it will be used instead of `AZURE_AKS_POOL_MINIMUM_MAXPODS`.
    - If only `AZURE_AKS_POOL_MINIMUM_MAXPODS` is set, this value will be used.
    - The default will be used neither options are configured.
    - If `Azure_AKSNodeMinimumMaxPods` is set a warning will be generated until the configuration is removed.
    - Support for `Azure_AKSNodeMinimumMaxPods` is deprecated and will be removed in v2.
    - See [upgrade notes][1] for details.
  - **Important change:** Replaced the `Azure_MinimumCertificateLifetime` option with `AZURE_APIM_MINIMUM_CERTIFICATE_LIFETIME` by @BernieWhite.
    [#941](https://github.com/Azure/PSRule.Rules.Azure/issues/941)
    - For compatibility, if `Azure_MinimumCertificateLifetime` is set it will be used instead of `AZURE_APIM_MINIMUM_CERTIFICATE_LIFETIME`.
    - If only `AZURE_APIM_MINIMUM_CERTIFICATE_LIFETIME` is set, this value will be used.
    - The default will be used neither options are configured.
    - If `Azure_MinimumCertificateLifetime` is set a warning will be generated until the configuration is removed.
    - Support for `Azure_MinimumCertificateLifetime` is deprecated and will be removed in v2.
    - See [upgrade notes][1] for details.
- Engineering:
  - Bump development tools to .NET 8.0 SDK by @BernieWhite.
    [#3017](https://github.com/Azure/PSRule.Rules.Azure/issues/3017)
- Bug fixed:
  - Fixed expansion with deployments by resource ID at management group by @BernieWhite
    [#3013](https://github.com/Azure/PSRule.Rules.Azure/issues/3013)
  - Fixed subscription aliases don't support tags by @BernieWhite.
    [#3021](https://github.com/Azure/PSRule.Rules.Azure/issues/3021)
  - Fixed `Azure.AppService.AvailabilityZone` only detects premium by tier property @BenjaminEngeset.
    [#3034](https://github.com/Azure/PSRule.Rules.Azure/issues/3034)
  - Fixed loading of expansion options from non-default options file @BernieWhite.
    [#3033](https://github.com/Azure/PSRule.Rules.Azure/issues/3033)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
