### PR TITLE
Fixes empty string handling in Azure.NSG.LateralTraversal #3130

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,10 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+- Bug fixes:
+  - Fixed evaluation of `Azure.NSG.LateralTraversal` with empty string properties by @BernieWhite.
+    [#3130](https://github.com/Azure/PSRule.Rules.Azure/issues/3130)
+
 ## v1.40.0-B0029 (pre-release)
 
 What's changed since v1.39.3:

--- a/src/PSRule.Rules.Azure/Data/Network/NetworkSecurityGroupEvaluator.cs
+++ b/src/PSRule.Rules.Azure/Data/Network/NetworkSecurityGroupEvaluator.cs
@@ -12,7 +12,7 @@ namespace PSRule.Rules.Azure.Data.Network;
 /// <summary>
 /// A basic implementation of an evaluator for checking NSG rules.
 /// </summary>
-internal sealed partial class NetworkSecurityGroupEvaluator : INetworkSecurityGroupEvaluator
+internal sealed class NetworkSecurityGroupEvaluator : INetworkSecurityGroupEvaluator
 {
     private const string PROPERTIES = "properties";
     private const string DIRECTION = "direction";
@@ -76,7 +76,7 @@ internal sealed partial class NetworkSecurityGroupEvaluator : INetworkSecurityGr
         if (o.TryProperty(propertyName, out string[] value) && value.Length > 0)
             return value;
 
-        return o.TryProperty(propertyName, out string s) && s != ANY ? [s] : null;
+        return o.TryProperty(propertyName, out string s) && s != ANY && !string.IsNullOrEmpty(s) ? [s] : null;
     }
 }
 

--- a/tests/PSRule.Rules.Azure.Tests/NetworkSecurityGroupEvaluatorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/NetworkSecurityGroupEvaluatorTests.cs
@@ -10,21 +10,32 @@ namespace PSRule.Rules.Azure.Data.Network;
 public sealed class NetworkSecurityGroupEvaluatorTests
 {
     [Fact]
+    public void Outbound_WhenMatchingRule_ShouldReturnAccess()
+    {
+        var evaluator = new NetworkSecurityGroupEvaluator();
+        evaluator.With([Rule(access: "Deny", destinationAddressPrefix: "VirtualNetwork", destinationPortRanges: ["3389"])]);
+
+        Assert.Equal(Access.Deny, evaluator.Outbound("VirtualNetwork", 3389));
+    }
+
+    [Fact]
     public void With_WhenDestinationPortRangeIsEmptyString_ShouldUseDestinationPortRanges()
     {
         var evaluator = new NetworkSecurityGroupEvaluator();
-        evaluator.With([NewRule(destinationPortRange: "", destinationPortRanges: ["80", "443"])]);
+        evaluator.With([Rule(access: "Deny", destinationPortRange: "", destinationPortRanges: ["80", "443"])]);
 
         Assert.Equal(Access.Deny, evaluator.Outbound("Virtual Network", 443));
     }
 
     #region Helper methods
 
-    private static PSObject NewRule(string? destinationPortRange = default, string[]? destinationPortRanges = default)
+    private static PSObject Rule(string direction = "Outbound", string access = "Allow", string protocol = "Tcp", string? destinationAddressPrefix = default, string? destinationPortRange = default, string[]? destinationPortRanges = default)
     {
         var properties = new PSObject();
-        properties.Properties.Add(new PSNoteProperty("direction", "Outbound"));
-        properties.Properties.Add(new PSNoteProperty("access", "Deny"));
+        properties.Properties.Add(new PSNoteProperty("direction", direction));
+        properties.Properties.Add(new PSNoteProperty("access", access));
+        properties.Properties.Add(new PSNoteProperty("protocol", protocol));
+        properties.Properties.Add(new PSNoteProperty("destinationAddressPrefix", destinationAddressPrefix));
 
         if (destinationPortRange != null)
             properties.Properties.Add(new PSNoteProperty("destinationPortRange", destinationPortRange));
@@ -32,9 +43,9 @@ public sealed class NetworkSecurityGroupEvaluatorTests
         if (destinationPortRanges != null)
             properties.Properties.Add(new PSNoteProperty("destinationPortRanges", destinationPortRanges));
 
-        var o = new PSObject();
-        o.Properties.Add(new PSNoteProperty("properties", properties));
-        return o;
+        var result = new PSObject();
+        result.Properties.Add(new PSNoteProperty("properties", properties));
+        return result;
     }
 
     #endregion Helper methods

--- a/tests/PSRule.Rules.Azure.Tests/NetworkSecurityGroupEvaluatorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/NetworkSecurityGroupEvaluatorTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Management.Automation;
+
+namespace PSRule.Rules.Azure.Data.Network;
+
+#nullable enable
+
+public sealed class NetworkSecurityGroupEvaluatorTests
+{
+    [Fact]
+    public void With_WhenDestinationPortRangeIsEmptyString_ShouldUseDestinationPortRanges()
+    {
+        var evaluator = new NetworkSecurityGroupEvaluator();
+        evaluator.With([NewRule(destinationPortRange: "", destinationPortRanges: ["80", "443"])]);
+
+        Assert.Equal(Access.Deny, evaluator.Outbound("Virtual Network", 443));
+    }
+
+    #region Helper methods
+
+    private static PSObject NewRule(string? destinationPortRange = default, string[]? destinationPortRanges = default)
+    {
+        var properties = new PSObject();
+        properties.Properties.Add(new PSNoteProperty("direction", "Outbound"));
+        properties.Properties.Add(new PSNoteProperty("access", "Deny"));
+
+        if (destinationPortRange != null)
+            properties.Properties.Add(new PSNoteProperty("destinationPortRange", destinationPortRange));
+
+        if (destinationPortRanges != null)
+            properties.Properties.Add(new PSNoteProperty("destinationPortRanges", destinationPortRanges));
+
+        var o = new PSObject();
+        o.Properties.Add(new PSNoteProperty("properties", properties));
+        return o;
+    }
+
+    #endregion Helper methods
+}
+
+#nullable restore


### PR DESCRIPTION
## PR Summary

- Fixed evaluation of `Azure.NSG.LateralTraversal` with empty string properties.

Fixes #3130

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
