### PR TITLE
Bump Azure.Grafana.Version to version 11 #3293

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -35,6 +35,11 @@ What's changed since pre-release v1.42.0-B0021:
   - Azure SQL Database:
     - Check that logical SQL servers have vulnerability assessment enabled by @BernieWhite.
       [#3196](https://github.com/Azure/PSRule.Rules.Azure/issues/3196)
+- Updated rules:
+  - Azure Managed Grafana:
+    - Bumped `Azure.Grafana.Version` to use version `11` as `10` is now depreciated by @BernieWhite.
+      [#3293](https://github.com/Azure/PSRule.Rules.Azure/issues/3293)
+      - Bumped rule set to `2025_03`.
 - Engineering:
   - Updated resource providers and policy aliases by @BernieWhite.
     [#3285](https://github.com/Azure/PSRule.Rules.Azure/issues/3285)

--- a/docs/en/rules/Azure.Grafana.Version.md
+++ b/docs/en/rules/Azure.Grafana.Version.md
@@ -1,4 +1,5 @@
 ---
+reviewed: 2025-03-25
 severity: Important
 pillar: Reliability
 category: RE:04 Target metrics
@@ -7,7 +8,7 @@ resourceType: Microsoft.Dashboard/grafana
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Grafana.Version/
 ---
 
-# Upgrade Grafana version
+# Azure Managed Grafana uses a deprecated version of Grafana
 
 ## SYNOPSIS
 
@@ -15,51 +16,31 @@ Grafana workspaces should be on Grafana version 10.
 
 ## DESCRIPTION
 
-Support for Grafana version 9 within Azure Managed Grafana is deprecated and will retire on 31 August 2024.
-To avoid support disruptions, upgrade to Grafana version 10.
+Support for Grafana version 10 within Azure Managed Grafana is deprecated.
+Azure Managed Grafana supports Grafana version 11.
+In August 2025, all Grafana workspaces running Grafana version 10 will be automatically upgraded to Grafana version 11.
+
+However, Grafana 11 introduces several breaking changes.
+To avoid support disruptions, familiarize yourself with the breaking changes and start planning your upgrade.
+Plan to complete your upgrade to Grafana 11 before the deadline.
 
 ## RECOMMENDATION
 
-Upgrade to Grafana version 10 for Azure Managed Grafana workspaces to avoid support disruptions.
+Consider familiarize yourself with the breaking changes introduced in Grafana 11,
+and plan to upgrade your Azure Managed Grafana workspaces before the deadline to avoid support disruptions.
 
 ## EXAMPLES
-
-### Configure with Azure template
-
-To deploy Azure Managed Grafana workspaces that pass this rule:
-
-- Set the `properties.grafanaMajorVersion` property to `10`.
-
-For example:
-
-```json
-{
-  "type": "Microsoft.Dashboard/grafana",
-  "apiVersion": "2023-09-01",
-  "name": "[parameters('name')]",
-  "location": "[parameters('location')]",
-  "sku": {
-    "name": "Standard"
-  },
-  "identity": {
-    "type": "SystemAssigned"
-  },
-  "properties": {
-    "grafanaMajorVersion": "10"
-  }
-}
-```
 
 ### Configure with Bicep
 
 To deploy Azure Managed Grafana workspaces that pass this rule:
 
-- Set the `properties.grafanaMajorVersion` property to `10`.
+- Set the `properties.grafanaMajorVersion` property to `11`.
 
 For example:
 
 ```bicep
-resource grafana 'Microsoft.Dashboard/grafana@2023-09-01' = {
+resource grafana 'Microsoft.Dashboard/grafana@2024-10-01' = {
   name: name
   location: location
   sku: {
@@ -69,7 +50,35 @@ resource grafana 'Microsoft.Dashboard/grafana@2023-09-01' = {
     type: 'SystemAssigned'
   }
   properties: {
-    grafanaMajorVersion: '10'
+    grafanaMajorVersion: '11'
+    zoneRedundancy: 'Enabled'
+  }
+}
+```
+
+### Configure with Azure template
+
+To deploy Azure Managed Grafana workspaces that pass this rule:
+
+- Set the `properties.grafanaMajorVersion` property to `11`.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.Dashboard/grafana",
+  "apiVersion": "2024-10-01",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "sku": {
+    "name": "Standard"
+  },
+  "identity": {
+    "type": "SystemAssigned"
+  },
+  "properties": {
+    "grafanaMajorVersion": "11",
+    "zoneRedundancy": "Enabled"
   }
 }
 ```
@@ -77,12 +86,12 @@ resource grafana 'Microsoft.Dashboard/grafana@2023-09-01' = {
 ### Configure with Azure CLI
 
 ```bash
-az grafana update --name <azure-managed-grafana-workspace> --major-version 10
+az grafana update --name <azure-managed-grafana-workspace> --major-version 11
 ```
 
 ## LINKS
 
 - [RE:04 Target metrics](https://learn.microsoft.com/azure/well-architected/reliability/metrics)
-- [Update to using Grafana version 10 for Azure Managed Grafana](https://azure.microsoft.com/updates/action-recommended-update-to-using-grafana-version-10-for-azure-managed-grafana)
-- [Upgrade to Grafana 10](https://learn.microsoft.com/azure/managed-grafana/how-to-upgrade-grafana-10)
+- [Upgrade to Grafana 11](https://learn.microsoft.com/azure/managed-grafana/how-to-upgrade-grafana-11)
+- [Breaking changes in Grafana v11.0](https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v11-0/)
 - [Azure resource deployment](https://learn.microsoft.com/azure/templates/microsoft.dashboard/grafana)

--- a/docs/examples/resources/grafana.bicep
+++ b/docs/examples/resources/grafana.bicep
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Bicep documentation examples
+
+@sys.description('The name of the resource.')
+param name string
+
+@sys.description('The location resources will be deployed.')
+param location string = resourceGroup().location
+
+// An example of a Grafana resource with a system-assigned identity and the Standard SKU.
+resource grafana 'Microsoft.Dashboard/grafana@2024-10-01' = {
+  name: name
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    grafanaMajorVersion: '11'
+    zoneRedundancy: 'Enabled'
+  }
+}

--- a/docs/examples/resources/grafana.json
+++ b/docs/examples/resources/grafana.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.34.1.11899",
+      "templateHash": "10670661185846540130"
+    }
+  },
+  "parameters": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the resource."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location resources will be deployed."
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Dashboard/grafana",
+      "apiVersion": "2024-10-01",
+      "name": "[parameters('name')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard"
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "grafanaMajorVersion": "11",
+        "zoneRedundancy": "Enabled"
+      }
+    }
+  ]
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.Grafana.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.Grafana.Rule.yaml
@@ -16,14 +16,14 @@ metadata:
   ref: AZR-000424
   tags:
     release: GA
-    ruleSet: 2024_06
+    ruleSet: 2025_03
     Azure.WAF/pillar: Reliability
 spec:
   type:
     - Microsoft.Dashboard/grafana
   condition:
     field: properties.grafanaMajorVersion
-    greaterOrEquals: 10
+    greaterOrEquals: 11
     convert: true
 
 #endregion Rules

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
@@ -248,7 +248,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2024_06' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 414;
+            $filteredResult.Length | Should -Be 413;
         }
 
         It 'With Azure.Preview_2024_06' {
@@ -262,7 +262,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2024_09' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 431;
+            $filteredResult.Length | Should -Be 430;
         }
 
         It 'With Azure.Preview_2024_09' {
@@ -276,7 +276,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2024_12' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 434;
+            $filteredResult.Length | Should -Be 433;
         }
 
         It 'With Azure.Preview_2024_12' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Grafana.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Grafana.Tests.ps1
@@ -41,15 +41,15 @@ Describe 'Azure.Grafana' -Tag 'Grafana' {
 
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
-            $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'grafana-a';
+            $ruleResult.Length | Should -Be 1;
 
-            $ruleResult[0].Reason | Should -Be "Path properties.grafanaMajorVersion: The value '9' is not >= 10.";
+            $ruleResult[0].Reason | Should -Be "Path properties.grafanaMajorVersion: The value '10' is not >= 11.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
-            $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'grafana-b';
+            $ruleResult.Length | Should -Be 1;
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Grafana.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Grafana.json
@@ -41,7 +41,7 @@
           }
         ]
       },
-      "grafanaMajorVersion": "9",
+      "grafanaMajorVersion": "10",
       "grafanaPlugins": {
         "{customized property}": {}
       },
@@ -91,7 +91,7 @@
           }
         ]
       },
-      "grafanaMajorVersion": "10",
+      "grafanaMajorVersion": "11",
       "grafanaPlugins": {
         "{customized property}": {}
       },


### PR DESCRIPTION
## PR Summary

- Bumped `Azure.Grafana.Version` to use version `11` as `10` is now depreciated.

Fixes #3293

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
