### PR TITLE
Fixes for pre-flight expansion #3251 #3252

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -137,16 +137,6 @@
     "webhooks",
     "xunit"
   ],
-  "cSpell.enabledLanguageIds": [
-    "csharp",
-    "git-commit",
-    "markdown",
-    "plaintext",
-    "powershell",
-    "text",
-    "yaml",
-    "yml"
-  ],
   "json.schemas": [
     {
       "fileMatch": [
@@ -155,9 +145,7 @@
       "url": "./.vscode/policy-ignore.schema.json"
     }
   ],
-  "omnisharp.organizeImportsOnFormat": true,
   "omnisharp.enableEditorConfigSupport": true,
-  "omnisharp.enableRoslynAnalyzers": true,
   "PSRule.documentation.path": "docs",
   "PSRule.documentation.localePath": "en/rules/",
   "PSRule.documentation.customSnippetPath": ".vscode/markdown.code-snippets",
@@ -167,8 +155,17 @@
     "release/*"
   ],
   "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
-  "cSpell.enableFiletypes": [
-    "bicep",
-    "python"
-  ]
+  "cSpell.enabledFileTypes": {
+    "csharp": true,
+    "git-commit": true,
+    "markdown": true,
+    "plaintext": true,
+    "powershell": true,
+    "text": true,
+    "yaml": true,
+    "yml": true,
+    "python": true,
+    "bicep": true,
+  },
+  "dotnet.formatting.organizeImportsOnFormat": true
 }

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,16 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.41.2:
+
+- Bug fixes:
+  - Fixed recursive lookup of cross module resources in the deployment by @BernieWhite.
+    [#3251](https://github.com/Azure/PSRule.Rules.Azure/issues/3251)
+    - This improves the ability to reference resource properties in the same parent deployment.
+    - Additionally, projection of runtime properties has been improved.
+  - Fixed literal strings may be incorrectly interpreted as expressions by @BernieWhite.
+    [#3252](https://github.com/Azure/PSRule.Rules.Azure/issues/3252)
+
 ## v1.41.1
 
 What's changed since v1.41.0:

--- a/src/PSRule.Rules.Azure/Data/APIM/APIMPolicyReader.cs
+++ b/src/PSRule.Rules.Azure/Data/APIM/APIMPolicyReader.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Xml;
-using System.Text.RegularExpressions;
 using System.IO;
+using System.Text.RegularExpressions;
+using System.Xml;
 
 namespace PSRule.Rules.Azure.Data.APIM;
 

--- a/src/PSRule.Rules.Azure/Data/Template/FunctionDescriptor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/FunctionDescriptor.cs
@@ -1,38 +1,44 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
+using System.Threading;
+using PSRule.Rules.Azure.Resources;
 
-namespace PSRule.Rules.Azure.Data.Template
+namespace PSRule.Rules.Azure.Data.Template;
+
+/// <summary>
+/// A wrapper for the function definition that can be invoked.
+/// </summary>
+[DebuggerDisplay("Function: {Name}")]
+internal sealed class FunctionDescriptor(string name, ExpressionFn fn, bool delayBinding = false) : IFunctionDescriptor
 {
-    /// <summary>
-    /// A wrapper for the function definition that can be invoked.
-    /// </summary>
-    [DebuggerDisplay("Function: {Name}")]
-    internal sealed class FunctionDescriptor : IFunctionDescriptor
+    private readonly ExpressionFn _Fn = fn;
+    private readonly bool _DelayBinding = delayBinding;
+
+    /// <inheritdoc/>
+    public string Name { get; } = name;
+
+    /// <inheritdoc/>
+    public object Invoke(ITemplateContext context, DebugSymbol debugSymbol, ExpressionFnOuter[] args)
     {
-        private readonly ExpressionFn _Fn;
-        private readonly bool _DelayBinding;
+        var parameters = new object[args.Length];
+        for (var i = 0; i < args.Length; i++)
+            parameters[i] = _DelayBinding ? args[i] : ExpressionHelpers.UnwrapLiteralString(args[i](context));
 
-        public FunctionDescriptor(string name, ExpressionFn fn, bool delayBinding = false)
+        context.DebugSymbol = debugSymbol;
+        try
         {
-            Name = name;
-            _Fn = fn;
-            _DelayBinding = delayBinding;
+            return ExpressionHelpers.WrapLiteralString(_Fn(context, parameters));
         }
-
-        /// <inheritdoc/>
-        public string Name { get; }
-
-        /// <inheritdoc/>
-        public object Invoke(ITemplateContext context, DebugSymbol debugSymbol, ExpressionFnOuter[] args)
+        catch (TemplateFunctionException ex)
         {
-            var parameters = new object[args.Length];
-            for (var i = 0; i < args.Length; i++)
-                parameters[i] = _DelayBinding ? args[i] : args[i](context);
-
-            context.DebugSymbol = debugSymbol;
-            return _Fn(context, parameters);
+            throw new TemplateFunctionException(Name, ex.ErrorType, string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.FunctionGenericError, Name, ex.Message), ex);
+        }
+        catch (Exception ex)
+        {
+            throw new TemplateFunctionException(Name, FunctionErrorType.Unknown, string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.FunctionGenericError, Name, ex.Message), ex);
         }
     }
 }

--- a/src/PSRule.Rules.Azure/Data/Template/FunctionErrorType.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/FunctionErrorType.cs
@@ -9,7 +9,17 @@ namespace PSRule.Rules.Azure.Data.Template;
 public enum FunctionErrorType
 {
     /// <summary>
+    /// A generic error.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
     /// An error cause by mismatching resource segments.
     /// </summary>
-    MismatchingResourceSegments
+    MismatchingResourceSegments,
+
+    /// <summary>
+    /// An error caused by failed deserialization.
+    /// </summary>
+    DeserializationFailure,
 }

--- a/src/PSRule.Rules.Azure/Data/Template/ITemplateContext.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ITemplateContext.cs
@@ -5,94 +5,97 @@ using System;
 using PSRule.Rules.Azure.Configuration;
 using static PSRule.Rules.Azure.Data.Template.TemplateVisitor;
 
-namespace PSRule.Rules.Azure.Data.Template
+namespace PSRule.Rules.Azure.Data.Template;
+
+/// <summary>
+/// An interface for a template context.
+/// </summary>
+internal interface ITemplateContext : IValidationContext
 {
+    TemplateContext.CopyIndexStore CopyIndex { get; }
+
     /// <summary>
-    /// An interface for a template context.
+    /// The current deployment.
     /// </summary>
-    internal interface ITemplateContext : IValidationContext
-    {
-        TemplateContext.CopyIndexStore CopyIndex { get; }
+    DeploymentValue Deployment { get; }
 
-        /// <summary>
-        /// The current deployment.
-        /// </summary>
-        DeploymentValue Deployment { get; }
+    /// <summary>
+    /// The scope of the current context.
+    /// </summary>
+    string ScopeId { get; }
 
-        /// <summary>
-        /// The scope of the current context.
-        /// </summary>
-        string ScopeId { get; }
+    string TemplateFile { get; }
 
-        string TemplateFile { get; }
+    string ParameterFile { get; }
 
-        string ParameterFile { get; }
+    ResourceGroupOption ResourceGroup { get; }
 
-        ResourceGroupOption ResourceGroup { get; }
+    SubscriptionOption Subscription { get; }
 
-        SubscriptionOption Subscription { get; }
+    TenantOption Tenant { get; }
 
-        TenantOption Tenant { get; }
+    ManagementGroupOption ManagementGroup { get; }
 
-        ManagementGroupOption ManagementGroup { get; }
+    bool ShouldThrowMissingProperty { get; }
 
-        bool ShouldThrowMissingProperty { get; }
+    DebugSymbol DebugSymbol { get; set; }
 
-        DebugSymbol DebugSymbol { get; set; }
+    ExpressionFnOuter BuildExpression(string s);
 
-        ExpressionFnOuter BuildExpression(string s);
+    CloudEnvironment GetEnvironment();
 
-        CloudEnvironment GetEnvironment();
+    /// <summary>
+    /// Get a parameter from the current context.
+    /// </summary>
+    /// <param name="parameterName">The name of the parameter. Parameter names are case-insensitive.</param>
+    /// <param name="value">The returned value of the parameter.</param>
+    /// <returns>Returns <c>true</c> if the parameter exists or <c>false</c> if a parameter with the specified name could not be found.</returns>
+    bool TryParameter(string parameterName, out object value);
 
-        /// <summary>
-        /// Get a parameter from the current context.
-        /// </summary>
-        /// <param name="parameterName">The name of the parameter. Parameter names are case-insensitive.</param>
-        /// <param name="value">The returned value of the parameter.</param>
-        /// <returns>Returns <c>true</c> if the parameter exists or <c>false</c> if a parameter with the specified name could not be found.</returns>
-        bool TryParameter(string parameterName, out object value);
+    /// <summary>
+    /// Get a variable from the current context.
+    /// </summary>
+    /// <param name="variableName">The name of the variable. Variable names are case-insensitive.</param>
+    /// <param name="value">The returned value of the variable.</param>
+    /// <returns>Returns <c>true</c> if the variable exists or <c>false</c> if a variable with the specified name could not be found.</returns>
+    bool TryVariable(string variableName, out object value);
 
-        /// <summary>
-        /// Get a variable from the current context.
-        /// </summary>
-        /// <param name="variableName">The name of the variable. Variable names are case-insensitive.</param>
-        /// <param name="value">The returned value of the variable.</param>
-        /// <returns>Returns <c>true</c> if the variable exists or <c>false</c> if a variable with the specified name could not be found.</returns>
-        bool TryVariable(string variableName, out object value);
+    bool TryDefinition(string type, out ITypeDefinition definition);
 
-        bool TryDefinition(string type, out ITypeDefinition definition);
+#nullable enable
 
-        /// <summary>
-        /// Try to get a resource from the current context.
-        /// </summary>
-        /// <param name="nameOrResourceId">The symbolic name or resource identifier.</param>
-        /// <param name="resource">A resource.</param>
-        /// <returns>Returns <c>true</c> when the resource exists.</returns>
-        bool TryGetResource(string nameOrResourceId, out IResourceValue resource);
+    /// <summary>
+    /// Try to get a resource from the current context.
+    /// </summary>
+    /// <param name="nameOrResourceId">The symbolic name or resource identifier.</param>
+    /// <param name="resource">A resource.</param>
+    /// <returns>Returns <c>true</c> when the resource exists.</returns>
+    bool TryGetResource(string nameOrResourceId, out IResourceValue? resource);
 
-        /// <summary>
-        /// Try to get a resource collection from the current context.
-        /// </summary>
-        /// <param name="symbolicName">The symbolic name for the collection.</param>
-        /// <param name="resources">A collection of resources.</param>
-        /// <returns>Returns <c>true</c> when the symbolic name exists.</returns>
-        bool TryGetResourceCollection(string symbolicName, out IResourceValue[] resources);
+    /// <summary>
+    /// Try to get a resource collection from the current context.
+    /// </summary>
+    /// <param name="symbolicName">The symbolic name for the collection.</param>
+    /// <param name="resources">A collection of resources.</param>
+    /// <returns>Returns <c>true</c> when the symbolic name exists.</returns>
+    bool TryGetResourceCollection(string symbolicName, out IResourceValue[]? resources);
 
-        /// <summary>
-        /// Write a debug message for the current execution context.
-        /// </summary>
-        /// <param name="message">The format message.</param>
-        /// <param name="args">Additional arguments for the format message.</param>
-        void WriteDebug(string message, params object[] args);
+#nullable restore
 
-        /// <summary>
-        /// Get a lambda variable from the current context scope.
-        /// This will throw an exception if the current context is not within a lambda expression.
-        /// </summary>
-        /// <param name="variableName">The name of the variable. Variable names are case-insensitive.</param>
-        /// <param name="value">The returned value of the variable.</param>
-        /// <returns>Returns <c>true</c> if the variable exists or <c>false</c> if a variable with the specified name could not be found.</returns>
-        /// <exception cref="NotImplementedException">A lambda variable can not be evaluated outside a lambda expression.</exception>
-        bool TryLambdaVariable(string variableName, out object value);
-    }
+    /// <summary>
+    /// Write a debug message for the current execution context.
+    /// </summary>
+    /// <param name="message">The format message.</param>
+    /// <param name="args">Additional arguments for the format message.</param>
+    void WriteDebug(string message, params object[] args);
+
+    /// <summary>
+    /// Get a lambda variable from the current context scope.
+    /// This will throw an exception if the current context is not within a lambda expression.
+    /// </summary>
+    /// <param name="variableName">The name of the variable. Variable names are case-insensitive.</param>
+    /// <param name="value">The returned value of the variable.</param>
+    /// <returns>Returns <c>true</c> if the variable exists or <c>false</c> if a variable with the specified name could not be found.</returns>
+    /// <exception cref="NotImplementedException">A lambda variable can not be evaluated outside a lambda expression.</exception>
+    bool TryLambdaVariable(string variableName, out object value);
 }

--- a/src/PSRule.Rules.Azure/DictionaryExtensions.cs
+++ b/src/PSRule.Rules.Azure/DictionaryExtensions.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Newtonsoft.Json.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Management.Automation;
+using Newtonsoft.Json.Linq;
 
 namespace PSRule.Rules.Azure;
 

--- a/src/PSRule.Rules.Azure/JsonExtensions.cs
+++ b/src/PSRule.Rules.Azure/JsonExtensions.cs
@@ -130,6 +130,20 @@ internal static class JsonExtensions
     }
 
     /// <summary>
+    /// Add a property to the object if a property with the same name does not exist.
+    /// </summary>
+    /// <param name="o">The object to set properties on.</param>
+    /// <param name="propertyName">The property to check. A case insensitive compare is used.</param>
+    /// <param name="value">The value to set as the property if the property didn't exist.</param>
+    internal static void AddIfNotExists(this JObject o, string propertyName, JToken value)
+    {
+        if (o == null || propertyName == null || value == null) return;
+
+        if (!o.ContainsKeyInsensitive(propertyName))
+            o.Add(propertyName, value);
+    }
+
+    /// <summary>
     /// Determine if the token is a value.
     /// </summary>
     internal static bool HasValue(this JToken o)

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
@@ -232,6 +232,15 @@ namespace PSRule.Rules.Azure.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to deserialize &apos;{0}&apos;. {1}.
+        /// </summary>
+        internal static string DeserializationFailure {
+            get {
+                return ResourceManager.GetString("DeserializationFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The expand resulted in an empty condition being returned for &apos;{0}&apos; from &apos;{1}&apos;..
         /// </summary>
         internal static string EmptyConditionExpandResult {
@@ -255,6 +264,15 @@ namespace PSRule.Rules.Azure.Resources {
         internal static string ExpressionInvalid {
             get {
                 return ResourceManager.GetString("ExpressionInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The function &apos;{0}&apos; failed. {1}.
+        /// </summary>
+        internal static string FunctionGenericError {
+            get {
+                return ResourceManager.GetString("FunctionGenericError", resourceCulture);
             }
         }
         

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
@@ -175,6 +175,9 @@
   <data name="CloudEnvironmentInvalid" xml:space="preserve">
     <value>Failed to read cloud environment content.</value>
   </data>
+  <data name="DeserializationFailure" xml:space="preserve">
+    <value>Failed to deserialize '{0}'. {1}</value>
+  </data>
   <data name="EmptyConditionExpandResult" xml:space="preserve">
     <value>The expand resulted in an empty condition being returned for '{0}' from '{1}'.</value>
   </data>
@@ -184,6 +187,9 @@
   <data name="ExpressionInvalid" xml:space="preserve">
     <value>Failed to parse expression. The expression may not be valid. Expression: "{0}"</value>
     <comment>Occurs when an expression fails to be parsed.</comment>
+  </data>
+  <data name="FunctionGenericError" xml:space="preserve">
+    <value>The function '{0}' failed. {1}</value>
   </data>
   <data name="FunctionInvalidString" xml:space="preserve">
     <value>The specified parameter is not a valid string.</value>

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/AVMTestCases/BicepAVMTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/AVMTestCases/BicepAVMTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Linq;
 using Newtonsoft.Json.Linq;
 using PSRule.Rules.Azure.Data.Template;
-using System.Linq;
 
 namespace PSRule.Rules.Azure.Bicep.AVMTestCases;
 
@@ -35,5 +35,18 @@ public sealed class BicepAVMTests : TemplateVisitorTestsBase
         Assert.Equal([
             "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/ps-rule-test-rg/providers/Microsoft.Network/networkInterfaces/nic1"
         ], id);
+    }
+
+    [Fact]
+    public void ProcessTemplate_WhenReferencingCrossModuleDependency_ShouldGetResource()
+    {
+        var resources = ProcessTemplate(GetSourcePath("Bicep/AVMTestCases/Tests.Bicep.2.json"), null, out var templateContext);
+
+        var actual = resources.FirstOrDefault(r => r["name"].Value<string>() == "site1");
+        Assert.NotNull(actual);
+
+        var endpoint = actual["properties"]["siteConfig"]["appSettings"].ToArray().FirstOrDefault(setting => setting["name"].Value<string>() == "endpoint");
+        Assert.NotNull(endpoint);
+        Assert.Equal("https://storage1.blob.core.windows.net/", endpoint["value"].Value<string>());
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/AVMTestCases/Tests.Bicep.2.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/AVMTestCases/Tests.Bicep.2.bicep
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+targetScope = 'resourceGroup'
+
+module child1 'Tests.Bicep.2.child1.bicep' = {
+  name: 'child1'
+}
+
+module child2 'Tests.Bicep.2.child2.bicep' = {
+  name: 'child2'
+  dependsOn: [
+    child1
+  ]
+}

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/AVMTestCases/Tests.Bicep.2.child1.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/AVMTestCases/Tests.Bicep.2.child1.bicep
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+targetScope = 'resourceGroup'
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: 'storage1'
+  location: resourceGroup().location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/AVMTestCases/Tests.Bicep.2.child2.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/AVMTestCases/Tests.Bicep.2.child2.bicep
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+targetScope = 'resourceGroup'
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: 'storage1'
+}
+
+resource site 'Microsoft.Web/sites@2024-04-01' = {
+  name: 'site1'
+  location: 'eastus'
+  kind: 'web'
+  properties: {
+    httpsOnly: true
+    siteConfig: {
+      appSettings: [
+        {
+          name: 'endpoint'
+          value: storage.properties.primaryEndpoints.blob
+        }
+      ]
+    }
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/AVMTestCases/Tests.Bicep.2.json
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/AVMTestCases/Tests.Bicep.2.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.33.93.31351",
+      "templateHash": "1050198469096767405"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "child1",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.33.93.31351",
+              "templateHash": "3538110272279749699"
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "apiVersion": "2023-05-01",
+              "name": "storage1",
+              "location": "[resourceGroup().location]",
+              "sku": {
+                "name": "Standard_LRS"
+              },
+              "kind": "StorageV2"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "child2",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.33.93.31351",
+              "templateHash": "590798776475046430"
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Web/sites",
+              "apiVersion": "2024-04-01",
+              "name": "site1",
+              "location": "eastus",
+              "kind": "web",
+              "properties": {
+                "httpsOnly": true,
+                "siteConfig": {
+                  "appSettings": [
+                    {
+                      "name": "endpoint",
+                      "value": "[reference(resourceId('Microsoft.Storage/storageAccounts', 'storage1'), '2023-05-01').primaryEndpoints.blob]"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'child1')]"
+      ]
+    }
+  ]
+}

--- a/tests/PSRule.Rules.Azure.Tests/ExpressionHelpersTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/ExpressionHelpersTests.cs
@@ -4,28 +4,49 @@
 using Newtonsoft.Json.Linq;
 using PSRule.Rules.Azure.Data.Template;
 
-namespace PSRule.Rules.Azure
-{
-    /// <summary>
-    /// Unit tests for <see cref="ExpressionHelpers"/>.
-    /// </summary>
-    public sealed class ExpressionHelpersTests
-    {
-        [Fact]
-        public void TryArray()
-        {
-            Assert.True(ExpressionHelpers.TryArray(JToken.Parse("[ 1, 2, 3 ]"), out _));
-            Assert.True(ExpressionHelpers.TryArray(new JArray(1, 2, 3), out _));
-            Assert.True(ExpressionHelpers.TryArray(new int[] { 1, 2, 3 }, out _));
-        }
+namespace PSRule.Rules.Azure;
 
-        [Fact]
-        public void GetUnique()
-        {
-            Assert.Equal("0b0d0856d2b1e9", ExpressionHelpers.GetUniqueString(new string[] { "test", "123" }));
-            Assert.Equal("0b0d0856d2b1e9", ExpressionHelpers.GetUniqueString(new string[] { "test123" }));
-            Assert.Equal("0b0d0856d2b1e9", ExpressionHelpers.GetUniqueString(new string[] { null, "test", "123" }));
-            Assert.Equal("9c7543ad4767e2", ExpressionHelpers.GetUniqueString(new string[] { "test", "1234" }));
-        }
+/// <summary>
+/// Unit tests for <see cref="ExpressionHelpers"/>.
+/// </summary>
+public sealed class ExpressionHelpersTests
+{
+    [Fact]
+    public void TryArray()
+    {
+        Assert.True(ExpressionHelpers.TryArray(JToken.Parse("[ 1, 2, 3 ]"), out _));
+        Assert.True(ExpressionHelpers.TryArray(new JArray(1, 2, 3), out _));
+        Assert.True(ExpressionHelpers.TryArray(new int[] { 1, 2, 3 }, out _));
+    }
+
+    [Fact]
+    public void GetUnique()
+    {
+        Assert.Equal("0b0d0856d2b1e9", ExpressionHelpers.GetUniqueString(new string[] { "test", "123" }));
+        Assert.Equal("0b0d0856d2b1e9", ExpressionHelpers.GetUniqueString(new string[] { "test123" }));
+        Assert.Equal("0b0d0856d2b1e9", ExpressionHelpers.GetUniqueString(new string[] { null, "test", "123" }));
+        Assert.Equal("9c7543ad4767e2", ExpressionHelpers.GetUniqueString(new string[] { "test", "1234" }));
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("test", "test")]
+    [InlineData("[test", "[test")]
+    [InlineData("[test]", "[[test]")]
+    [InlineData("[[test]", "[[test]")]
+    public void WrapLiteralString_WhenEnclosed_ShouldAddEscape(string? value, string? expected)
+    {
+        Assert.Equal(expected, ExpressionHelpers.WrapLiteralString(value));
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("test", "test")]
+    [InlineData("[test", "[test")]
+    [InlineData("[test]", "[test]")]
+    [InlineData("[[test]", "[test]")]
+    public void UnwrapLiteralString_WhenEnclosed_ShouldRemoveEscape(string? value, string? expected)
+    {
+        Assert.Equal(expected, ExpressionHelpers.UnwrapLiteralString(value));
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/JsonExtensionsTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/JsonExtensionsTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json.Linq;
+
+namespace PSRule.Rules.Azure;
+
+/// <summary>
+/// Unit tests for <see cref="JsonExtensions"/>.
+/// </summary>
+public sealed class JsonExtensionsTests
+{
+    [Fact]
+    public void AddIfNotExists_WithNewProperty_ShouldAdd()
+    {
+        var json = new JObject
+        {
+            { "existing", "value" }
+        };
+
+        json.AddIfNotExists("new", "value");
+
+        Assert.Equal("value", json["existing"]);
+        Assert.Equal("value", json["new"]);
+        Assert.Equal(2, json.Count);
+    }
+
+    [Fact]
+    public void AddIfNotExists_WithExistingProperty_ShouldNotAdd()
+    {
+        var json = new JObject
+        {
+            { "existing", "value" }
+        };
+
+        json.AddIfNotExists("existing", "value");
+
+        Assert.Equal("value", json["existing"]);
+        Assert.Single(json);
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -32,6 +32,9 @@
     <None Update="Bicep\AVMTestCases\Tests.Bicep.1.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Bicep\AVMTestCases\Tests.Bicep.2.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Bicep\SymbolicNameTestCases\Tests.Bicep.2.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Rules.Azure.Tests/ResourceHelperTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/ResourceHelperTests.cs
@@ -193,6 +193,52 @@ public sealed class ResourceHelperTests
         Assert.False(ResourceHelper.TryManagementGroup(resourceId, out var actualManagementGroup));
         Assert.Null(actualManagementGroup);
     }
+
+    [Theory]
+    [InlineData("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff")]
+    [InlineData("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/rg-4")]
+    [InlineData("/providers/Microsoft.Management/managementGroups/mg-1")]
+    [InlineData("/providers/Microsoft.Management/managementGroups/mg-1/providers/Microsoft.Authorization/policyAssignments/assignment-1")]
+    [InlineData("/providers/Microsoft.Authorization/policyDefinitions/policy-1")]
+    [InlineData("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/rg-4/providers/Microsoft.KeyVault/vaults/keyvault-1/secrets/secret-1")]
+    [InlineData("/")]
+    public void IsResourceId_WithValidResourceId_ShouldReturnTrue(string resourceId)
+    {
+        Assert.True(ResourceHelper.IsResourceId(resourceId));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("/subscriptions")]
+    [InlineData("subscriptions")]
+    public void IsResourceId_WithInvalidResourceId_ShouldReturnFalse(string? resourceId)
+    {
+        Assert.False(ResourceHelper.IsResourceId(resourceId));
+    }
+
+    [Theory]
+    [InlineData("/providers/Microsoft.Authorization/policyDefinitions/policy-1", "Microsoft.Authorization", new string[] { "Microsoft.Authorization/policyDefinitions" }, new string[] { "policy-1" })]
+    [InlineData("/providers/Microsoft.Management/managementGroups/mg-1", "Microsoft.Management", new string[] { "Microsoft.Management/managementGroups" }, new string[] { "mg-1" })]
+    [InlineData("/providers/Microsoft.Management/managementGroups/mg-1/providers/Microsoft.Authorization/policyAssignments/assignment-1", "Microsoft.Management", new string[] { "Microsoft.Management/managementGroups", "providers", "policyAssignments" }, new string[] { "mg-1", "Microsoft.Authorization", "assignment-1" })]
+    public void TryTenantResourceProvider_WithValidTenantResourceId_ShouldReturnTenantResourceProvider(string resourceId, string provider, string[] type, string[] name)
+    {
+        Assert.True(ResourceHelper.TryTenantResourceProvider(resourceId, out var actualProvider, out var actualType, out var actualName));
+        Assert.Equal(provider, actualProvider);
+        Assert.Equal(type, actualType);
+        Assert.Equal(name, actualName);
+    }
+
+    [Theory]
+    [InlineData("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff")]
+    [InlineData("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/rg-4")]
+    [InlineData("subscriptions")]
+    [InlineData("/")]
+    public void TryTenantResourceProvider_WithOtherResourceId_ShouldReturnFalse(string resourceId)
+    {
+        Assert.False(ResourceHelper.TryTenantResourceProvider(resourceId, out _, out _, out _));
+    }
 }
 
 #nullable restore

--- a/tests/PSRule.Rules.Azure.Tests/StringExtensionsTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/StringExtensionsTests.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Rules.Azure;
+
+#nullable enable
+
+/// <summary>
+/// Unit tests for <see cref="StringExtensions"/>.
+/// </summary>
+public sealed class StringExtensionsTests
+{
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("test", false)]
+    [InlineData("[test]", true)]
+    [InlineData("[[test]", false)]
+    public void IsExpressionString_WhenExpression_ShouldReturnTrue(string? value, bool expected)
+    {
+        Assert.Equal(expected, StringExtensions.IsExpressionString(value));
+    }
+}
+
+#nullable restore

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -504,12 +504,12 @@ namespace PSRule.Rules.Azure
 
             actual = resources[5];
             Assert.Equal("Microsoft.Storage/storageAccounts", actual["type"].Value<string>());
-            Assert.Equal("sabicep001f8cbd7940fe93", actual["name"].Value<string>());
+            Assert.Equal("sabicep00193e72b142f565", actual["name"].Value<string>());
             Assert.Equal("test", actual["tags"]["env"].Value<string>());
 
             actual = resources[6];
             Assert.Equal("Microsoft.Network/privateEndpoints", actual["type"].Value<string>());
-            Assert.Equal("pe-sabicep001f8cbd7940fe93", actual["name"].Value<string>());
+            Assert.Equal("pe-sabicep00193e72b142f565", actual["name"].Value<string>());
 
             actual = resources[7];
             Assert.Equal("Microsoft.Resources/deployments", actual["type"].Value<string>());


### PR DESCRIPTION
## PR Summary

- Fixed recursive lookup of cross module resources in the deployment.
  - This improves the ability to reference resource properties in the same parent deployment.
  - Additionally, projection of runtime properties has been improved.
- Fixed literal strings may be incorrectly interpreted as expressions.

Fixes #3251 
Fixes #3252

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
