### PR TITLE
Merge patch v1.41.1

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,11 +29,21 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
-What's changed since v1.41.0:
+What's changed since v1.41.1:
 
 - General improvements:
   - Added a new quickstart guide for using Azure Pipelines with PSRule by @that-ar-guy.  
     [#3220](https://github.com/Azure/PSRule.Rules.Azure/pull/3220)
+
+## v1.41.1
+
+What's changed since v1.41.0:
+
+- Bug fixes:
+  - Fixed incorrect generation of resource ID for tenant scoped deployments by @BernieWhite.
+    [#3237](https://github.com/Azure/PSRule.Rules.Azure/issues/3237)
+  - Fixed in-flight export of subscription resource type `Microsoft.Subscription` by @BernieWhite.
+    [#3231](https://github.com/Azure/PSRule.Rules.Azure/issues/3231)
 
 ## v1.41.0
 

--- a/src/PSRule.Rules.Azure/Common/ResourceHelper.cs
+++ b/src/PSRule.Rules.Azure/Common/ResourceHelper.cs
@@ -121,6 +121,20 @@ internal static class ResourceHelper
     }
 
     /// <summary>
+    /// Get the name of the management group from the specified resource Id.
+    /// </summary>
+    internal static bool TryManagementGroup(string resourceId, out string? managementGroup)
+    {
+        managementGroup = null;
+        if (string.IsNullOrEmpty(resourceId))
+            return false;
+
+        var idParts = resourceId.Split(SLASH_C);
+        var i = 0;
+        return TryConsumeManagementGroupPart(idParts, ref i, out managementGroup);
+    }
+
+    /// <summary>
     /// Combines Id fragments to form a resource Id.
     /// </summary>
     /// <remarks>

--- a/src/PSRule.Rules.Azure/Pipeline/Export/ResourceExportVisitor.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/Export/ResourceExportVisitor.cs
@@ -19,8 +19,8 @@ internal sealed class ResourceExportVisitor
     private const string PROPERTY_PROPERTIES = "properties";
     private const string PROPERTY_ZONES = "zones";
     private const string PROPERTY_RESOURCES = "resources";
-    private const string PROPERTY_SUBSCRIPTIONID = "subscriptionId";
-    private const string PROPERTY_RESOURCEGROUPNAME = "resourceGroupName";
+    private const string PROPERTY_SUBSCRIPTION_ID = "subscriptionId";
+    private const string PROPERTY_RESOURCE_GROUP_NAME = "resourceGroupName";
     private const string PROPERTY_KIND = "kind";
     private const string PROPERTY_SHAREDKEY = "sharedKey";
     private const string PROPERTY_NETWORKPROFILE = "networkProfile";
@@ -235,11 +235,12 @@ internal sealed class ResourceExportVisitor
     private static void SetResourceIdentifiers(JObject resource, string resourceType, string resourceId)
     {
         if (ResourceHelper.TryResourceGroup(resourceId, out var subscriptionId, out var resourceGroupName) &&
-            !string.Equals(resourceType, TYPE_RESOURCES_RESOURCEGROUP, StringComparison.OrdinalIgnoreCase))
-            resource.Add(PROPERTY_RESOURCEGROUPNAME, resourceGroupName);
+            !string.Equals(resourceType, TYPE_RESOURCES_RESOURCEGROUP, StringComparison.OrdinalIgnoreCase) &&
+            !resource.ContainsKeyInsensitive(PROPERTY_RESOURCE_GROUP_NAME))
+            resource.Add(PROPERTY_RESOURCE_GROUP_NAME, resourceGroupName);
 
-        if (!string.IsNullOrEmpty(subscriptionId))
-            resource.Add(PROPERTY_SUBSCRIPTIONID, subscriptionId);
+        if (!string.IsNullOrEmpty(subscriptionId) && !resource.ContainsKeyInsensitive(PROPERTY_SUBSCRIPTION_ID))
+            resource.Add(PROPERTY_SUBSCRIPTION_ID, subscriptionId);
     }
 
     private bool TryGetLatestAPIVersion(string resourceType, out string apiVersion)

--- a/src/PSRule.Rules.Azure/Pipeline/Export/SubscriptionExportContext.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/Export/SubscriptionExportContext.cs
@@ -12,7 +12,7 @@ namespace PSRule.Rules.Azure.Pipeline.Export;
 /// <summary>
 /// A context to export an Azure subscription.
 /// </summary>
-internal class SubscriptionExportContext : ExportDataContext, ISubscriptionExportContext
+internal sealed class SubscriptionExportContext : ExportDataContext, ISubscriptionExportContext
 {
     private readonly string _ResourceEndpoint;
     private readonly string _ResourceGroupEndpoint;
@@ -27,7 +27,7 @@ internal class SubscriptionExportContext : ExportDataContext, ISubscriptionExpor
     {
         _ResourceEndpoint = $"{RESOURCE_MANAGER_URL}/subscriptions/{scope.SubscriptionId}/resources?api-version=2021-04-01{GetFilter(tag)}";
         _ResourceGroupEndpoint = $"{RESOURCE_MANAGER_URL}/subscriptions/{scope.SubscriptionId}/resourcegroups?api-version=2021-04-01{GetFilter(tag)}";
-        _SubscriptionEndpoint = $"{RESOURCE_MANAGER_URL}/subscriptions/{scope.SubscriptionId}";
+        _SubscriptionEndpoint = $"{RESOURCE_MANAGER_URL}/subscriptions/{scope.SubscriptionId}?api-version=2022-12-01";
         SubscriptionId = scope.SubscriptionId;
         TenantId = scope.TenantId;
         RefreshToken(scope.TenantId);

--- a/src/PSRule.Rules.Azure/Pipeline/ResourceDataPipeline.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/ResourceDataPipeline.cs
@@ -28,6 +28,8 @@ internal sealed class ResourceDataPipeline : ExportDataPipeline
     private const string PROPERTY_DISPLAYNAME = "displayName";
     private const string PROPERTY_TENANTID = "tenantId";
 
+    private const string PLACEHOLDER_SUBSCRIPTION_TYPE = "Microsoft.Subscription";
+
     private const string ERRORID_RESOURCEDATAEXPAND = "PSRule.Rules.Azure.ResourceDataExpand";
 
     private readonly ConcurrentQueue<JObject> _Resources;
@@ -170,7 +172,7 @@ internal sealed class ResourceDataPipeline : ExportDataPipeline
         var r = await context.GetSubscriptionAsync();
         if (r != null)
         {
-            r.Add(PROPERTY_TYPE, "Microsoft.Subscription");
+            r.Add(PROPERTY_TYPE, PLACEHOLDER_SUBSCRIPTION_TYPE);
             if (r.TryGetProperty(PROPERTY_DISPLAYNAME, out var displayName))
                 r.Add(PROPERTY_NAME, displayName);
 

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/BicepScopeTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/BicepScopeTests.cs
@@ -57,4 +57,20 @@ public sealed class BicepScopeTests : TemplateVisitorTestsBase
         var property = actual["identity"]["userAssignedIdentities"].Value<JObject>().Properties().FirstOrDefault();
         Assert.Equal("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/rg-1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-1", property.Name);
     }
+
+    [Fact]
+    public void ProcessTemplate_WhenTenantScope_ShouldReturnCorrectIdentifiers()
+    {
+        var resources = ProcessTemplate(GetSourcePath("Bicep/ScopeTestCases/Tests.Bicep.3.json"), null, out _);
+
+        Assert.NotNull(resources);
+
+        var actual = resources.Where(r => r["name"].Value<string>() == "mg-test").FirstOrDefault();
+        Assert.Equal("Microsoft.Management/managementGroups", actual["type"].Value<string>());
+        Assert.Equal("/providers/Microsoft.Management/managementGroups/mg-test", actual["id"].Value<string>());
+
+        actual = resources.Where(r => r["name"].Value<string>() == "mg-test/00000000-0000-0000-0000-000000000000").FirstOrDefault();
+        Assert.Equal("Microsoft.Management/managementGroups/subscriptions", actual["type"].Value<string>());
+        Assert.Equal("/providers/Microsoft.Management/managementGroups/mg-test/subscriptions/00000000-0000-0000-0000-000000000000", actual["id"].Value<string>());
+    }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.bicep
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/3237
+
+// Based on AVM subscription placement module.
+
+targetScope = 'tenant'
+
+module mg './Tests.Bicep.3.child1.bicep' = {
+  name: 'mg'
+  scope: tenant()
+}
+
+module child './Tests.Bicep.3.child2.bicep' = {
+  name: 'child'
+  params: {
+    managementGroups: [
+      {
+        id: mg.outputs.managementGroupId
+        subscriptionId: mg.outputs.subscriptionId
+      }
+    ]
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.child1.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.child1.bicep
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+targetScope = 'tenant'
+
+resource managementGroup 'Microsoft.Management/managementGroups@2023-04-01' = {
+  name: 'mg-test'
+  properties: {
+    displayName: 'Test Management Group'
+    details: {
+      parent: {
+        id: ''
+      }
+    }
+  }
+}
+
+output managementGroupId string = managementGroup.id
+output subscriptionId string = '00000000-0000-0000-0000-000000000000'

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.child2.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.child2.bicep
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+targetScope = 'tenant'
+
+param managementGroups managementGroup[]
+
+type managementGroup = {
+  id: string
+  subscriptionId: string
+}
+
+module customSubscriptionPlacement './Tests.Bicep.3.child3.bicep' = [
+  for (place, index) in managementGroups: {
+    name: 'placement-${uniqueString(place.id)}${index}'
+    params: {
+      managementGroupId: place.id
+      subscriptionId: place.subscriptionId
+    }
+  }
+]

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.child3.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.child3.bicep
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+targetScope = 'tenant'
+
+param managementGroupId string
+param subscriptionId string
+
+resource customSubscriptionPlacement 'Microsoft.Management/managementGroups/subscriptions@2023-04-01' = {
+  name: '${last(split(managementGroupId, '/'))}/${subscriptionId}'
+}

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.json
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/ScopeTestCases/Tests.Bicep.3.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.33.93.31351",
+      "templateHash": "2473504024471157297"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "mg",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.33.93.31351",
+              "templateHash": "17955590497928865384"
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Management/managementGroups",
+              "apiVersion": "2023-04-01",
+              "name": "mg-test",
+              "properties": {
+                "displayName": "Test Management Group",
+                "details": {
+                  "parent": {
+                    "id": ""
+                  }
+                }
+              }
+            }
+          ],
+          "outputs": {
+            "managementGroupId": {
+              "type": "string",
+              "value": "[tenantResourceId('Microsoft.Management/managementGroups', 'mg-test')]"
+            },
+            "subscriptionId": {
+              "type": "string",
+              "value": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "child",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "managementGroups": {
+            "value": [
+              {
+                "id": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'mg'), '2022-09-01').outputs.managementGroupId.value]",
+                "subscriptionId": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'mg'), '2022-09-01').outputs.subscriptionId.value]"
+              }
+            ]
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.33.93.31351",
+              "templateHash": "8581646487883214838"
+            }
+          },
+          "definitions": {
+            "managementGroup": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "subscriptionId": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "parameters": {
+            "managementGroups": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/managementGroup"
+              }
+            }
+          },
+          "resources": {
+            "customSubscriptionPlacement": {
+              "copy": {
+                "name": "customSubscriptionPlacement",
+                "count": "[length(parameters('managementGroups'))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('placement-{0}{1}', uniqueString(parameters('managementGroups')[copyIndex()].id), copyIndex())]",
+              "location": "[deployment().location]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "managementGroupId": {
+                    "value": "[parameters('managementGroups')[copyIndex()].id]"
+                  },
+                  "subscriptionId": {
+                    "value": "[parameters('managementGroups')[copyIndex()].subscriptionId]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.33.93.31351",
+                      "templateHash": "2385326936979591180"
+                    }
+                  },
+                  "parameters": {
+                    "managementGroupId": {
+                      "type": "string"
+                    },
+                    "subscriptionId": {
+                      "type": "string"
+                    }
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.Management/managementGroups/subscriptions",
+                      "apiVersion": "2023-04-01",
+                      "name": "[format('{0}/{1}', last(split(parameters('managementGroupId'), '/')), parameters('subscriptionId'))]"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[tenantResourceId('Microsoft.Resources/deployments', 'mg')]"
+      ]
+    }
+  ]
+}

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -320,6 +320,9 @@
     <None Update="Bicep\ScopeTestCases\Tests.Bicep.2.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Bicep\ScopeTestCases\Tests.Bicep.3.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="APIM\Tests.Policy.1.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Rules.Azure.Tests/ResourceHelperTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/ResourceHelperTests.cs
@@ -5,6 +5,9 @@ namespace PSRule.Rules.Azure;
 
 #nullable enable
 
+/// <summary>
+/// Unit tests for <see cref="ResourceHelper"/>.
+/// </summary>
 public sealed class ResourceHelperTests
 {
     [Fact]
@@ -170,6 +173,25 @@ public sealed class ResourceHelperTests
     public void ResourceIdDepth(string[] resourceType, string[] resourceName, int depth)
     {
         Assert.Equal(depth, ResourceHelper.ResourceIdDepth(null, null, null, null, resourceType, resourceName));
+    }
+
+    [Theory]
+    [InlineData("/providers/Microsoft.Management/managementGroups/mg-1", "mg-1")]
+    [InlineData("/providers/Microsoft.Management/managementGroups/mg-1/providers/Microsoft.Authorization/policyAssignments/assignment-1", "mg-1")]
+    [InlineData("Microsoft.Management/managementGroups/mg-1", "mg-1")]
+    public void TryManagementGroup_WithValidResourceId_ShouldReturnManagementGroup(string resourceId, string managementGroup)
+    {
+        Assert.True(ResourceHelper.TryManagementGroup(resourceId, out var actualManagementGroup));
+        Assert.Equal(managementGroup, actualManagementGroup);
+    }
+
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/rg-4")]
+    public void TryManagementGroup_WithInvalidResourceId_ShouldReturnFalse(string resourceId)
+    {
+        Assert.False(ResourceHelper.TryManagementGroup(resourceId, out var actualManagementGroup));
+        Assert.Null(actualManagementGroup);
     }
 }
 


### PR DESCRIPTION
## PR Summary

Merge patch v1.41.1:

- Bug fixes:
  - Fixed incorrect generation of resource ID for tenant scoped deployments by @BernieWhite.
    [#3237](https://github.com/Azure/PSRule.Rules.Azure/issues/3237)
  - Fixed in-flight export of subscription resource type `Microsoft.Subscription` by @BernieWhite.
    [#3231](https://github.com/Azure/PSRule.Rules.Azure/issues/3231)

Fixes #3237 
Fixes #3231

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
