### PR TITLE
Update enforce-custom-tags.md to link to correct page for assertion methods

### DIFF
--- a/docs/customization/enforce-custom-tags.md
+++ b/docs/customization/enforce-custom-tags.md
@@ -182,4 +182,4 @@ Grab the full sample code for each of these files from:
 - [ps-rule.yaml](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/customization/enforce-custom-tags/ps-rule.yaml)
 
 [AWAF]: https://learn.microsoft.com/azure/well-architected/
-[assertions]: https://microsoft.github.io/PSRule/v2/commands/PSRule/en-US/Assert-PSRule/
+[assertions]: https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Assert/


### PR DESCRIPTION
## PR Summary

The link to the list of supported assertions was incorrect, it was pointing to the Assert-PsRule page, instead of the Assertion methods page.

## PR Checklist

- [ x ] PR has a meaningful title
- [ x ] Summarized changes
- [ x ] Change is not breaking
- [ x ] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [ ] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
