### PR TITLE
Pre-release v1.42.0-B0021

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -29,6 +29,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.42.0-B0021 (pre-release)
+
 What's changed since v1.41.4:
 
 - New rules:
@@ -40,7 +42,7 @@ What's changed since v1.41.4:
     - Updated `Azure.AppService.MinTLS` to include TLS 1.3 as a valid minimum version by @BernieWhite.
       [#3269](https://github.com/Azure/PSRule.Rules.Azure/issues/3269)
 - General improvements:
-  - Added a new quickstart guide for using Azure Pipelines with PSRule by @that-ar-guy.  
+  - Added a new quickstart guide for using Azure Pipelines with PSRule by @that-ar-guy.
     [#3220](https://github.com/Azure/PSRule.Rules.Azure/pull/3220)
   - Added additional exclusions to policies for `Azure.AppService.MinTLS` by @BernieWhite.
     [#1731](https://github.com/Azure/PSRule.Rules.Azure/issues/1731)


### PR DESCRIPTION
## PR Summary

What's changed since v1.41.4:

- New rules:
  - Image Builder:
    - Check that image builder build and validation scripts are pinned by @BernieWhite.
      [#2903](https://github.com/Azure/PSRule.Rules.Azure/issues/2903)
- Updated rules:
  - App Service:
    - Updated `Azure.AppService.MinTLS` to include TLS 1.3 as a valid minimum version by @BernieWhite.
      [#3269](https://github.com/Azure/PSRule.Rules.Azure/issues/3269)
- General improvements:
  - Added a new quickstart guide for using Azure Pipelines with PSRule by @that-ar-guy.
    [#3220](https://github.com/Azure/PSRule.Rules.Azure/pull/3220)
  - Added additional exclusions to policies for `Azure.AppService.MinTLS` by @BernieWhite.
    [#1731](https://github.com/Azure/PSRule.Rules.Azure/issues/1731)
- Engineering:
  - Updates to WAF documentation by @BernieWhite.
    [#2570](https://github.com/Azure/PSRule.Rules.Azure/issues/2570)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
