### PR TITLE
Fixes key rotation policy fails due to missing data #3261

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -34,6 +34,9 @@ What's changed since v1.41.3:
 - Bug fixes:
   - Fixed Azure VM Standalone failing on data disks check by @BernieWhite.
     [#3263](https://github.com/Azure/PSRule.Rules.Azure/issues/3263)
+  - Fixed in-flight analysis of key rotation policy fails due to missing data by @BernieWhite.
+    [#3261](https://github.com/Azure/PSRule.Rules.Azure/issues/3261)
+    - Disabled export of `keys` from management plane API because the data is incomplete for this rule.
 
 ## v1.41.3
 

--- a/docs/en/rules/Azure.KeyVault.AutoRotationPolicy.md
+++ b/docs/en/rules/Azure.KeyVault.AutoRotationPolicy.md
@@ -1,5 +1,5 @@
 ---
-reviewed: 2024-06-17
+reviewed: 2025-02-27
 severity: Important
 pillar: Security
 category: SE:09 Application secrets
@@ -7,11 +7,11 @@ resource: Key Vault
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.AutoRotationPolicy/
 ---
 
-# Enable Key Vault key auto-rotation
+# Key Vault key rotation policy is not set
 
 ## SYNOPSIS
 
-Key Vault keys should have auto-rotation enabled.
+Keys that become compromised may be used to spoof, decrypt, or gain access to sensitive data.
 
 ## DESCRIPTION
 
@@ -123,6 +123,10 @@ resource vaultName_key1 'Microsoft.KeyVault/vaults/keys@2021-06-01-preview' = {
   }
 }
 ```
+
+## NOTES
+
+This rule only applies to pre-flight validation of Azure templates and Bicep files.
 
 ## LINKS
 

--- a/src/PSRule.Rules.Azure/Pipeline/Export/ResourceExportVisitor.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/Export/ResourceExportVisitor.cs
@@ -427,10 +427,14 @@ internal sealed class ResourceExportVisitor
             return false;
 
         await GetDiagnosticSettings(context, resource, resourceId);
-        if (resource.TryGetProperty(PROPERTY_PROPERTIES, out JObject properties) &&
-            properties.TryGetProperty(PROPERTY_TENANTID, out var tenantId) &&
-            string.Equals(tenantId, context.TenantId))
-            AddSubResource(resource, await GetSubResourcesByType(context, resourceId, "keys", APIVERSION_2022_07_01));
+
+        // Key rotations policies are not exposed in the management API.
+        // Exporting keys has been disabled to resolve issue https://github.com/Azure/PSRule.Rules.Azure/issues/3261
+        // Currently there is no rules applicable to in-flight that require getting key resources.
+        // if (resource.TryGetProperty(PROPERTY_PROPERTIES, out JObject properties) &&
+        //     properties.TryGetProperty(PROPERTY_TENANTID, out var tenantId) &&
+        //     string.Equals(tenantId, context.TenantId))
+        //     AddSubResource(resource, await GetSubResourcesByType(context, resourceId, "keys", APIVERSION_2022_07_01));
 
         return true;
     }


### PR DESCRIPTION
## PR Summary

- Fixed in-flight analysis of key rotation policy fails due to missing data.

Fixes #3261

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
