### PR TITLE
Update TLS defaults for Azure.Redis.MinTLS #3066

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.39.0-B0118:
+
+- Bug fixes:
+  - Fixed TLS defaults for `Azure.Redis.MinTLS` and `Azure.RedisEnterprise.MinTLS` by @BernieWhite.
+    [#3066](https://github.com/Azure/PSRule.Rules.Azure/issues/3066)
+
 ## v1.39.0-B0118 (pre-release)
 
 What's changed since pre-release v1.39.0-B0072:

--- a/docs/en/rules/Azure.Redis.MinTLS.md
+++ b/docs/en/rules/Azure.Redis.MinTLS.md
@@ -1,4 +1,5 @@
 ---
+reviewed: 2024-09-27
 severity: Critical
 pillar: Security
 category: SE:07 Encryption
@@ -15,16 +16,18 @@ Redis Cache should reject TLS versions older than 1.2.
 
 ## DESCRIPTION
 
-The minimum version of TLS that Redis Cache accepts is configurable.
+The minimum version of TLS that Redis Cache accepts was previously configurable.
 Older TLS versions are no longer considered secure by industry standards, such as PCI DSS.
 
-Azure lets you disable outdated protocols and require connections to use a minimum of TLS 1.2.
-By default, TLS 1.0, TLS 1.1, and TLS 1.2 is accepted.
+Depending on when your cache was deployed you may be using a default that specifies an older version of TLS.
+Any new deployments do not allow TLS 1.0 or 1.1 to be specified, however existing cache deployment may require updating.
+
+Support for TLS 1.0 and TLS 1.1 will be removed in 1 November 2024.
 
 ## RECOMMENDATION
 
 Consider configuring the minimum supported TLS version to be 1.2.
-Support for TLS 1.0/ 1.1 version will be removed.
+No action is required for new cache deployments from March 2024, which only support a minimum of TLS 1.2.
 
 ## EXAMPLES
 
@@ -32,14 +35,16 @@ Support for TLS 1.0/ 1.1 version will be removed.
 
 To deploy caches that pass this rule:
 
-- Set the `properties.minimumTlsVersion` property to a minimum of `1.2`.
+- Set the `properties.minimumTlsVersion` property to a minimum of `1.2` for existing caches with an old version of TLS configured.
+  It is not possible to set the `properties.minimumTlsVersion` on new cache deployments from March 2024.
+  New cache deployments only support a minimum TLS version of 1.2.
 
 For example:
 
 ```json
 {
   "type": "Microsoft.Cache/redis",
-  "apiVersion": "2023-04-01",
+  "apiVersion": "2024-03-01",
   "name": "[parameters('name')]",
   "location": "[parameters('location')]",
   "properties": {
@@ -53,7 +58,8 @@ For example:
     "redisConfiguration": {
       "maxmemory-reserved": "615"
     },
-    "enableNonSslPort": false
+    "enableNonSslPort": false,
+    "publicNetworkAccess": "Disabled"
   },
   "zones": [
     "1",
@@ -67,12 +73,14 @@ For example:
 
 To deploy caches that pass this rule:
 
-- Set the `properties.minimumTlsVersion` property to a minimum of `1.2`.
+- Set the `properties.minimumTlsVersion` property to a minimum of `1.2` for existing caches with an old version of TLS configured.
+  It is not possible to set the `properties.minimumTlsVersion` on new cache deployments from March 2024.
+  New cache deployments only support a minimum TLS version of 1.2.
 
 For example:
 
 ```bicep
-resource cache 'Microsoft.Cache/redis@2023-04-01' = {
+resource cache 'Microsoft.Cache/redis@2024-03-01' = {
   name: name
   location: location
   properties: {
@@ -87,6 +95,7 @@ resource cache 'Microsoft.Cache/redis@2023-04-01' = {
       'maxmemory-reserved': '615'
     }
     enableNonSslPort: false
+    publicNetworkAccess: 'Disabled'
   }
   zones: [
     '1'
@@ -103,6 +112,7 @@ resource cache 'Microsoft.Cache/redis@2023-04-01' = {
 To deploy caches that pass this rule:
 
 - Use the `--set` parameter.
+  This parameter only applies to old cache deployments using TLS 1.0 or TLS 1.1.
 
 For example:
 
@@ -115,6 +125,7 @@ az redis update -n '<name>' -g '<resource_group>' --set minimumTlsVersion=1.2
 To deploy caches that pass this rule:
 
 - Use the `-MinimumTlsVersion` parameter.
+  This parameter only applies to old cache deployments using TLS 1.0 or TLS 1.1.
 
 For example:
 

--- a/docs/en/rules/Azure.RedisEnterprise.MinTLS.md
+++ b/docs/en/rules/Azure.RedisEnterprise.MinTLS.md
@@ -1,4 +1,5 @@
 ---
+reviewed: 2024-09-27
 severity: Critical
 pillar: Security
 category: SE:07 Encryption
@@ -14,16 +15,18 @@ Redis Cache should reject TLS versions older than 1.2.
 
 ## DESCRIPTION
 
-The minimum version of TLS that Redis Cache accepts is configurable.
+The minimum version of TLS that Redis Cache accepts was previously configurable.
 Older TLS versions are no longer considered secure by industry standards, such as PCI DSS.
 
-Azure lets you disable outdated protocols and require connections to use a minimum of TLS 1.2.
-By default, TLS 1.0, TLS 1.1, and TLS 1.2 is accepted.
+Depending on when your cache was deployed you may be using a default that specifies an older version of TLS.
+Any new deployments do not allow TLS 1.0 or 1.1 to be specified, however existing cache deployment may require updating.
+
+Support for TLS 1.0 and TLS 1.1 will be removed in 1 November 2024.
 
 ## RECOMMENDATION
 
 Consider configuring the minimum supported TLS version to be 1.2.
-Support for TLS 1.0/ 1.1 version will be removed.
+No action is required for new cache deployments, which only support a minimum of TLS 1.2.
 
 ## EXAMPLES
 
@@ -31,14 +34,16 @@ Support for TLS 1.0/ 1.1 version will be removed.
 
 To deploy caches that pass this rule:
 
-- Set the `properties.minimumTlsVersion` property to `1.2`.
+- Set the `properties.minimumTlsVersion` property to a minimum of `1.2` for existing caches with an old version of TLS configured.
+  It is not possible to set the `properties.minimumTlsVersion` on new cache deployments.
+  New cache deployments only support a minimum TLS version of 1.2.
 
 For example:
 
 ```json
 {
   "type": "Microsoft.Cache/redisEnterprise",
-  "apiVersion": "2022-01-01",
+  "apiVersion": "2024-02-01",
   "name": "[parameters('name')]",
   "location": "[parameters('location')]",
   "sku": {
@@ -54,12 +59,14 @@ For example:
 
 To deploy caches that pass this rule:
 
-- Set the `properties.minimumTlsVersion` property to `1.2`.
+- Set the `properties.minimumTlsVersion` property to a minimum of `1.2` for existing caches with an old version of TLS configured.
+  It is not possible to set the `properties.minimumTlsVersion` on new cache deployments.
+  New cache deployments only support a minimum TLS version of 1.2.
 
 For example:
 
 ```bicep
-resource cache 'Microsoft.Cache/redisEnterprise@2022-01-01' = {
+resource cache 'Microsoft.Cache/redisEnterprise@2024-02-01' = {
   name: name
   location: location
   sku: {
@@ -76,6 +83,7 @@ resource cache 'Microsoft.Cache/redisEnterprise@2022-01-01' = {
 To deploy caches that pass this rule:
 
 - Use the `--set` parameter.
+  This parameter only applies to old cache deployments using TLS 1.0 or TLS 1.1.
 
 For example:
 
@@ -88,6 +96,7 @@ az redis update -n '<name>' -g '<resource_group>' --set minimumTlsVersion=1.2
 To deploy caches that pass this rule:
 
 - Use the `-MinimumTlsVersion` parameter.
+  This parameter only applies to old cache deployments using TLS 1.0 or TLS 1.1.
 
 For example:
 

--- a/docs/examples-redis.bicep
+++ b/docs/examples-redis.bicep
@@ -10,7 +10,7 @@ param name string
 param location string = resourceGroup().location
 
 // An example Redis Cache.
-resource cache 'Microsoft.Cache/redis@2023-08-01' = {
+resource cache 'Microsoft.Cache/redis@2024-03-01' = {
   name: name
   location: location
   properties: {
@@ -35,7 +35,7 @@ resource cache 'Microsoft.Cache/redis@2023-08-01' = {
 }
 
 // An example firewall rule for Redis Cache.
-resource rule 'Microsoft.Cache/redis/firewallRules@2023-08-01' = {
+resource rule 'Microsoft.Cache/redis/firewallRules@2024-03-01' = {
   parent: cache
   name: 'allow-on-premises'
   properties: {

--- a/docs/examples-redis.json
+++ b/docs/examples-redis.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.25.53.49325",
-      "templateHash": "7482944073131107404"
+      "version": "0.30.23.60470",
+      "templateHash": "16114660589456584580"
     }
   },
   "parameters": {
@@ -26,7 +26,7 @@
   "resources": [
     {
       "type": "Microsoft.Cache/redis",
-      "apiVersion": "2023-08-01",
+      "apiVersion": "2024-03-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -51,7 +51,7 @@
     },
     {
       "type": "Microsoft.Cache/redis/firewallRules",
-      "apiVersion": "2023-08-01",
+      "apiVersion": "2024-03-01",
       "name": "[format('{0}/{1}', parameters('name'), 'allow-on-premises')]",
       "properties": {
         "startIP": "10.0.1.1",

--- a/docs/examples-redisenterprise.bicep
+++ b/docs/examples-redisenterprise.bicep
@@ -10,7 +10,7 @@ param name string
 param location string = resourceGroup().location
 
 // An example Redis Enterprise cache.
-resource cache 'Microsoft.Cache/redisEnterprise@2023-11-01' = {
+resource cache 'Microsoft.Cache/redisEnterprise@2024-02-01' = {
   name: name
   location: location
   sku: {

--- a/docs/examples-redisenterprise.json
+++ b/docs/examples-redisenterprise.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.25.53.49325",
-      "templateHash": "3600259857722261042"
+      "version": "0.30.23.60470",
+      "templateHash": "18144616178175150817"
     }
   },
   "parameters": {
@@ -26,7 +26,7 @@
   "resources": [
     {
       "type": "Microsoft.Cache/redisEnterprise",
-      "apiVersion": "2023-11-01",
+      "apiVersion": "2024-02-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "sku": {

--- a/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.yaml
@@ -65,13 +65,13 @@ metadata:
     ruleSet: 2020_06
     Azure.WAF/pillar: Security
   labels:
-    Azure.MCSB.v1/control: 'DP-3'
+    Azure.MCSB.v1/control: DP-3
 spec:
   type:
     - Microsoft.Cache/Redis
   condition:
     field: properties.minimumTlsVersion
-    version: '>=1.2'
+    hasDefault: '1.2'
 
 ---
 # Synopsis: Redis cache should disable public network access.

--- a/src/PSRule.Rules.Azure/rules/Azure.RedisEnterprise.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.RedisEnterprise.Rule.yaml
@@ -19,12 +19,12 @@ metadata:
     ruleSet: 2022_09
     Azure.WAF/pillar: Security
   labels:
-    Azure.MCSB.v1/control: 'DP-3'
+    Azure.MCSB.v1/control: DP-3
 spec:
   type:
   - Microsoft.Cache/redisEnterprise
   condition:
     field: properties.minimumTlsVersion
-    version: '>=1.2'
+    hasDefault: '1.2'
 
 #endregion Rules

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Redis.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Redis.Tests.ps1
@@ -58,14 +58,14 @@ Describe 'Azure.Redis' -Tag 'Redis' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'redis-B', 'redis-C', 'redis-D';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'redis-B', 'redis-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 9;
-            $ruleResult.TargetName | Should -BeIn 'redis-A', 'redis-E', 'redis-F', 'redis-G', 'redis-H', 'redis-I', 'redis-J', 'redis-Q', 'redis-R';
+            $ruleResult.Length | Should -Be 10;
+            $ruleResult.TargetName | Should -BeIn 'redis-A', 'redis-C', 'redis-E', 'redis-F', 'redis-G', 'redis-H', 'redis-I', 'redis-J', 'redis-Q', 'redis-R';
         }
 
         It 'Azure.RedisEnterprise.MinTLS' {
@@ -74,14 +74,14 @@ Describe 'Azure.Redis' -Tag 'Redis' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'redis-S';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'redis-K', 'redis-L';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 6;
-            $ruleResult.TargetName | Should -BeIn 'redis-K', 'redis-L', 'redis-M', 'redis-N', 'redis-O', 'redis-P', 'redis-S';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'redis-M', 'redis-N', 'redis-O', 'redis-P', 'redis-S';
         }
 
         It 'Azure.Redis.MinSKU' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Redis.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Redis.json
@@ -58,6 +58,7 @@
         "family": "C",
         "capacity": 2
       },
+      "minimumTlsVersion": "1.0",
       "enableNonSslPort": true,
       "redisConfiguration": {
         "aad-enabled": null,
@@ -403,6 +404,7 @@
         "family": "C",
         "capacity": 1
       },
+      "minimumTlsVersion": "1.1",
       "enableNonSslPort": false,
       "instances": [
         {
@@ -912,7 +914,7 @@
     "SubscriptionId": "00000000-0000-0000-0000-000000000000",
     "Tags": {},
     "Properties": {
-      "minimumTlsVersion": "1.2",
+      "minimumTlsVersion": "1.0",
       "hostName": "redis-K.redis.cache.windows.net"
     },
     "sku": {
@@ -935,7 +937,7 @@
     "SubscriptionId": "00000000-0000-0000-0000-000000000000",
     "Tags": {},
     "Properties": {
-      "minimumTlsVersion": "1.2",
+      "minimumTlsVersion": "1.1",
       "hostName": "redis-L.redis.cache.windows.net"
     },
     "sku": {


### PR DESCRIPTION
## PR Summary

- Fixed TLS defaults for `Azure.Redis.MinTLS` and `Azure.RedisEnterprise.MinTLS`.

Fixces #3066 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
