### PR TITLE
Release v1.39.1

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,7 +29,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
-What's changed since pre-release v1.39.0:
+## v1.39.1
+
+What's changed since v1.39.0:
 
 - Bug fixes:
   - Fixed `GetBicepParamResources` exception when expanding `Microsoft.Graph/groups` resource by @BernieWhite.


### PR DESCRIPTION
## PR Summary

What's changed since v1.39.0:

- Bug fixes:
  - Fixed `GetBicepParamResources` exception when expanding `Microsoft.Graph/groups` resource by @BernieWhite.
    [#3062](https://github.com/Azure/PSRule.Rules.Azure/issues/3062)
  - Fixed `Azure.AppGw.AvailabilityZone` passes when a zonal configuration is used by @BernieWhite.
    [#3061](https://github.com/Azure/PSRule.Rules.Azure/issues/3061)
  - Fixed conditional secret as parameter or placeholder by @BernieWhite.
    [#2054](https://github.com/Azure/PSRule.Rules.Azure/issues/2054)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
