### PR TITLE
Fixes APIM policies when using embedded C# with quotes #3184

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.40.0-B0147:
+
+- Bug fixes:
+  - Fixed evaluation of APIM policies when using embedded C# with quotes by #BernieWhite.
+    [#3184](https://github.com/Azure/PSRule.Rules.Azure/issues/3184)
+
 ## v1.40.0-B0147 (pre-release)
 
 What's changed since pre-release v1.40.0-B0103:

--- a/src/PSRule.Rules.Azure/Data/APIM/APIMPolicyReader.cs
+++ b/src/PSRule.Rules.Azure/Data/APIM/APIMPolicyReader.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Xml;
+using System.Text.RegularExpressions;
+using System.IO;
+
+namespace PSRule.Rules.Azure.Data.APIM;
+
+/// <summary>
+/// A reader for APIM policy files.
+/// </summary>
+internal static class APIMPolicyReader
+{
+    // Create a regex pattern to match the `="@(` `)"` pairs.
+    private static readonly Regex _Pattern = new(@"(?<=\=""\@\().*?(?=\)"")", RegexOptions.Singleline | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Read the content of the policy file as XML.
+    /// </summary>
+    /// <remarks>
+    /// This method automatically escapes quotes within policy expressions to ensure the XML is well-formed.
+    /// </remarks>
+    public static XmlReader ReadContent(string content)
+    {
+        // For each match replace `"` characters with `&quot;`.
+        foreach (Match match in _Pattern.Matches(content))
+        {
+            content = content.Replace(match.Value, match.Value.Replace("\"", "&quot;"));
+        }
+
+        return XmlReader.Create(new StringReader(content));
+    }
+}

--- a/src/PSRule.Rules.Azure/Runtime/Helper.cs
+++ b/src/PSRule.Rules.Azure/Runtime/Helper.cs
@@ -5,8 +5,10 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
+using System.Xml;
 using PSRule.Rules.Azure.Configuration;
 using PSRule.Rules.Azure.Data;
+using PSRule.Rules.Azure.Data.APIM;
 using PSRule.Rules.Azure.Data.Bicep;
 using PSRule.Rules.Azure.Data.Network;
 using PSRule.Rules.Azure.Data.Template;
@@ -204,6 +206,17 @@ public static class Helper
 
         var parts = resourceName.Split('/');
         return parts[parts.Length - 1];
+    }
+
+    /// <summary>
+    /// Load a APIM policy as an XML document.
+    /// </summary>
+    public static XmlDocument GetAPIMPolicyDocument(string content)
+    {
+        using var reader = APIMPolicyReader.ReadContent(content);
+        var doc = new XmlDocument();
+        doc.Load(reader);
+        return doc;
     }
 
     #region Helper methods

--- a/src/PSRule.Rules.Azure/rules/Azure.APIM.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.APIM.Rule.ps1
@@ -383,7 +383,7 @@ function global:GetAPIMPolicyNode {
         }
         $policies | ForEach-Object {
             if (!($IgnoreGlobal -and $_.type -eq 'Microsoft.ApiManagement/service/policies') -and $_.properties.format -in 'rawxml', 'xml' -and $_.properties.value) {
-                $xml = [Xml]$_.properties.value
+                $xml = [PSRule.Rules.Azure.Runtime.Helper]::GetAPIMPolicyDocument($_.properties.value)
                 $xml.SelectNodes("//${Node}")
             }
         }

--- a/tests/PSRule.Rules.Azure.Tests/APIM/APIMPolicyTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/APIM/APIMPolicyTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Xml;
+using PSRule.Rules.Azure.Data.APIM;
+
+namespace PSRule.Rules.Azure.APIM;
+
+/// <summary>
+/// Test cases for APIM policy files with complex syntax.
+/// </summary>
+public sealed class APIMPolicyTests : BaseTests
+{
+    /// <summary>
+    /// Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/3184
+    /// </summary>
+    [Fact]
+    public void APIMPolicyReader_WhenExpressionIsFound_ShouldEscapeAndLoad()
+    {
+        using var reader = ReadContentFromFile("APIM/Tests.Policy.1.xml");
+
+        var doc = new XmlDocument();
+        doc.Load(reader);
+
+        var node = doc.SelectSingleNode("//set-variable");
+
+        Assert.Equal("@(context.Request.Headers.GetValueOrDefault(\"X-Original-Host\", \"NotAvailable\"))", node.Attributes["value"].Value);
+    }
+
+    #region Helper methods
+
+    private static XmlReader ReadContentFromFile(string fileName)
+    {
+        var content = GetContent(fileName);
+        return APIMPolicyReader.ReadContent(content);
+    }
+
+    #endregion Helper methods
+}

--- a/tests/PSRule.Rules.Azure.Tests/APIM/Tests.Policy.1.xml
+++ b/tests/PSRule.Rules.Azure.Tests/APIM/Tests.Policy.1.xml
@@ -1,0 +1,19 @@
+<!-- Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/3184 -->
+<!-- Based on work contributed by @GABRIELNGBTUC -->
+<policies>
+	<inbound>
+		<base />
+		<set-backend-service base-url="{{backend}}" />
+		<authentication-managed-identity resource="{{audience}}" />
+    <set-variable name="originalHost" value="@(context.Request.Headers.GetValueOrDefault("X-Original-Host", "NotAvailable"))" />
+	</inbound>
+	<backend>
+		<base />
+	</backend>
+	<outbound>
+		<base />
+	</outbound>
+	<on-error>
+		<base />
+	</on-error>
+</policies>

--- a/tests/PSRule.Rules.Azure.Tests/BaseTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/BaseTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+
+namespace PSRule.Rules.Azure;
+
+public abstract class BaseTests
+{
+    protected static string GetSourcePath(string fileName)
+    {
+        return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
+    }
+
+    protected static string GetContent(string fileName)
+    {
+        var path = GetSourcePath(fileName);
+        return File.ReadAllText(path);
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -317,6 +317,9 @@
     <None Update="Bicep\ScopeTestCases\Tests.Bicep.1.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="APIM\Tests.Policy.1.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTestsBase.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTestsBase.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.IO;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using PSRule.Rules.Azure.Configuration;
@@ -12,14 +10,9 @@ using static PSRule.Rules.Azure.Data.Template.TemplateVisitor;
 
 namespace PSRule.Rules.Azure;
 
-public abstract class TemplateVisitorTestsBase
+public abstract class TemplateVisitorTestsBase : BaseTests
 {
     #region Helper methods
-
-    protected static string GetSourcePath(string fileName)
-    {
-        return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
-    }
 
     protected static JObject[] ProcessTemplate(string templateFile, string parametersFile)
     {


### PR DESCRIPTION
## PR Summary

- Fixed evaluation of APIM policies when using embedded C# with quotes.

Fixes #3184

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
