### PR TITLE
Add buildUri and parseUri function #3345

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.43.0:
+
+- New features:
+  - Added support for the `buildUri` and `parseUri` functions during Bicep expansion by @BernieWhite.
+    [#3345](https://github.com/Azure/PSRule.Rules.Azure/issues/3345)
+
 ## v1.43.0
 
 What's changed since v1.42.0:

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
@@ -349,6 +349,15 @@ namespace PSRule.Rules.Azure.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The required input property &apos;{0}&apos; was not provided for &apos;{1}&apos;..
+        /// </summary>
+        internal static string ObjectPropertyNotProvided {
+            get {
+                return ResourceManager.GetString("ObjectPropertyNotProvided", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The type for output &apos;{0}&apos; was not defined or invalid..
         /// </summary>
         internal static string OutputTypeInvalid {

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
@@ -217,6 +217,9 @@
   <data name="MismatchingResourceSegments" xml:space="preserve">
     <value>The number of resource segments needs to match the provided resource type.</value>
   </data>
+  <data name="ObjectPropertyNotProvided" xml:space="preserve">
+    <value>The required input property '{0}' was not provided for '{1}'.</value>
+  </data>
   <data name="OutputTypeInvalid" xml:space="preserve">
     <value>The type for output '{0}' was not defined or invalid.</value>
   </data>

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -1678,6 +1678,42 @@ public sealed class FunctionTests
 
     [Fact]
     [Trait(TRAIT, TRAIT_STRING)]
+    public void BuildUri()
+    {
+        var context = GetContext();
+
+        var actual = Functions.BuildUri(context, [new JObject
+        {
+            {"scheme", "https" },
+            {"host", "example.com"},
+            {"port", 1234},
+            {"path", "/foo/bar"},
+        }]) as string;
+        Assert.Equal("https://example.com:1234/foo/bar", actual);
+
+        actual = Functions.BuildUri(context, [new JObject
+        {
+            {"scheme", "https" },
+            {"host", "example.com"},
+        }]) as string;
+        Assert.Equal("https://example.com/", actual);
+
+        actual = Functions.BuildUri(context, [new JObject
+        {
+            {"scheme", "https" },
+            {"host", "example.com"},
+            {"path", "/foo/bar"},
+            {"query", "?a=1&b=2"},
+        }]) as string;
+        Assert.Equal("https://example.com/foo/bar?a=1&b=2", actual);
+
+        Assert.Throws<ExpressionArgumentException>(() => Functions.BuildUri(context, null));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.BuildUri(context, []));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.BuildUri(context, [1]));
+    }
+
+    [Fact]
+    [Trait(TRAIT, TRAIT_STRING)]
     public void DataUri()
     {
         var context = GetContext();
@@ -1707,6 +1743,38 @@ public sealed class FunctionTests
         Assert.Throws<ExpressionArgumentException>(() => Functions.DataUriToString(context, System.Array.Empty<object>()));
         Assert.Throws<ArgumentException>(() => Functions.DataUriToString(context, [1]));
         Assert.Throws<ArgumentException>(() => Functions.DataUriToString(context, ["SGVsbG8sIFdvcmxkIQ=="]));
+    }
+
+    [Fact]
+    [Trait(TRAIT, TRAIT_STRING)]
+    public void ParseUri()
+    {
+        var context = GetContext();
+
+        var actual = Functions.ParseUri(context, ["https://example.com:1234/foo/bar"]) as JObject;
+        Assert.Equal("https", actual["scheme"]);
+        Assert.Equal("example.com", actual["host"]);
+        Assert.Equal(1234, actual["port"]);
+        Assert.Equal("/foo/bar", actual["path"]);
+        Assert.False(actual.ContainsKey("query"));
+
+        actual = Functions.ParseUri(context, ["https://example.com/"]) as JObject;
+        Assert.Equal("https", actual["scheme"]);
+        Assert.Equal("example.com", actual["host"]);
+        Assert.Equal(JTokenType.Null, actual["port"].Type);
+        Assert.False(actual.ContainsKey("path"));
+        Assert.False(actual.ContainsKey("query"));
+
+        actual = Functions.ParseUri(context, ["https://example.com/foo/bar?a=1&b=2"]) as JObject;
+        Assert.Equal("https", actual["scheme"]);
+        Assert.Equal("example.com", actual["host"]);
+        Assert.Equal(JTokenType.Null, actual["port"].Type);
+        Assert.Equal("/foo/bar", actual["path"]);
+        Assert.Equal("?a=1&b=2", actual["query"]);
+
+        Assert.Throws<ExpressionArgumentException>(() => Functions.ParseUri(context, null));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.ParseUri(context, []));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.ParseUri(context, [1]));
     }
 
     [Fact]


### PR DESCRIPTION
## PR Summary

- Added support for the `buildUri` and `parseUri` functions during Bicep expansion.

Fixes #3345

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
