### PR TITLE
Added support for fail and deployer Bicep functions #3308

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -57,6 +57,9 @@ What's changed since pre-release v1.42.0-B0021:
     - Bumped `Azure.Grafana.Version` to use version `11` as `10` is now depreciated by @BernieWhite.
       [#3293](https://github.com/Azure/PSRule.Rules.Azure/issues/3293)
       - Bumped rule set to `2025_03`.
+- General improvements:
+  - Added support for `fail` and `deployer` functions during Bicep expansion by @BernieWhite.
+    [#3308](https://github.com/Azure/PSRule.Rules.Azure/issues/3308)
 - Engineering:
   - Updated resource providers and policy aliases by @BernieWhite.
     [#3285](https://github.com/Azure/PSRule.Rules.Azure/issues/3285)

--- a/docs/setup/configuring-expansion.md
+++ b/docs/setup/configuring-expansion.md
@@ -385,6 +385,43 @@ configuration:
       displayName: 'My test management group'
 ```
 
+### Deployer properties
+
+<!-- module:version v1.42.0 -->
+
+This configuration option sets the deployer object used by the `deployer()` function.
+Configure this option to change the details of the deployer when exporting templates for analysis.
+Provided properties will override the default.
+Any properties that are not provided with use the defaults as specified below.
+
+Syntax:
+
+```yaml title='ps-rule.yaml'
+configuration:
+  AZURE_DEPLOYER:
+    objectId: string
+    tenantId: string
+```
+
+Default:
+
+```yaml title='ps-rule.yaml'
+# YAML: The default AZURE_DEPLOYER configuration option
+configuration:
+  AZURE_DEPLOYER:
+    objectId: 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+    tenantId: 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+```
+
+Example:
+
+```yaml title='ps-rule.yaml'
+# YAML: Override the objectID of the deployer object
+configuration:
+  AZURE_DEPLOYER:
+    objectId: '00000000-0000-0000-0000-000000000000'
+```
+
 ### Required parameter defaults
 
 <!-- module:version v1.13.0 -->

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -247,3 +247,14 @@ For the PSRule GitHub Action, use **>=1.4.0**.
 - name: Run PSRule analysis
   uses: microsoft/ps-rule@v2.9.0
 ```
+
+## PFA0001: Unable to process the deployment
+
+!!! Message
+
+    PFA0001: Unable to process the deployment because the template requested a failure. See https://aka.ms/ps-rule-azure/troubleshooting.
+
+This error is returned when the template or Bicep module called the `fail()` function.
+A template or Bicep module author may call the `fail()` function cause a validation error.
+
+If you got this message, continue reading to the end of the message to see the instructions left by the template author.

--- a/src/PSRule.Rules.Azure/Configuration/ConfigurationOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/ConfigurationOption.cs
@@ -24,6 +24,7 @@ public sealed class ConfigurationOption : IEquatable<ConfigurationOption>
         ManagementGroup = ManagementGroupOption.Default,
         ParameterDefaults = ParameterDefaultsOption.Default,
         Deployment = DeploymentOption.Default,
+        Deployer = DeployerOption.Default,
         PolicyRulePrefix = DEFAULT_POLICY_RULE_PREFIX,
         BicepMinimumVersion = DEFAULT_BICEP_MINIMUM_VERSION,
         BicepFileExpansionTimeout = DEFAULT_BICEP_FILE_EXPANSION_TIMEOUT,
@@ -40,6 +41,7 @@ public sealed class ConfigurationOption : IEquatable<ConfigurationOption>
         ManagementGroup = null;
         ParameterDefaults = null;
         Deployment = null;
+        Deployer = null;
         PolicyIgnoreList = null;
         PolicyRulePrefix = null;
         BicepMinimumVersion = null;
@@ -57,6 +59,7 @@ public sealed class ConfigurationOption : IEquatable<ConfigurationOption>
         ManagementGroup = new ManagementGroupOption(option.ManagementGroup);
         ParameterDefaults = new ParameterDefaultsOption(option.ParameterDefaults);
         Deployment = new DeploymentOption(option.Deployment);
+        Deployer = new DeployerOption(option.Deployer);
         PolicyIgnoreList = (string[])option.PolicyIgnoreList?.Clone();
         PolicyRulePrefix = option.PolicyRulePrefix;
         BicepMinimumVersion = option.BicepMinimumVersion;
@@ -79,6 +82,7 @@ public sealed class ConfigurationOption : IEquatable<ConfigurationOption>
             ManagementGroup == other.ManagementGroup &&
             ParameterDefaults == other.ParameterDefaults &&
             Deployment == other.Deployment &&
+            Deployer == other.Deployer &&
             PolicyIgnoreList == other.PolicyIgnoreList &&
             PolicyRulePrefix == other.PolicyRulePrefix &&
             BicepMinimumVersion == other.BicepMinimumVersion &&
@@ -97,6 +101,7 @@ public sealed class ConfigurationOption : IEquatable<ConfigurationOption>
             hash = hash * 23 + (ManagementGroup != null ? ManagementGroup.GetHashCode() : 0);
             hash = hash * 23 + (ParameterDefaults != null ? ParameterDefaults.GetHashCode() : 0);
             hash = hash * 23 + (Deployment != null ? Deployment.GetHashCode() : 0);
+            hash = hash * 23 + (Deployer != null ? Deployer.GetHashCode() : 0);
             hash = hash * 23 + (PolicyIgnoreList != null ? PolicyIgnoreList.GetHashCode() : 0);
             hash = hash * 23 + (PolicyRulePrefix != null ? PolicyRulePrefix.GetHashCode() : 0);
             hash = hash * 23 + (BicepMinimumVersion != null ? BicepMinimumVersion.GetHashCode() : 0);
@@ -115,6 +120,7 @@ public sealed class ConfigurationOption : IEquatable<ConfigurationOption>
             ManagementGroup = ManagementGroupOption.Combine(o1?.ManagementGroup, o2?.ManagementGroup),
             ParameterDefaults = ParameterDefaultsOption.Combine(o1?.ParameterDefaults, o2?.ParameterDefaults),
             Deployment = DeploymentOption.Combine(o1?.Deployment, o2?.Deployment),
+            Deployer = DeployerOption.Combine(o1?.Deployer, o2?.Deployer),
             PolicyIgnoreList = o1?.PolicyIgnoreList ?? o2?.PolicyIgnoreList,
             PolicyRulePrefix = o1?.PolicyRulePrefix ?? o2?.PolicyRulePrefix,
             BicepMinimumVersion = o1?.BicepMinimumVersion ?? o2?.BicepMinimumVersion,
@@ -163,6 +169,13 @@ public sealed class ConfigurationOption : IEquatable<ConfigurationOption>
     [DefaultValue(null)]
     [YamlMember(Alias = "AZURE_DEPLOYMENT", ApplyNamingConventions = false)]
     public DeploymentOption Deployment { get; set; }
+
+    /// <summary>
+    /// Configures the properties of the deployer object.
+    /// </summary>
+    [DefaultValue(null)]
+    [YamlMember(Alias = "AZURE_DEPLOYER", ApplyNamingConventions = false)]
+    public DeployerOption Deployer { get; set; }
 
     /// <summary>
     /// Configures the policy rule prefix.

--- a/src/PSRule.Rules.Azure/Configuration/DeployerOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/DeployerOption.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.ComponentModel;
+using System;
+
+namespace PSRule.Rules.Azure.Configuration;
+
+/// <summary>
+/// Options that affect the properties of the <c>deployer()</c> object during expansion.
+/// </summary>
+public sealed class DeployerOption : IEquatable<DeployerOption>
+{
+    private const string DEFAULT_TENANT_ID = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+    private const string DEFAULT_OBJECT_ID = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+
+    internal static readonly DeployerOption Default = new()
+    {
+        ObjectId = DEFAULT_OBJECT_ID,
+        TenantId = DEFAULT_TENANT_ID
+    };
+
+    /// <summary>
+    /// Creates an empty tenant option.
+    /// </summary>
+    public DeployerOption()
+    {
+        ObjectId = null;
+        TenantId = null;
+    }
+
+    internal DeployerOption(DeployerOption option)
+    {
+        if (option == null)
+            return;
+
+        ObjectId = option.ObjectId;
+        TenantId = option.TenantId;
+    }
+
+    internal DeployerOption(string objectId, string tenantId)
+    {
+        ObjectId = objectId ?? DEFAULT_OBJECT_ID;
+        TenantId = tenantId ?? DEFAULT_TENANT_ID;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object obj)
+    {
+        return obj is DeployerOption option && Equals(option);
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(DeployerOption other)
+    {
+        return other != null &&
+            ObjectId == other.ObjectId &&
+            TenantId == other.TenantId;
+    }
+
+    /// <summary>
+    /// Compares two deployer options to determine if they are equal.
+    /// </summary>
+    public static bool operator ==(DeployerOption o1, DeployerOption o2)
+    {
+        return Equals(o1, o2);
+    }
+
+    /// <summary>
+    /// Compares two deployer options to determine if they are not equal.
+    /// </summary>
+    public static bool operator !=(DeployerOption o1, DeployerOption o2)
+    {
+        return !Equals(o1, o2);
+    }
+
+    /// <summary>
+    /// Compares two deployer options to determine if they are equal.
+    /// </summary>
+    public static bool Equals(DeployerOption o1, DeployerOption o2)
+    {
+        return (object.Equals(null, o1) && object.Equals(null, o2)) ||
+            (!object.Equals(null, o1) && o1.Equals(o2));
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        unchecked // Overflow is fine
+        {
+            var hash = 17;
+            hash = hash * 23 + (ObjectId != null ? ObjectId.GetHashCode() : 0);
+            hash = hash * 23 + (TenantId != null ? TenantId.GetHashCode() : 0);
+            return hash;
+        }
+    }
+
+    internal static DeployerOption Combine(DeployerOption o1, DeployerOption o2)
+    {
+        var result = new DeployerOption()
+        {
+            ObjectId = o1?.ObjectId ?? o2?.ObjectId,
+            TenantId = o1?.TenantId ?? o2?.TenantId,
+        };
+        return result;
+    }
+
+    internal static DeployerOption FromHashtable(Hashtable hashtable)
+    {
+        var result = new DeployerOption();
+        if (hashtable != null)
+        {
+            var index = PSRuleOption.BuildIndex(hashtable);
+            if (index.TryPopValue("ObjectId", out string objectId))
+                result.ObjectId = objectId;
+
+            if (index.TryPopValue("TenantId", out string tenantId))
+                result.TenantId = tenantId;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// The unique GUID for the object.
+    /// </summary>
+    [DefaultValue(null)]
+    public string ObjectId { get; set; }
+
+    /// <summary>
+    /// The unique GUID associated with the tenant.
+    /// </summary>
+    [DefaultValue(null)]
+    public string TenantId { get; set; }
+}

--- a/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Policy/PolicyAssignmentVisitor.cs
@@ -141,21 +141,11 @@ namespace PSRule.Rules.Azure.Data.Policy
                 Pipeline = context;
                 _FieldPrefix = new Stack<string>();
 
-                ResourceGroup = ResourceGroupOption.Default;
-                if (context?.Option?.Configuration?.ResourceGroup != null)
-                    ResourceGroup = context?.Option?.Configuration?.ResourceGroup;
-
-                Subscription = SubscriptionOption.Default;
-                if (context?.Option?.Configuration?.Subscription != null)
-                    Subscription = context?.Option?.Configuration?.Subscription;
-
-                Tenant = TenantOption.Default;
-                if (context?.Option?.Configuration?.Tenant != null)
-                    Tenant = context?.Option?.Configuration?.Tenant;
-
-                ManagementGroup = ManagementGroupOption.Default;
-                if (context?.Option?.Configuration?.ManagementGroup != null)
-                    ManagementGroup = context?.Option?.Configuration?.ManagementGroup;
+                ResourceGroup = context?.Option?.Configuration?.ResourceGroup ?? ResourceGroupOption.Default;
+                Subscription = context?.Option?.Configuration?.Subscription ?? SubscriptionOption.Default;
+                Tenant = context?.Option?.Configuration?.Tenant ?? TenantOption.Default;
+                ManagementGroup = context?.Option?.Configuration?.ManagementGroup ??ManagementGroupOption.Default;
+                Deployer = context?.Option?.Configuration?.Deployer ?? DeployerOption.Default;
 
                 PolicyRulePrefix = ConfigurationOption.Default.PolicyRulePrefix;
                 if (context?.Option?.Configuration?.PolicyRulePrefix != null)
@@ -185,6 +175,7 @@ namespace PSRule.Rules.Azure.Data.Policy
             public SubscriptionOption Subscription { get; }
             public TenantOption Tenant { get; }
             public ManagementGroupOption ManagementGroup { get; }
+            public DeployerOption Deployer { get; }
 
             public string PolicyRulePrefix { get; }
             public string FieldPrefix

--- a/src/PSRule.Rules.Azure/Data/Template/DeploymentFailureException.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/DeploymentFailureException.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.Serialization;
+using System.Security.Permissions;
+
+namespace PSRule.Rules.Azure.Data.Template;
+
+/// <summary>
+/// An exception caused by a failed deployment.
+/// This exception only occurs when the template or module specifically calls fail().
+/// </summary>
+[Serializable]
+public sealed class DeploymentFailureException : ExpressionException
+{
+    /// <summary>
+    /// Create an instance of a deployment failure exception.
+    /// </summary>
+    public DeploymentFailureException() { }
+
+    /// <summary>
+    /// Create an instance of a deployment failure exception.
+    /// </summary>
+    public DeploymentFailureException(string message)
+        : base(message) { }
+
+    /// <summary>
+    /// Create an instance of a deployment failure exception.
+    /// </summary>
+    public DeploymentFailureException(string message, Exception innerException)
+        : base(message, innerException) { }
+
+    /// <summary>
+    /// Create an instance of a deployment failure exception.
+    /// </summary>
+    internal DeploymentFailureException(string expression, string message)
+        : base(expression, message) { }
+
+    /// <summary>
+    /// Create an instance of a deployment failure exception.
+    /// </summary>
+    private DeploymentFailureException(SerializationInfo info, StreamingContext context)
+        : base(info, context) { }
+
+    /// <inheritdoc/>
+    [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        if (info == null) throw new ArgumentNullException(nameof(info));
+        base.GetObjectData(info, context);
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Template/ITemplateContext.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ITemplateContext.cs
@@ -36,6 +36,8 @@ internal interface ITemplateContext : IValidationContext
 
     ManagementGroupOption ManagementGroup { get; }
 
+    DeployerOption Deployer { get; }
+
     bool ShouldThrowMissingProperty { get; }
 
     DebugSymbol DebugSymbol { get; set; }

--- a/src/PSRule.Rules.Azure/Data/Template/NestedTemplateContext.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/NestedTemplateContext.cs
@@ -37,6 +37,8 @@ namespace PSRule.Rules.Azure.Data.Template
 
         public ManagementGroupOption ManagementGroup => _Inner.ManagementGroup;
 
+        public DeployerOption Deployer => _Inner.Deployer;
+
         public ExpressionFnOuter BuildExpression(string s)
         {
             return _Inner.BuildExpression(s);

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -112,6 +112,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 Subscription = SubscriptionOption.Default;
                 Tenant = TenantOption.Default;
                 ManagementGroup = ManagementGroupOption.Default;
+                Deployer = DeployerOption.Default;
                 _Deployment = new Stack<DeploymentValue>();
                 _ExpressionFactory = new ExpressionFactory();
                 _ExpressionBuilder = new ExpressionBuilder(_ExpressionFactory);
@@ -124,7 +125,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 _Symbols = new Dictionary<string, IDeploymentSymbol>(StringComparer.OrdinalIgnoreCase);
             }
 
-            internal TemplateContext(ITemplateContext? parent, PipelineContext pipelineContext, SubscriptionOption subscription, ResourceGroupOption resourceGroup, TenantOption tenant, ManagementGroupOption managementGroup, IDictionary<string, object> parameterDefaults)
+            internal TemplateContext(ITemplateContext? parent, PipelineContext pipelineContext, SubscriptionOption subscription, ResourceGroupOption resourceGroup, TenantOption tenant, ManagementGroupOption managementGroup, DeployerOption? deployer, IDictionary<string, object> parameterDefaults)
                 : this()
             {
                 Parent = parent;
@@ -140,6 +141,9 @@ namespace PSRule.Rules.Azure.Data.Template
 
                 if (managementGroup != null)
                     ManagementGroup = managementGroup;
+
+                if (deployer != null)
+                    Deployer = deployer;
 
                 if (parameterDefaults != null)
                     ParameterDefaults = new Dictionary<string, object>(parameterDefaults, StringComparer.OrdinalIgnoreCase);
@@ -161,6 +165,9 @@ namespace PSRule.Rules.Azure.Data.Template
                 if (pipelineContext?.Option?.Configuration?.ManagementGroup != null)
                     ManagementGroup = pipelineContext.Option.Configuration.ManagementGroup;
 
+                if (pipelineContext?.Option?.Configuration.Deployer != null)
+                    Deployer = pipelineContext.Option.Configuration.Deployer;
+
                 if (pipelineContext?.Option?.Configuration?.ParameterDefaults != null)
                     ParameterDefaults = new Dictionary<string, object>(pipelineContext.Option.Configuration.ParameterDefaults, StringComparer.OrdinalIgnoreCase);
             }
@@ -178,6 +185,8 @@ namespace PSRule.Rules.Azure.Data.Template
             public TenantOption Tenant { get; internal set; }
 
             public ManagementGroupOption ManagementGroup { get; internal set; }
+
+            public DeployerOption Deployer { get; internal set; }
 
             public IDictionary<string, object> ParameterDefaults { get; private set; }
 
@@ -1559,6 +1568,7 @@ namespace PSRule.Rules.Azure.Data.Template
             var resourceGroup = new ResourceGroupOption(context.ResourceGroup);
             var tenant = new TenantOption(context.Tenant);
             var managementGroup = new ManagementGroupOption(context.ManagementGroup);
+            var deployer = new DeployerOption(context.Deployer);
             if (TryStringProperty(resource, PROPERTY_SUBSCRIPTION_ID, out var subscriptionId))
             {
                 var targetSubscriptionId = ExpandString(context, subscriptionId);
@@ -1588,7 +1598,7 @@ namespace PSRule.Rules.Azure.Data.Template
             resourceGroup.SubscriptionId = subscription.SubscriptionId;
             TryObjectProperty(template, PROPERTY_PARAMETERS, out var templateParameters);
 
-            var deploymentContext = new TemplateContext(context, context.Pipeline, subscription, resourceGroup, tenant, managementGroup, context.ParameterDefaults);
+            var deploymentContext = new TemplateContext(context, context.Pipeline, subscription, resourceGroup, tenant, managementGroup, deployer, context.ParameterDefaults);
 
             // Handle custom type definitions early to allow type mapping of parameters if required.
             if (TryObjectProperty(template, PROPERTY_DEFINITIONS, out var definitions))

--- a/src/PSRule.Rules.Azure/Pipeline/PipelineContext.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PipelineContext.cs
@@ -17,10 +17,14 @@ internal sealed class PipelineContext
         Option.Configuration.Tenant = TenantOption.Combine(Option.Configuration.Tenant, TenantOption.Default);
         Option.Configuration.Tenant.TenantId = tenantId;
         Option.Configuration.ManagementGroup = ManagementGroupOption.Combine(Option.Configuration.ManagementGroup, ManagementGroupOption.Default);
+        Option.Configuration.Deployer = DeployerOption.Combine(Option.Configuration.Deployer, DeployerOption.Default);
         Option.Configuration.Subscription = SubscriptionOption.Combine(Option.Configuration.Subscription, SubscriptionOption.Default);
+
+        // Adjust based on other options if they have been set.
         Option.Configuration.Subscription.TenantId = Option.Configuration.Tenant.TenantId;
         Option.Configuration.ResourceGroup.SubscriptionId = Option.Configuration.Subscription.SubscriptionId;
         Option.Configuration.ManagementGroup.Properties.TenantId = Option.Configuration.Tenant.TenantId;
+        Option.Configuration.Deployer.TenantId = Option.Configuration.Tenant.TenantId;
     }
 
     public PSRuleOption Option { get; }

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
@@ -232,6 +232,15 @@ namespace PSRule.Rules.Azure.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to PFA0001: Unable to process the deployment because the template requested a failure. See https://aka.ms/ps-rule-azure/troubleshooting. {0}.
+        /// </summary>
+        internal static string DeploymentFailure {
+            get {
+                return ResourceManager.GetString("DeploymentFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to deserialize &apos;{0}&apos;. {1}.
         /// </summary>
         internal static string DeserializationFailure {

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -174,6 +174,9 @@
   </data>
   <data name="CloudEnvironmentInvalid" xml:space="preserve">
     <value>Failed to read cloud environment content.</value>
+  </data>
+  <data name="DeploymentFailure" xml:space="preserve">
+    <value>PFA0001: Unable to process the deployment because the template requested a failure. See https://aka.ms/ps-rule-azure/troubleshooting. {0}</value>
   </data>
   <data name="DeserializationFailure" xml:space="preserve">
     <value>Failed to deserialize '{0}'. {1}</value>

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -49,7 +49,7 @@ public sealed class FunctionTests
         Assert.Empty(actual4);
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.Array(context, null));
-        Assert.Throws<ExpressionArgumentException>(() => Functions.Array(context, System.Array.Empty<object>()));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Array(context, []));
         Assert.Throws<ExpressionArgumentException>(() => Functions.Array(context, ["abcd", "efgh"]));
     }
 
@@ -68,7 +68,7 @@ public sealed class FunctionTests
         Assert.Equal("a", Functions.Coalesce(context, [null, "a", throws]));
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.Coalesce(context, null));
-        Assert.Throws<ExpressionArgumentException>(() => Functions.Coalesce(context, System.Array.Empty<object>()));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Coalesce(context, []));
         Assert.Throws<NotImplementedException>(() => Functions.Coalesce(context, [null, throws]));
     }
 
@@ -161,7 +161,7 @@ public sealed class FunctionTests
             "mockProp",
             new Mock.MockResource("Microsoft.Resources/deployments/test1")["outputs"]["aksSubnetId"]["value"],
         ]) as JObject;
-        var actual2 = Functions.CreateObject(context, System.Array.Empty<object>()) as JObject;
+        var actual2 = Functions.CreateObject(context, []) as JObject;
         var actual3 = Functions.CreateObject(context, [
             "intProp",
             new Mock.MockValue(1),
@@ -246,7 +246,7 @@ public sealed class FunctionTests
         Assert.Null(actual2);
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.First(context, null));
-        Assert.Throws<ExpressionArgumentException>(() => Functions.First(context, System.Array.Empty<object>()));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.First(context, []));
     }
 
     [Fact]
@@ -268,7 +268,7 @@ public sealed class FunctionTests
         Assert.Equal([], actual);
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.Flatten(context, null));
-        Assert.Throws<ExpressionArgumentException>(() => Functions.Flatten(context, System.Array.Empty<object>()));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Flatten(context, []));
     }
 
     [Fact]
@@ -290,7 +290,7 @@ public sealed class FunctionTests
         Assert.Equal("c", actual2["three"]);
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.Intersection(context, null));
-        Assert.Throws<ExpressionArgumentException>(() => Functions.Intersection(context, System.Array.Empty<object>()));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Intersection(context, []));
         Assert.Throws<ExpressionArgumentException>(() => Functions.Intersection(context, ["one", "two", "three"]));
     }
 
@@ -330,7 +330,7 @@ public sealed class FunctionTests
         Assert.Null(actual3);
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.Json(context, null));
-        Assert.Throws<ExpressionArgumentException>(() => Functions.Json(context, System.Array.Empty<object>()));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Json(context, []));
     }
 
     [Fact]
@@ -396,7 +396,7 @@ public sealed class FunctionTests
         Assert.Equal(2, actual);
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.Length(context, null));
-        Assert.Throws<ExpressionArgumentException>(() => Functions.Length(context, System.Array.Empty<object>()));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Length(context, []));
         Assert.Throws<ExpressionArgumentException>(() => Functions.Length(context, [null]));
     }
 
@@ -423,7 +423,7 @@ public sealed class FunctionTests
         Assert.Equal(8, actual6);
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.Max(context, null));
-        Assert.Throws<ExpressionArgumentException>(() => Functions.Max(context, System.Array.Empty<object>()));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Max(context, []));
         Assert.Throws<ExpressionArgumentException>(() => Functions.Max(context, ["one", "two"]));
         Assert.Throws<ExpressionArgumentException>(() => Functions.Max(context, [1, "0"]));
     }
@@ -451,7 +451,7 @@ public sealed class FunctionTests
         Assert.Equal(4, actual6);
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.Min(context, null));
-        Assert.Throws<ExpressionArgumentException>(() => Functions.Min(context, System.Array.Empty<object>()));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Min(context, []));
         Assert.Throws<ExpressionArgumentException>(() => Functions.Min(context, ["one", "two"]));
         Assert.Throws<ExpressionArgumentException>(() => Functions.Min(context, [1, "0"]));
     }
@@ -478,7 +478,7 @@ public sealed class FunctionTests
         Assert.Equal(new string[] { "a", "A" }, actual.Values<string>().ToArray());
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.ObjectKeys(context, null));
-        Assert.Throws<ExpressionArgumentException>(() => Functions.ObjectKeys(context, System.Array.Empty<object>()));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.ObjectKeys(context, []));
         Assert.Throws<ExpressionArgumentException>(() => Functions.ObjectKeys(context, [1]));
     }
 
@@ -557,7 +557,7 @@ public sealed class FunctionTests
         Assert.False(actual.ContainsKey("g"));
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.ShallowMerge(context, null));
-        Assert.Throws<ExpressionArgumentException>(() => Functions.ShallowMerge(context, System.Array.Empty<object>()));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.ShallowMerge(context, []));
         Assert.Throws<ExpressionArgumentException>(() => Functions.ShallowMerge(context, [1]));
     }
 
@@ -678,7 +678,7 @@ public sealed class FunctionTests
         Assert.Equal(2, actual2.Length);
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.Union(context, null));
-        Assert.Throws<ExpressionArgumentException>(() => Functions.Union(context, System.Array.Empty<object>()));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Union(context, []));
         Assert.Throws<ExpressionArgumentException>(() => Functions.Union(context, [1]));
     }
 
@@ -708,7 +708,7 @@ public sealed class FunctionTests
         Assert.Null(Functions.TryGet(context, [testObject, "properties", "notValue", "value"]));
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.TryGet(context, null));
-        Assert.Throws<ExpressionArgumentException>(() => Functions.TryGet(context, System.Array.Empty<object>()));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.TryGet(context, []));
         Assert.Throws<ExpressionArgumentException>(() => Functions.TryGet(context, ["one"]));
     }
 
@@ -1061,11 +1061,11 @@ public sealed class FunctionTests
     {
         var context = GetContext();
 
-        var actual1 = Functions.Environment(context, null) as JObject;
-        Assert.Equal("AzureCloud", actual1["name"]);
-        Assert.Equal("https://graph.windows.net/", actual1["graph"]);
-        Assert.Equal("https://management.azure.com/", actual1["resourceManager"]);
-        Assert.Equal("https://login.microsoftonline.com/", actual1["authentication"]["loginEndpoint"]);
+        var actual = Functions.Environment(context, null) as JObject;
+        Assert.Equal("AzureCloud", actual["name"]);
+        Assert.Equal("https://graph.windows.net/", actual["graph"]);
+        Assert.Equal("https://management.azure.com/", actual["resourceManager"]);
+        Assert.Equal("https://login.microsoftonline.com/", actual["authentication"]["loginEndpoint"]);
     }
 
     [Fact]
@@ -1100,6 +1100,42 @@ public sealed class FunctionTests
         // Parameters object
         var actual2 = Functions.Variables(context, ["test"]) as TestLengthObject;
         Assert.Equal("two", actual2.propB);
+    }
+
+    [Fact]
+    [Trait(TRAIT, TRAIT_DEPLOYMENT)]
+    public void Deployer()
+    {
+        var context = GetContext();
+
+        var actual = Functions.Deployer(context, null) as DeployerOption;
+        Assert.Equal("ffffffff-ffff-ffff-ffff-ffffffffffff", actual.ObjectId);
+        Assert.Equal("ffffffff-ffff-ffff-ffff-ffffffffffff", actual.TenantId);
+
+        context.Deployer.ObjectId = "00000000-0000-0000-0000-000000000000";
+        context.Deployer.TenantId = "00000000-0000-0000-0000-000000000000";
+        actual = Functions.Deployer(context, null) as DeployerOption;
+        Assert.Equal("00000000-0000-0000-0000-000000000000", actual.ObjectId);
+        Assert.Equal("00000000-0000-0000-0000-000000000000", actual.TenantId);
+
+        // Accepts no arguments.
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Deployer(context, [123]));
+    }
+
+    [Fact]
+    [Trait(TRAIT, TRAIT_DEPLOYMENT)]
+    public void Fail()
+    {
+        var context = GetContext();
+
+        // Check for out of range and invalid errors.
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Fail(context, null));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Fail(context, []));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Fail(context, [1, 2]));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Fail(context, [1]));
+
+        // Check for intended failure message.
+        Assert.Throws<DeploymentFailureException>(() => Functions.Fail(context, ["test"]));
     }
 
     #endregion Deployment
@@ -2300,6 +2336,7 @@ public sealed class FunctionTests
             Subscription = SubscriptionOption.Default,
             Tenant = TenantOption.Default,
             ManagementGroup = ManagementGroupOption.Default,
+            Deployer = DeployerOption.Default,
         };
         context.Load(JObject.Parse("{ \"parameters\": { \"name\": { \"value\": \"abcdef\" } } }"));
         return context;
@@ -2313,6 +2350,7 @@ public sealed class FunctionTests
             Subscription = option.Configuration.Subscription,
             Tenant = option.Configuration.Tenant,
             ManagementGroup = option.Configuration.ManagementGroup,
+            Deployer = option.Configuration.Deployer,
         };
         context.Load(JObject.Parse("{ \"parameters\": { \"name\": { \"value\": \"abcdef\" } } }"));
         return context;

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -284,6 +284,9 @@
     <None Update="Tests.Bicep.40.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Tests.Bicep.41.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Bicep\SymbolicNameTestCases\Tests.Bicep.1.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Newtonsoft.Json.Linq;
 using PSRule.Rules.Azure.Configuration;
 using PSRule.Rules.Azure.Data.Template;
+using PSRule.Rules.Azure.Pipeline;
 using static PSRule.Rules.Azure.Data.Template.TemplateVisitor;
 
 namespace PSRule.Rules.Azure
@@ -1301,6 +1302,18 @@ namespace PSRule.Rules.Azure
             Assert.Equal("Microsoft.Sql/servers/databases/transparentDataEncryption", actual["type"].Value<string>());
             Assert.Equal("server01/db02/current", actual["name"].Value<string>());
             Assert.Equal("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/ps-rule-test-rg/providers/Microsoft.Sql/servers/server01/databases/db02", actual["scope"].Value<string>());
+        }
+
+        /// <summary>
+        /// Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/3308
+        /// </summary>
+        [Fact]
+        public void ProcessTemplate_WhenFailCalled_ShouldThrowException()
+        {
+            var ex = Assert.Throws<TemplateReadException>(() => ProcessTemplate(GetSourcePath("Tests.Bicep.41.json"), null, out _));
+
+            Assert.StartsWith("PFA0001:", ex.InnerException.InnerException.InnerException.Message);
+            Assert.EndsWith(" This is a test failure message.", ex.InnerException.InnerException.InnerException.Message);
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.41.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.41.bicep
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/3308
+
+output na string = fail('This is a test failure message.')

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.41.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.41.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.34.44.8038",
+      "templateHash": "11379625219536584542"
+    }
+  },
+  "resources": [],
+  "outputs": {
+    "na": {
+      "type": "string",
+      "value": "[fail('This is a test failure message.')]"
+    }
+  }
+}


### PR DESCRIPTION
## PR Summary

- Added support for `fail` and `deployer` functions during Bicep expansion.

Fixes #3308
Fixes microsoft/PSRule#2840

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
