### PR TITLE
Release v1.41.0

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,36 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.41.0
+
+What's changed since v1.40.0:
+
+- New features:
+  - Added December 2024 baselines `Azure.GA_2024_12` and `Azure.Preview_2024_12` by @BernieWhite.
+    [#3165](https://github.com/Azure/PSRule.Rules.Azure/issues/3165)
+    - Includes rules released before or during December 2024.
+    - Marked `Azure.GA_2024_09` and `Azure.Preview_2024_09` baselines as obsolete.
+- Updated rules:
+  - Azure Kubernetes Service:
+    - Updated `Azure.AKS.Version` to use `1.30.6` as the minimum version by @BernieWhite.
+      [#3206](https://github.com/Azure/PSRule.Rules.Azure/issues/3206)
+  - Container Registry:
+    - Updated documentation and promoted `Azure.ACR.AnonymousAccess` to GA by @BernieWhite.
+      [#3119](https://github.com/Azure/PSRule.Rules.Azure/issues/3119)
+      - Bumped rule set to `2024_12`.
+- General improvements:
+  - **Important change**: Deprecated rules with no clear WAF alignment by @BernieWhite.
+    [#3102](https://github.com/Azure/PSRule.Rules.Azure/issues/3102)
+    - The following rules are deprecated:
+      - `Azure.APIM.ProductTerms`
+- Engineering:
+  - Updated resource providers and policy aliases by @BernieWhite.
+    [#3166](https://github.com/Azure/PSRule.Rules.Azure/pull/3166)
+
+What's changed since pre-release v1.41.0-B0015:
+
+- No additional changes.
+
 ## v1.41.0-B0015 (pre-release)
 
 What's changed since v1.40.0:

--- a/scripts/dependencies.psm1
+++ b/scripts/dependencies.psm1
@@ -140,7 +140,7 @@ function InstallVersion {
             Write-Host -Object "[$group] -- Installing $($module.Name) v$($module.Value.version)";
             $installParams = @{ RequiredVersion = $module.Value.version };
             if ($Null -eq (Get-InstalledModule -Name $module.Name @installParams -ErrorAction Ignore)) {
-                Install-Module -Name $module.Name @installParams -Force -Repository $Repository;
+                Install-Module -Name $module.Name @installParams -Force -Repository $Repository -AllowClobber;
             }
         }
     }


### PR DESCRIPTION
## PR Summary

What's changed since v1.40.0:

- New features:
  - Added December 2024 baselines `Azure.GA_2024_12` and `Azure.Preview_2024_12` by @BernieWhite.
    [#3165](https://github.com/Azure/PSRule.Rules.Azure/issues/3165)
    - Includes rules released before or during December 2024.
    - Marked `Azure.GA_2024_09` and `Azure.Preview_2024_09` baselines as obsolete.
- Updated rules:
  - Azure Kubernetes Service:
    - Updated `Azure.AKS.Version` to use `1.30.6` as the minimum version by @BernieWhite.
      [#3206](https://github.com/Azure/PSRule.Rules.Azure/issues/3206)
  - Container Registry:
    - Updated documentation and promoted `Azure.ACR.AnonymousAccess` to GA by @BernieWhite.
      [#3119](https://github.com/Azure/PSRule.Rules.Azure/issues/3119)
      - Bumped rule set to `2024_12`.
- General improvements:
  - **Important change**: Deprecated rules with no clear WAF alignment by @BernieWhite.
    [#3102](https://github.com/Azure/PSRule.Rules.Azure/issues/3102)
    - The following rules are deprecated:
      - `Azure.APIM.ProductTerms`
- Engineering:
  - Updated resource providers and policy aliases by @BernieWhite.
    [#3166](https://github.com/Azure/PSRule.Rules.Azure/pull/3166)

What's changed since pre-release v1.41.0-B0015:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**

