### PR TITLE
Fixed GetBicepParamResources exception when expanding Microsoft Graph #3062

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.39.0:
+
+- Bug fixes:
+  - Fixed `GetBicepParamResources` exception when expanding `Microsoft.Graph/groups` resource by @BernieWhite.
+    [#3062](https://github.com/Azure/PSRule.Rules.Azure/issues/3062)
+
 ## v1.39.0
 
 What's changed since pre-release v1.38.0:

--- a/src/PSRule.Rules.Azure/Common/JsonExtensions.cs
+++ b/src/PSRule.Rules.Azure/Common/JsonExtensions.cs
@@ -19,6 +19,7 @@ namespace PSRule.Rules.Azure
         private const string PROPERTY_TYPE = "type";
         private const string PROPERTY_FIELD = "field";
         private const string PROPERTY_EXISTING = "existing";
+        private const string PROPERTY_IMPORT = "import";
         private const string PROPERTY_SCOPE = "scope";
         private const string PROPERTY_SUBSCRIPTION_ID = "subscriptionId";
         private const string PROPERTY_RESOURCE_GROUP = "resourceGroup";
@@ -508,9 +509,25 @@ namespace PSRule.Rules.Azure
                 (value.Type == JTokenType.String && string.IsNullOrEmpty(value.Value<string>()));
         }
 
+        /// <summary>
+        /// Resources with the <c>existing</c> property set to <c>true</c> are references to existing resources.
+        /// </summary>
+        /// <param name="o">The resource <seealso cref="JObject"/>.</param>
+        /// <returns>Returns <c>true</c> if the resource is a reference to an existing resource.</returns>
         internal static bool IsExisting(this JObject o)
         {
             return o != null && o.TryBoolProperty(PROPERTY_EXISTING, out var existing) && existing != null && existing.Value;
+        }
+
+        /// <summary>
+        /// Resources with an <c>import</c> property set to a non-empty string refer to extensibility provided resources.
+        /// For example, Microsoft Graph.
+        /// </summary>
+        /// <param name="o">The resource <seealso cref="JObject"/>.</param>
+        /// <returns>Returns <c>true</c> if the resource is imported from an extensibility provider.</returns>
+        internal static bool IsImport(this JObject o)
+        {
+            return o != null && o.TryStringProperty(PROPERTY_IMPORT, out var s) && !string.IsNullOrEmpty(s);
         }
 
         internal static bool TryResourceType(this JObject o, out string type)

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -1231,7 +1231,7 @@ namespace PSRule.Rules.Azure.Data.Template
                     {
                         Reference(context, p.Name, resource);
                     }
-                    else
+                    else if (!resource.IsImport())
                     {
                         r.AddRange(ResourceExpand(context, p.Name, resource));
                     }

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ExtensibilityTestCases/Tests.Bicep.1.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ExtensibilityTestCases/Tests.Bicep.1.bicep
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/3062
+
+extension microsoftGraphV1_0
+
+var appRoleId = 'appRoleId'
+var certKey = 'certKey'
+
+resource resourceApp 'Microsoft.Graph/applications@v1.0' = {
+  uniqueName: 'ExampleResourceApp'
+  displayName: 'Example Resource Application'
+  appRoles: [
+    {
+      id: appRoleId
+      allowedMemberTypes: ['User', 'Application']
+      description: 'Read access to resource app data'
+      displayName: 'ResourceAppData.Read.All'
+      value: 'ResourceAppData.Read.All'
+      isEnabled: true
+    }
+  ]
+}
+
+resource resourceSp 'Microsoft.Graph/servicePrincipals@v1.0' = {
+  appId: resourceApp.appId
+}
+
+resource clientApp 'Microsoft.Graph/applications@v1.0' = {
+  uniqueName: 'ExampleClientApp'
+  displayName: 'Example Client Application'
+  keyCredentials: [
+    {
+      displayName: 'Example Client App Key Credential'
+      usage: 'Verify'
+      type: 'AsymmetricX509Cert'
+      key: certKey
+    }
+  ]
+}
+
+resource clientSp 'Microsoft.Graph/servicePrincipals@v1.0' = {
+  appId: clientApp.appId
+}

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ExtensibilityTestCases/Tests.Bicep.1.json
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ExtensibilityTestCases/Tests.Bicep.1.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.1-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+    "_EXPERIMENTAL_FEATURES_ENABLED": [
+      "Extensibility"
+    ],
+    "_generator": {
+      "name": "bicep",
+      "version": "0.30.23.60470",
+      "templateHash": "2001503425732761903"
+    }
+  },
+  "variables": {
+    "appRoleId": "appRoleId",
+    "certKey": "certKey"
+  },
+  "imports": {
+    "MicrosoftGraph": {
+      "provider": "MicrosoftGraph",
+      "version": "0.1.8-preview"
+    }
+  },
+  "resources": {
+    "resourceApp": {
+      "import": "MicrosoftGraph",
+      "type": "Microsoft.Graph/applications@v1.0",
+      "properties": {
+        "uniqueName": "ExampleResourceApp",
+        "displayName": "Example Resource Application",
+        "appRoles": [
+          {
+            "id": "[variables('appRoleId')]",
+            "allowedMemberTypes": [
+              "User",
+              "Application"
+            ],
+            "description": "Read access to resource app data",
+            "displayName": "ResourceAppData.Read.All",
+            "value": "ResourceAppData.Read.All",
+            "isEnabled": true
+          }
+        ]
+      }
+    },
+    "resourceSp": {
+      "import": "MicrosoftGraph",
+      "type": "Microsoft.Graph/servicePrincipals@v1.0",
+      "properties": {
+        "appId": "[reference('resourceApp').appId]"
+      },
+      "dependsOn": [
+        "resourceApp"
+      ]
+    },
+    "clientApp": {
+      "import": "MicrosoftGraph",
+      "type": "Microsoft.Graph/applications@v1.0",
+      "properties": {
+        "uniqueName": "ExampleClientApp",
+        "displayName": "Example Client Application",
+        "keyCredentials": [
+          {
+            "displayName": "Example Client App Key Credential",
+            "usage": "Verify",
+            "type": "AsymmetricX509Cert",
+            "key": "[variables('certKey')]"
+          }
+        ]
+      }
+    },
+    "clientSp": {
+      "import": "MicrosoftGraph",
+      "type": "Microsoft.Graph/servicePrincipals@v1.0",
+      "properties": {
+        "appId": "[reference('clientApp').appId]"
+      },
+      "dependsOn": [
+        "clientApp"
+      ]
+    }
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ExtensibilityTestCases/bicepconfig.json
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ExtensibilityTestCases/bicepconfig.json
@@ -1,0 +1,9 @@
+{
+  "experimentalFeaturesEnabled": {
+    "optionalModuleNames": true,
+    "extensibility": true
+  },
+  "extensions": {
+    "microsoftGraphV1_0": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview"
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -287,6 +287,9 @@
     <None Update="Template.Policy.WithDeployment.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Bicep\ExtensibilityTestCases\Tests.Bicep.1.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -1351,6 +1351,21 @@ namespace PSRule.Rules.Azure
             Assert.Equal("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/ps-rule-test-rg/providers/Microsoft.Sql/servers/server01/databases/db02", actual["scope"].Value<string>());
         }
 
+        /// <summary>
+        /// Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/3062
+        /// </summary>
+        [Fact]
+        public void ProcessTemplate_WhenMicrosoftGraphType_ShouldIgnoreExtensibilityResources()
+        {
+            var resources = ProcessTemplate(GetSourcePath("Bicep/ExtensibilityTestCases/Tests.Bicep.1.json"), null, out _);
+
+            Assert.Single(resources);
+
+            var actual = resources[0];
+            Assert.Equal("Microsoft.Resources/deployments", actual["type"].Value<string>());
+            Assert.Equal("ps-rule-test-deployment", actual["name"].Value<string>());
+        }
+
         #region Helper methods
 
         private static string GetSourcePath(string fileName)


### PR DESCRIPTION
## PR Summary

- Fixed `GetBicepParamResources` exception when expanding `Microsoft.Graph/groups` resource.

Fixes #3062

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
