### PR TITLE
Updated Azure.ContainerApp.AvailabilityZone to check for infrastructure subnet #3068

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -31,6 +31,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v1.39.0-B0118:
 
+- Updated rules:
+  - Container Apps:
+    - Updated `Azure.ContainerApp.AvailabilityZone` to check for infrastructure subnet by @BernieWhite.
+      [#3068](https://github.com/Azure/PSRule.Rules.Azure/issues/3068)
+      - Configuring an infrastructure subnet is a requirement for enabling zone redundancy.
+        Both rule and documentation have been updated to clearly call this out.
 - Engineering:
   - Quality updates to rule documentation by @BernieWhite.
     [#2570](https://github.com/Azure/PSRule.Rules.Azure/issues/2570)

--- a/docs/en/rules/Azure.ContainerApp.AvailabilityZone.md
+++ b/docs/en/rules/Azure.ContainerApp.AvailabilityZone.md
@@ -1,5 +1,5 @@
 ---
-reviewed: 2024-04-07
+reviewed: 2024-10-01
 severity: Important
 pillar: Reliability
 category: RE:05 Regions and availability zones
@@ -16,14 +16,21 @@ Use Container Apps environments that are zone redundant to improve reliability.
 ## DESCRIPTION
 
 Container App environments can be configured to be zone redundant in regions that support availability zones.
+Zone redundancy is supported in both the workload profiles and consumption only environments.
 When configured, replicas of each Container App are spread across availability zones automatically.
 A Container App must have multiple replicas to be zone redundant.
 
-For example, if a Container App has three replicas, each replica is placed in a different availability zone.
+For example:
+
+- If a Container App has three replicas, each replica is placed in a different availability zone.
+- If a Container App has one replica, it is only available in a single zone.
+
+Zone redundancy can only be enabled at initial environment creation.
+Additionally, the Container App environment must be deployed with an infrastructure subnet configured.
 
 ## RECOMMENDATION
 
-Consider configuring Container App environments to be zone redundant to improve reliability.
+Consider configuring Container App environments to be zone redundant to improve workload resiliency.
 
 ## EXAMPLES
 
@@ -32,6 +39,7 @@ Consider configuring Container App environments to be zone redundant to improve 
 To deploy Container App environments that pass this rule:
 
 - Set the `properties.zoneRedundant` property to `true`.
+- Set the `properties.vnetConfiguration.infrastructureSubnetId` property to reference a valid subnet.
 
 For example:
 
@@ -69,6 +77,7 @@ For example:
 To deploy Container App environments that pass this rule:
 
 - Set the `properties.zoneRedundant` property to `true`.
+- Set the `properties.vnetConfiguration.infrastructureSubnetId` property to reference a valid subnet.
 
 For example:
 
@@ -99,7 +108,7 @@ resource containerEnv 'Microsoft.App/managedEnvironments@2023-05-01' = {
 }
 ```
 
-<!-- external:avm avm/res/app/managed-environment:0.8.0 zoneRedundant -->
+<!-- external:avm avm/res/app/managed-environment:0.8.0 zoneRedundant,vnetConfiguration.infrastructureSubnetId -->
 
 ## LINKS
 

--- a/src/PSRule.Rules.Azure/rules/Azure.ContainerApp.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.ContainerApp.Rule.ps1
@@ -30,6 +30,7 @@ Rule 'Azure.ContainerApp.AvailabilityZone' -Ref 'AZR-000414' -Type 'Microsoft.Ap
     }
 
     $Assert.HasFieldValue($TargetObject, 'properties.zoneRedundant', $True);
+    $Assert.HasFieldValue($TargetObject, 'properties.vnetConfiguration.infrastructureSubnetId');
 }
 
 #endregion Rules
@@ -38,9 +39,9 @@ Rule 'Azure.ContainerApp.AvailabilityZone' -Ref 'AZR-000414' -Type 'Microsoft.Ap
 
 function global:HasIngress {
     [CmdletBinding()]
-    param ()    
+    param ()
     process {
-        $Assert.HasField($TargetObject, 'properties.configuration.ingress').Result   
+        $Assert.HasField($TargetObject, 'properties.configuration.ingress').Result
     }
 }
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ContainerApp.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ContainerApp.Tests.ps1
@@ -197,7 +197,7 @@ Describe 'Azure.ContainerApp' -Tag 'ContainerApp' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult.Length | Should -Be 2;
             $ruleResult.TargetName | Should -BeIn 'capp-env-A', 'capp-env-B';
-            $ruleResult.Detail.Reason.Path | Should -BeIn 'properties.zoneRedundant';
+            $ruleResult.Detail.Reason.Path | Should -BeIn 'properties.zoneRedundant', 'properties.vnetConfiguration.infrastructureSubnetId';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });


### PR DESCRIPTION
## PR Summary

- Updated `Azure.ContainerApp.AvailabilityZone` to check for infrastructure subnet by @BernieWhite.
  - Configuring an infrastructure subnet is a requirement for enabling zone redundancy.
    Both rule and documentation have been updated to clearly call this out.

Fixes #3068 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section