### PR TITLE
Fixes tenant scope resource ID #3237

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.41.0:
+
+- Bug fixes:
+  - Fixed incorrect generation of resource ID for tenant scoped deployments by @BernieWhite.
+    [#3237](https://github.com/Azure/PSRule.Rules.Azure/issues/3237)
+
 ## v1.41.0
 
 What's changed since v1.40.0:

--- a/src/PSRule.Rules.Azure/Common/ResourceHelper.cs
+++ b/src/PSRule.Rules.Azure/Common/ResourceHelper.cs
@@ -121,6 +121,20 @@ internal static class ResourceHelper
     }
 
     /// <summary>
+    /// Get the name of the management group from the specified resource Id.
+    /// </summary>
+    internal static bool TryManagementGroup(string resourceId, out string? managementGroup)
+    {
+        managementGroup = null;
+        if (string.IsNullOrEmpty(resourceId))
+            return false;
+
+        var idParts = resourceId.Split(SLASH_C);
+        var i = 0;
+        return TryConsumeManagementGroupPart(idParts, ref i, out managementGroup);
+    }
+
+    /// <summary>
     /// Combines Id fragments to form a resource Id.
     /// </summary>
     /// <remarks>

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/BicepScopeTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/BicepScopeTests.cs
@@ -57,4 +57,20 @@ public sealed class BicepScopeTests : TemplateVisitorTestsBase
         var property = actual["identity"]["userAssignedIdentities"].Value<JObject>().Properties().FirstOrDefault();
         Assert.Equal("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/rg-1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-1", property.Name);
     }
+
+    [Fact]
+    public void ProcessTemplate_WhenTenantScope_ShouldReturnCorrectIdentifiers()
+    {
+        var resources = ProcessTemplate(GetSourcePath("Bicep/ScopeTestCases/Tests.Bicep.3.json"), null, out _);
+
+        Assert.NotNull(resources);
+
+        var actual = resources.Where(r => r["name"].Value<string>() == "mg-test").FirstOrDefault();
+        Assert.Equal("Microsoft.Management/managementGroups", actual["type"].Value<string>());
+        Assert.Equal("/providers/Microsoft.Management/managementGroups/mg-test", actual["id"].Value<string>());
+
+        actual = resources.Where(r => r["name"].Value<string>() == "mg-test/00000000-0000-0000-0000-000000000000").FirstOrDefault();
+        Assert.Equal("Microsoft.Management/managementGroups/subscriptions", actual["type"].Value<string>());
+        Assert.Equal("/providers/Microsoft.Management/managementGroups/mg-test/subscriptions/00000000-0000-0000-0000-000000000000", actual["id"].Value<string>());
+    }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.bicep
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/3237
+
+// Based on AVM subscription placement module.
+
+targetScope = 'tenant'
+
+module mg './Tests.Bicep.3.child1.bicep' = {
+  name: 'mg'
+  scope: tenant()
+}
+
+module child './Tests.Bicep.3.child2.bicep' = {
+  name: 'child'
+  params: {
+    managementGroups: [
+      {
+        id: mg.outputs.managementGroupId
+        subscriptionId: mg.outputs.subscriptionId
+      }
+    ]
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.child1.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.child1.bicep
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+targetScope = 'tenant'
+
+resource managementGroup 'Microsoft.Management/managementGroups@2023-04-01' = {
+  name: 'mg-test'
+  properties: {
+    displayName: 'Test Management Group'
+    details: {
+      parent: {
+        id: ''
+      }
+    }
+  }
+}
+
+output managementGroupId string = managementGroup.id
+output subscriptionId string = '00000000-0000-0000-0000-000000000000'

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.child2.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.child2.bicep
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+targetScope = 'tenant'
+
+param managementGroups managementGroup[]
+
+type managementGroup = {
+  id: string
+  subscriptionId: string
+}
+
+module customSubscriptionPlacement './Tests.Bicep.3.child3.bicep' = [
+  for (place, index) in managementGroups: {
+    name: 'placement-${uniqueString(place.id)}${index}'
+    params: {
+      managementGroupId: place.id
+      subscriptionId: place.subscriptionId
+    }
+  }
+]

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.child3.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.child3.bicep
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+targetScope = 'tenant'
+
+param managementGroupId string
+param subscriptionId string
+
+resource customSubscriptionPlacement 'Microsoft.Management/managementGroups/subscriptions@2023-04-01' = {
+  name: '${last(split(managementGroupId, '/'))}/${subscriptionId}'
+}

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.json
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.33.93.31351",
+      "templateHash": "2473504024471157297"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "mg",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.33.93.31351",
+              "templateHash": "17955590497928865384"
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Management/managementGroups",
+              "apiVersion": "2023-04-01",
+              "name": "mg-test",
+              "properties": {
+                "displayName": "Test Management Group",
+                "details": {
+                  "parent": {
+                    "id": ""
+                  }
+                }
+              }
+            }
+          ],
+          "outputs": {
+            "managementGroupId": {
+              "type": "string",
+              "value": "[tenantResourceId('Microsoft.Management/managementGroups', 'mg-test')]"
+            },
+            "subscriptionId": {
+              "type": "string",
+              "value": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "child",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "managementGroups": {
+            "value": [
+              {
+                "id": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'mg'), '2022-09-01').outputs.managementGroupId.value]",
+                "subscriptionId": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'mg'), '2022-09-01').outputs.subscriptionId.value]"
+              }
+            ]
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.33.93.31351",
+              "templateHash": "8581646487883214838"
+            }
+          },
+          "definitions": {
+            "managementGroup": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "subscriptionId": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "parameters": {
+            "managementGroups": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/managementGroup"
+              }
+            }
+          },
+          "resources": {
+            "customSubscriptionPlacement": {
+              "copy": {
+                "name": "customSubscriptionPlacement",
+                "count": "[length(parameters('managementGroups'))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('placement-{0}{1}', uniqueString(parameters('managementGroups')[copyIndex()].id), copyIndex())]",
+              "location": "[deployment().location]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "managementGroupId": {
+                    "value": "[parameters('managementGroups')[copyIndex()].id]"
+                  },
+                  "subscriptionId": {
+                    "value": "[parameters('managementGroups')[copyIndex()].subscriptionId]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.33.93.31351",
+                      "templateHash": "2385326936979591180"
+                    }
+                  },
+                  "parameters": {
+                    "managementGroupId": {
+                      "type": "string"
+                    },
+                    "subscriptionId": {
+                      "type": "string"
+                    }
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.Management/managementGroups/subscriptions",
+                      "apiVersion": "2023-04-01",
+                      "name": "[format('{0}/{1}', last(split(parameters('managementGroupId'), '/')), parameters('subscriptionId'))]"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[tenantResourceId('Microsoft.Resources/deployments', 'mg')]"
+      ]
+    }
+  ]
+}

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -320,6 +320,9 @@
     <None Update="Bicep\ScopeTestCases\Tests.Bicep.2.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Bicep\ScopeTestCases\Tests.Bicep.3.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="APIM\Tests.Policy.1.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Rules.Azure.Tests/ResourceHelperTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/ResourceHelperTests.cs
@@ -5,6 +5,9 @@ namespace PSRule.Rules.Azure;
 
 #nullable enable
 
+/// <summary>
+/// Unit tests for <see cref="ResourceHelper"/>.
+/// </summary>
 public sealed class ResourceHelperTests
 {
     [Fact]
@@ -170,6 +173,25 @@ public sealed class ResourceHelperTests
     public void ResourceIdDepth(string[] resourceType, string[] resourceName, int depth)
     {
         Assert.Equal(depth, ResourceHelper.ResourceIdDepth(null, null, null, null, resourceType, resourceName));
+    }
+
+    [Theory]
+    [InlineData("/providers/Microsoft.Management/managementGroups/mg-1", "mg-1")]
+    [InlineData("/providers/Microsoft.Management/managementGroups/mg-1/providers/Microsoft.Authorization/policyAssignments/assignment-1", "mg-1")]
+    [InlineData("Microsoft.Management/managementGroups/mg-1", "mg-1")]
+    public void TryManagementGroup_WithValidResourceId_ShouldReturnManagementGroup(string resourceId, string managementGroup)
+    {
+        Assert.True(ResourceHelper.TryManagementGroup(resourceId, out var actualManagementGroup));
+        Assert.Equal(managementGroup, actualManagementGroup);
+    }
+
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/rg-4")]
+    public void TryManagementGroup_WithInvalidResourceId_ShouldReturnFalse(string resourceId)
+    {
+        Assert.False(ResourceHelper.TryManagementGroup(resourceId, out var actualManagementGroup));
+        Assert.Null(actualManagementGroup);
     }
 }
 


### PR DESCRIPTION
## PR Summary

- Fixed incorrect generation of resource ID for tenant scoped deployments.

Fixes #3237

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
