### PR TITLE
Pre-release v1.40.0-B0063

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,10 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.40.0-B0063 (pre-release)
+
+What's changed since pre-release v1.40.0-B0029:
+
 - Updated rules:
   - Microsoft Defender for Cloud:
     - Updated `Azure.DefenderCloud.Contact` to use `emails` property and removed `phone` by @BernieWhite.


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.40.0-B0029:

- Updated rules:
  - Microsoft Defender for Cloud:
    - Updated `Azure.DefenderCloud.Contact` to use `emails` property and removed `phone` by @BernieWhite.
      [#3117](https://github.com/Azure/PSRule.Rules.Azure/issues/3117)
      - Renamed rule to `Azure.Defender.SecurityContact` to better align with naming for defender rules.
      - Bumped rule set to `2024_12`.
- Bug fixes:
  - Fixed evaluation of `Azure.NSG.LateralTraversal` with empty string properties by @BernieWhite.
    [#3130](https://github.com/Azure/PSRule.Rules.Azure/issues/3130)
  - Fixed evaluation of `Azure.Deployment.AdminUsername` with symbolic references by @BernieWhite.
    [#3146](https://github.com/Azure/PSRule.Rules.Azure/issues/3146)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
