### PR TITLE
Added December 2024 baselines #3165

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -31,6 +31,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since v1.40.0:
 
+- New features:
+  - Added December 2024 baselines `Azure.GA_2024_12` and `Azure.Preview_2024_12` by @BernieWhite.
+    [#3165](https://github.com/Azure/PSRule.Rules.Azure/issues/3165)
+    - Includes rules released before or during December 2024.
+    - Marked `Azure.GA_2024_09` and `Azure.Preview_2024_09` baselines as obsolete.
 - Updated rules:
   - Azure Kubernetes Service:
     - Updated `Azure.AKS.Version` to use `1.30.6` as the minimum version by @BernieWhite.

--- a/src/PSRule.Rules.Azure/rules/Baseline.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Baseline.Rule.yaml
@@ -818,6 +818,7 @@ metadata:
   annotations:
     export: true
     moduleVersion: v1.39.0
+    obsolete: true
 spec:
   configuration:
     # Configure minimum AKS cluster version
@@ -854,6 +855,7 @@ metadata:
   annotations:
     export: true
     moduleVersion: v1.39.0
+    obsolete: true
 spec:
   configuration:
     # Configure minimum AKS cluster version
@@ -880,3 +882,77 @@ spec:
       - '2024_03'
       - '2024_06'
       - '2024_09'
+
+---
+# Synopsis: Include rules released December 2024 or prior for Azure GA features.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Baseline
+metadata:
+  name: Azure.GA_2024_12
+  annotations:
+    export: true
+    moduleVersion: v1.41.0
+spec:
+  configuration:
+    # Configure minimum AKS cluster version
+    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.30.6'
+  rule:
+    tag:
+      release: GA
+      ruleSet:
+      - '2020_06'
+      - '2020_09'
+      - '2020_12'
+      - '2021_03'
+      - '2021_06'
+      - '2021_09'
+      - '2021_12'
+      - '2022_03'
+      - '2022_06'
+      - '2022_09'
+      - '2022_12'
+      - '2023_03'
+      - '2023_06'
+      - '2023_09'
+      - '2023_12'
+      - '2024_03'
+      - '2024_06'
+      - '2024_09'
+      - '2024_12'
+
+---
+# Synopsis: Include rules released December 2024 or prior for Azure preview only features.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Baseline
+metadata:
+  name: Azure.Preview_2024_12
+  annotations:
+    export: true
+    moduleVersion: v1.41.0
+spec:
+  configuration:
+    # Configure minimum AKS cluster version
+    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.30.6'
+  rule:
+    tag:
+      release: preview
+      ruleSet:
+      - '2020_06'
+      - '2020_09'
+      - '2020_12'
+      - '2021_03'
+      - '2021_06'
+      - '2021_09'
+      - '2021_12'
+      - '2022_03'
+      - '2022_06'
+      - '2022_09'
+      - '2022_12'
+      - '2023_03'
+      - '2023_06'
+      - '2023_09'
+      - '2023_12'
+      - '2024_03'
+      - '2024_06'
+      - '2024_09'
+      - '2024_12'

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
@@ -271,5 +271,19 @@ Describe 'Baselines' -Tag Baseline {
             $filteredResult | Should -Not -BeNullOrEmpty;
             $filteredResult.Length | Should -Be 12;
         }
+
+        It 'With Azure.GA_2024_12' {
+            $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2024_12' -WarningAction Ignore);
+            $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
+            $filteredResult | Should -Not -BeNullOrEmpty;
+            $filteredResult.Length | Should -Be 435;
+        }
+
+        It 'With Azure.Preview_2024_12' {
+            $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2024_12' -WarningAction Ignore);
+            $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
+            $filteredResult | Should -Not -BeNullOrEmpty;
+            $filteredResult.Length | Should -Be 12;
+        }
     }
 }


### PR DESCRIPTION
## PR Summary

- Added December 2024 baselines `Azure.GA_2024_12` and `Azure.Preview_2024_12`.
  - Includes rules released before or during December 2024.
  - Marked `Azure.GA_2024_09` and `Azure.Preview_2024_09` baselines as obsolete.

Fixes #3165

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
