### PR TITLE
Fixed Azure.Deployment.SecureParameter with custom types #3347

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,9 @@ What's changed since v1.43.0:
 - New features:
   - Added support for the `buildUri` and `parseUri` functions during Bicep expansion by @BernieWhite.
     [#3345](https://github.com/Azure/PSRule.Rules.Azure/issues/3345)
+- Bug fixes:
+  - Fixed identification of secure parameters with custom type for `Azure.Deployment.SecureParameter` by @BernieWhite.
+    [#3347](https://github.com/Azure/PSRule.Rules.Azure/issues/3347)
 
 ## v1.43.0
 

--- a/docs/en/rules/Azure.Deployment.SecureParameter.md
+++ b/docs/en/rules/Azure.Deployment.SecureParameter.md
@@ -105,6 +105,23 @@ The following business logic is used to determine if a parameter is marked as se
   - The `customermanagedkey` parameter.
   - Parameter names ending in `publickey` or `publickeys`.
 
+### Custom types
+
+When using custom object or array types, only one property of the definition is required to be marked as `secure`.
+For example:
+
+```bicep
+param secrets secretType = []
+
+type secretType object {
+  name string
+  description string
+
+  @secure()
+  value string
+}
+```
+
 ### Rule configuration
 
 <!-- module:config rule AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES -->

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Deployment.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Deployment.Tests.ps1
@@ -143,14 +143,14 @@ Describe 'Azure.Deployment' -Tag 'Deployment' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -BeIn 'nestedDeployment-I';
+            $ruleResult.Length | Should -Be 1;
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 9;
-            $ruleResult.TargetName | Should -BeIn 'nestedDeployment-A', 'nestedDeployment-B', 'nestedDeployment-C', 'nestedDeployment-D', 'nestedDeployment-E', 'nestedDeployment-F', 'nestedDeployment-G', 'nestedDeployment-H', 'nestedDeployment-J';
+            $ruleResult.TargetName | Should -BeIn 'nestedDeployment-A', 'nestedDeployment-B', 'nestedDeployment-C', 'nestedDeployment-D', 'nestedDeployment-E', 'nestedDeployment-F', 'nestedDeployment-G', 'nestedDeployment-H', 'nestedDeployment-J', 'nestedDeployment-K';
+            $ruleResult.Length | Should -Be 10;
         }
     }
 }
@@ -174,14 +174,14 @@ Describe 'Azure.Deployment.AdminUsername' -Tag 'Deployment' {
              # Fail
              $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
              $ruleResult | Should -Not -BeNullOrEmpty;
-             $ruleResult.Length | Should -Be 3;
              $ruleResult.TargetName | Should -BeIn 'nestedDeployment-A', 'nestedDeployment-D', 'nestedDeployment-E';
+             $ruleResult.Length | Should -Be 3;
  
              # Pass
              $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
              $ruleResult | Should -Not -BeNullOrEmpty;
-             $ruleResult.Length | Should -Be 7;
-             $ruleResult.TargetName | Should -BeIn 'nestedDeployment-B', 'nestedDeployment-C', 'nestedDeployment-F', 'nestedDeployment-G', 'nestedDeployment-H', 'nestedDeployment-I', 'nestedDeployment-J';
+             $ruleResult.TargetName | Should -BeIn 'nestedDeployment-B', 'nestedDeployment-C', 'nestedDeployment-F', 'nestedDeployment-G', 'nestedDeployment-H', 'nestedDeployment-I', 'nestedDeployment-J', 'nestedDeployment-K';
+             $ruleResult.Length | Should -Be 8;
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Deployments.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Deployments.json
@@ -324,5 +324,75 @@
       },
       "parameters": {}
     }
+  },
+  {
+    "name": "nestedDeployment-K",
+    "type": "Microsoft.Resources/deployments",
+    "apiVersion": "2020-10-01",
+    "properties": {
+      "expressionEvaluationOptions": {
+        "scope": "inner"
+      },
+      "mode": "Incremental",
+      "template": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "contentVersion": "1.0.0.0",
+        "languageVersion": "2.0",
+        "parameters": {
+          "adminUser": {
+            "type": "string"
+          },
+          "secrets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/secretType"
+            },
+            "nullable": true,
+            "metadata": {
+              "description": "Optional. All secrets to create."
+            }
+          }
+        },
+        "variables": {},
+        "resources": {},
+        "definitions": {
+          "secretType": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "metadata": {
+                  "description": "Required. The name of the secret."
+                }
+              },
+              "value": {
+                "type": "securestring",
+                "metadata": {
+                  "description": "Required. The value of the secret. NOTE: \"value\" will never be returned from the service, as APIs using this model are is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets."
+                }
+              },
+              "roleAssignments": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/roleAssignmentType"
+                },
+                "nullable": true,
+                "metadata": {
+                  "description": "Optional. Array of role assignments to create."
+                }
+              }
+            },
+            "metadata": {
+              "__bicep_export!": true,
+              "description": "The type for a secret output."
+            }
+          }
+        },
+        "roleAssignmentType": {
+          "type": "object"
+        }
+      },
+      "parameters": {}
+    }
   }
 ]


### PR DESCRIPTION
## PR Summary

- Fixed identification of secure parameters with custom type for `Azure.Deployment.SecureParameter`.

Fixes #3347 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section

