### PR TITLE
Fixes name expand of existing resource references #3123

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -34,6 +34,8 @@ What's changed since v1.39.1:
 - Bug fixes:
   - Fixed user-defined function reference to exported variable by @BernieWhite.
     [#3120](https://github.com/Azure/PSRule.Rules.Azure/issues/3120)
+  - Fixed name expand of existing resource references by @BernieWhite.
+    [#3123](https://github.com/Azure/PSRule.Rules.Azure/issues/3123)
 
 ## v1.39.1
 

--- a/src/PSRule.Rules.Azure/Data/Template/ExistingResourceValue.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExistingResourceValue.cs
@@ -70,8 +70,7 @@ internal sealed class ExistingResourceValue : IResourceValue
     /// <returns></returns>
     private string GetId()
     {
-        if (!Value.TryResourceScope(_Context, out var scopeId))
-            throw new TemplateSymbolException(SymbolicName);
+        if (!Value.TryResourceScope(_Context, out var scopeId)) throw new TemplateSymbolException(SymbolicName);
 
         return _Id = ResourceHelper.ResourceId(Type, Name, scopeId);
     }
@@ -81,10 +80,9 @@ internal sealed class ExistingResourceValue : IResourceValue
     /// </summary>
     private string GetName()
     {
-        if (!Value.TryResourceName(out var name) || string.IsNullOrEmpty(name))
-            throw new TemplateSymbolException(SymbolicName);
+        if (!Value.TryResourceName(out var name) || string.IsNullOrEmpty(name)) throw new TemplateSymbolException(SymbolicName);
 
-        return _Name = name.IsExpressionString() ? name.ToString() : name;
+        return _Name = ExpandString(_Context, name);
     }
 }
 

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.1.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.1.bicep
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 // Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/2922
+// Based on work contributed by @GABRIELNGBTUC
 
 module child_loop './Tests.Bicep.1.child.bicep' = [
   for (item, index) in range(0, 2): {

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.3.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.3.bicep
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/3123
+// Contributed by @CharlesToniolo
+
+var webAppsNames = [
+  'example1'
+  'example2'
+]
+
+resource webApps 'Microsoft.Web/sites@2022-09-01' existing = [
+  for webAppName in webAppsNames: {
+    name: webAppName
+  }
+]
+
+#disable-next-line no-unused-existing-resources
+resource webAppSettings 'Microsoft.Web/sites/config@2022-09-01' existing = [
+  for i in range(0, length(webAppsNames)): {
+    name: 'appsettings'
+    parent: webApps[i]
+  }
+]

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.3.json
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.3.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.30.23.60470",
+      "templateHash": "3757483382650491065"
+    }
+  },
+  "variables": {
+    "webAppsNames": [
+      "example1",
+      "example2"
+    ]
+  },
+  "resources": {
+    "webApps": {
+      "copy": {
+        "name": "webApps",
+        "count": "[length(variables('webAppsNames'))]"
+      },
+      "existing": true,
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2022-09-01",
+      "name": "[variables('webAppsNames')[copyIndex()]]"
+    },
+    "webAppSettings": {
+      "copy": {
+        "name": "webAppSettings",
+        "count": "[length(range(0, length(variables('webAppsNames'))))]"
+      },
+      "existing": true,
+      "type": "Microsoft.Web/sites/config",
+      "apiVersion": "2022-09-01",
+      "name": "[format('{0}/{1}', variables('webAppsNames')[range(0, length(variables('webAppsNames')))[copyIndex()]], 'appsettings')]",
+      "dependsOn": [
+        "[format('webApps[{0}]', range(0, length(variables('webAppsNames')))[copyIndex()])]"
+      ]
+    }
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/UserDefinedFunctionTestCases/Tests.Bicep.1.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/UserDefinedFunctionTestCases/Tests.Bicep.1.bicep
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 // Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/3120
+// Based on work contributed by @GABRIELNGBTUC
 
 import * as child from './Tests.Bicep.1.child.bicep'
 

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -296,6 +296,9 @@
     <None Update="Bicep\UserDefinedFunctionTestCases\Tests.Bicep.1.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Bicep\SymbolicNameTestCases\Tests.Bicep.3.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -1308,6 +1308,15 @@ namespace PSRule.Rules.Azure
             Assert.Equal("02041802-66a9-0a85-7330-8186e16422c7", actual["name"].Value<string>());
         }
 
+        /// <summary>
+        /// Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/3123
+        /// </summary>
+        [Fact]
+        public void ProcessTemplate_WhenExistingReferenceNameUsesExpression_ShouldExpandExpression()
+        {
+            var resources = ProcessTemplate(GetSourcePath("Bicep/SymbolicNameTestCases/Tests.Bicep.3.json"), null, out _);
+        }
+
         [Fact]
         public void ProcessTemplate_WhenParented_ShouldReturnExpectedScope()
         {

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.38.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.38.bicep
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 // Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/2850
+// Based on work contributed by @maythamfahmi
 
 // Handle from subscription scope.
 targetScope = 'subscription'


### PR DESCRIPTION
## PR Summary

- Fixed name expand of existing resource references.

Fixes #3123

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
