### PR TITLE
Bump AKS version to v1.30.6 #3206

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -32,6 +32,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 What's changed since v1.40.0:
 
 - Updated rules:
+  - Azure Kubernetes Service:
+    - Updated `Azure.AKS.Version` to use `1.30.6` as the minimum version by @BernieWhite.
+      [#3206](https://github.com/Azure/PSRule.Rules.Azure/issues/3206)
   - Container Registry:
     - Updated documentation and promoted `Azure.ACR.AnonymousAccess` to GA by @BernieWhite.
       [#3119](https://github.com/Azure/PSRule.Rules.Azure/issues/3119)

--- a/docs/concepts/about_PSRule_Azure_Configuration.md
+++ b/docs/concepts/about_PSRule_Azure_Configuration.md
@@ -50,7 +50,7 @@ Default:
 ```yaml
 # YAML: The default AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option
 configuration:
-  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.29.7
+  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.30.6
 ```
 
 Example:

--- a/docs/en/rules/Azure.AKS.NodeAutoUpgrade.md
+++ b/docs/en/rules/Azure.AKS.NodeAutoUpgrade.md
@@ -60,7 +60,7 @@ For example:
         }
     },
     "properties": {
-        "kubernetesVersion": "1.29.7",
+        "kubernetesVersion": "1.30.6",
         "enableRBAC": true,
         "dnsPrefix": "[parameters('dnsPrefix')]",
         "agentPoolProfiles": "[variables('allPools')]",
@@ -137,7 +137,7 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2023-07-01' = {
     }
   }
   properties: {
-    kubernetesVersion: '1.29.7'
+    kubernetesVersion: '1.30.6'
     enableRBAC: true
     dnsPrefix: dnsPrefix
     agentPoolProfiles: allPools
@@ -213,7 +213,6 @@ It's important for you to know when a particular AKS release is hitting your reg
 
 AKS release tracker provides  specific component updates present in an AKS version release real time by versions and regions.
 It also helps you to identify such fixes shipped to a core add-on, and node image updates for Azure Linux, Ubuntu, and Windows.
-
 
 ## LINKS
 

--- a/docs/en/rules/Azure.AKS.NodeMinPods.md
+++ b/docs/en/rules/Azure.AKS.NodeMinPods.md
@@ -230,6 +230,8 @@ resource clusterWithPools 'Microsoft.ContainerService/managedClusters@2023-11-01
 }
 ```
 
+<!-- external:avm avm/res/container-service/managed-cluster agentPools[*].minPods -->
+
 ## NOTES
 
 ### Rule configuration

--- a/docs/en/rules/Azure.AKS.PoolVersion.md
+++ b/docs/en/rules/Azure.AKS.PoolVersion.md
@@ -1,7 +1,7 @@
 ---
 severity: Important
 pillar: Reliability
-category: Design
+category: RE:04 Target metrics
 resource: Azure Kubernetes Service
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AKS.PoolVersion/
 ---
@@ -26,7 +26,7 @@ Consider upgrading node pools to match AKS control plan version.
 
 ## LINKS
 
-- [Target and non-functional requirements](https://learn.microsoft.com/azure/architecture/framework/resiliency/design-requirements#meet-application-platform-requirements)
+- [RE:04 Target metrics](https://learn.microsoft.com/azure/well-architected/reliability/metrics)
 - [Upgrade a cluster control plane with multiple node pools](https://learn.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-cluster-control-plane-with-multiple-node-pools)
 - [Supported Kubernetes versions in Azure Kubernetes Service](https://learn.microsoft.com/azure/aks/supported-kubernetes-versions)
 - [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.containerservice/managedclusters)

--- a/docs/en/rules/Azure.AKS.Version.md
+++ b/docs/en/rules/Azure.AKS.Version.md
@@ -67,7 +67,7 @@ For example:
         }
     },
     "properties": {
-        "kubernetesVersion": "1.29.7",
+        "kubernetesVersion": "1.30.6",
         "enableRBAC": true,
         "dnsPrefix": "[parameters('dnsPrefix')]",
         "agentPoolProfiles": "[variables('allPools')]",
@@ -145,7 +145,7 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2023-07-01' = {
     }
   }
   properties: {
-    kubernetesVersion: '1.29.7'
+    kubernetesVersion: '1.30.6'
     enableRBAC: true
     dnsPrefix: dnsPrefix
     agentPoolProfiles: allPools
@@ -200,6 +200,8 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2023-07-01' = {
 }
 ```
 
+<!-- external:avm avm/res/container-service/managed-cluster kubernetesVersion -->
+
 ### Configure with Azure CLI
 
 ```bash
@@ -207,13 +209,13 @@ az aks update -n '<name>' -g '<resource_group>' --auto-upgrade-channel 'stable'
 ```
 
 ```bash
-az aks upgrade -n '<name>' -g '<resource_group>' --kubernetes-version '1.29.7'
+az aks upgrade -n '<name>' -g '<resource_group>' --kubernetes-version '1.30.6'
 ```
 
 ### Configure with Azure PowerShell
 
 ```powershell
-Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -KubernetesVersion '1.29.7'
+Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -KubernetesVersion '1.30.6'
 ```
 
 ## NOTES

--- a/docs/examples/resources/aks.bicep
+++ b/docs/examples/resources/aks.bicep
@@ -46,7 +46,7 @@ param systemPoolMin int
 param systemPoolMax int = 3
 
 @description('The version of Kubernetes.')
-param kubernetesVersion string = '1.29.7'
+param kubernetesVersion string = '1.30.6'
 
 @description('Maximum number of pods that can run on nodes in the system pool.')
 @minValue(30)

--- a/docs/examples/resources/aks.json
+++ b/docs/examples/resources/aks.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "2547527017795438682"
+      "version": "0.31.92.45157",
+      "templateHash": "6019742219031876579"
     }
   },
   "parameters": {
@@ -73,7 +73,7 @@
     },
     "kubernetesVersion": {
       "type": "string",
-      "defaultValue": "1.29.7",
+      "defaultValue": "1.30.6",
       "metadata": {
         "description": "The version of Kubernetes."
       }

--- a/docs/setup/configuring-rules.md
+++ b/docs/setup/configuring-rules.md
@@ -68,7 +68,7 @@ Default:
 ```yaml title="ps-rule.yaml"
 # YAML: The default AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option
 configuration:
-  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.29.7
+  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.30.6
 ```
 
 Example:

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -60,7 +60,7 @@ Use comments to add context.
       AZURE_BICEP_MINIMUM_VERSION: '0.28.1'
 
       # Configure the minimum AKS cluster version.
-      AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.29.7'
+      AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.30.6'
 
     rule:
       # Enable custom rules that don't exist in the baseline

--- a/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
@@ -40,7 +40,7 @@ spec:
     AZURE_BICEP_CHECK_TOOL: false
 
     # Configures minimum AKS cluster version.
-    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.29.7'
+    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.30.6'
 
     # Configures the minimum allowed max pods setting per node pool.
     AZURE_AKS_POOL_MINIMUM_MAXPODS: 50

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -96,7 +96,7 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult.TargetName | Should -BeIn 'cluster-B';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[0].Reason | Should -BeExactly "Path Properties.kubernetesVersion: The version '1.13.8' does not match the constraint '>=1.29.7'.";
+            $ruleResult[0].Reason | Should -BeExactly "Path Properties.kubernetesVersion: The version '1.13.8' does not match the constraint '>=1.30.6'.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -50,7 +50,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.29.7",
+                "kubernetesVersion": "1.30.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -210,7 +210,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.29.7",
+                "kubernetesVersion": "1.30.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -395,7 +395,7 @@
                 "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-03')]",
                 "maxPods": 50,
                 "type": "VirtualMachineScaleSets",
-                "orchestratorVersion": "1.29.7",
+                "orchestratorVersion": "1.30.6",
                 "osType": "Linux",
                 "enableAutoScaling": false
             }
@@ -427,7 +427,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.29.7",
+                "kubernetesVersion": "1.30.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -628,7 +628,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.29.7",
+                "kubernetesVersion": "1.30.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName5'))]",
                 "agentPoolProfiles": [
                     {
@@ -831,7 +831,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.29.7",
+                "kubernetesVersion": "1.30.6",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName6'))]",
                 "agentPoolProfiles": [
                     {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -6,7 +6,7 @@
     "ResourceName": "cluster-A",
     "Name": "cluster-A",
     "Properties": {
-      "kubernetesVersion": "1.29.7",
+      "kubernetesVersion": "1.30.6",
       "dnsPrefix": "cluster-A",
       "fqdn": "cluster-A-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -18,7 +18,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "AvailabilitySet",
-          "orchestratorVersion": "1.29.7",
+          "orchestratorVersion": "1.30.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -204,7 +204,7 @@
     "ParentResource": null,
     "Properties": {
       "provisioningState": "Succeeded",
-      "kubernetesVersion": "1.29.7",
+      "kubernetesVersion": "1.30.6",
       "dnsPrefix": "cluster-C",
       "fqdn": "cluster-C-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -218,7 +218,7 @@
           "maxPods": 50,
           "type": "VirtualMachineScaleSets",
           "provisioningState": "Succeeded",
-          "orchestratorVersion": "1.29.7",
+          "orchestratorVersion": "1.30.6",
           "osType": "Linux",
           "enableAutoScaling": false
         }
@@ -428,7 +428,7 @@
     "Plan": null,
     "Properties": {
       "provisioningState": "Succeeded",
-      "kubernetesVersion": "1.29.7",
+      "kubernetesVersion": "1.30.6",
       "dnsPrefix": "cluster-D",
       "fqdn": "cluster-D-nnnnnnnn.hcp.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -441,7 +441,7 @@
           "maxPods": 50,
           "type": "VirtualMachineScaleSets",
           "provisioningState": "Succeeded",
-          "orchestratorVersion": "1.29.7",
+          "orchestratorVersion": "1.30.6",
           "nodeLabels": {},
           "mode": "System",
           "osType": "Linux",
@@ -655,7 +655,7 @@
       "powerState": {
         "code": "Running"
       },
-      "orchestratorVersion": "1.29.7",
+      "orchestratorVersion": "1.30.6",
       "nodeLabels": {},
       "mode": "System",
       "osType": "Linux",
@@ -725,7 +725,7 @@
       "powerState": {
         "code": "Running"
       },
-      "kubernetesVersion": "1.29.7",
+      "kubernetesVersion": "1.30.6",
       "dnsPrefix": "cluster-F",
       "fqdn": "cluster-F-00000000.hcp.region.azmk8s.io",
       "azurePortalFQDN": "cluster-F-00000000.portal.hcp.region.azmk8s.io",
@@ -746,7 +746,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.29.7",
+          "orchestratorVersion": "1.30.6",
           "nodeLabels": {},
           "mode": "System",
           "osType": "Linux",
@@ -1018,7 +1018,7 @@
     "ResourceName": "cluster-G",
     "Name": "cluster-G",
     "Properties": {
-      "kubernetesVersion": "1.29.7",
+      "kubernetesVersion": "1.30.6",
       "dnsPrefix": "cluster-G",
       "fqdn": "cluster-G-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1030,7 +1030,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.29.7",
+          "orchestratorVersion": "1.30.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -1193,7 +1193,7 @@
     "ResourceName": "cluster-H",
     "Name": "cluster-H",
     "Properties": {
-      "kubernetesVersion": "1.29.7",
+      "kubernetesVersion": "1.30.6",
       "dnsPrefix": "cluster-H",
       "fqdn": "cluster-H-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1205,7 +1205,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.29.7",
+          "orchestratorVersion": "1.30.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": []
@@ -1372,7 +1372,7 @@
     "ResourceName": "cluster-I",
     "Name": "cluster-I",
     "Properties": {
-      "kubernetesVersion": "1.29.7",
+      "kubernetesVersion": "1.30.6",
       "dnsPrefix": "cluster-I",
       "fqdn": "cluster-I-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1390,7 +1390,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.29.7",
+          "orchestratorVersion": "1.30.6",
           "mode": "System",
           "osType": "Linux",
           "osSKU": "Ubuntu",
@@ -1413,7 +1413,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.29.7",
+          "orchestratorVersion": "1.30.6",
           "mode": "User",
           "osType": "Linux",
           "osSKU": "Ubuntu",
@@ -1582,7 +1582,7 @@
     "ResourceName": "cluster-J",
     "Name": "cluster-J",
     "Properties": {
-      "kubernetesVersion": "1.29.7",
+      "kubernetesVersion": "1.30.6",
       "dnsPrefix": "cluster-J",
       "fqdn": "cluster-J-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1594,7 +1594,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.29.7",
+          "orchestratorVersion": "1.30.6",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -1767,7 +1767,7 @@
       "powerState": {
         "code": "Running"
       },
-      "kubernetesVersion": "1.29.7",
+      "kubernetesVersion": "1.30.6",
       "dnsPrefix": "cluster-K",
       "fqdn": "cluster-K-00000000.hcp.eastus.azmk8s.io",
       "azurePortalFQDN": "cluster-K-00000000.portal.hcp.eastus.azmk8s.io",
@@ -1788,7 +1788,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.29.7",
+          "orchestratorVersion": "1.30.6",
           "mode": "System",
           "osType": "Linux",
           "osSKU": "Ubuntu",


### PR DESCRIPTION
## PR Summary

- Updated `Azure.AKS.Version` to use `1.30.6` as the minimum version.

Fixes #3206

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section

