### PR TITLE
Updated and promoted GA rules #3386 #3378

### DIFF
--- a/.vscode/markdown.code-snippets
+++ b/.vscode/markdown.code-snippets
@@ -88,6 +88,8 @@
     "body": [
       "### Configure with Azure CLI",
       "",
+      "To address this issue at runtime use the following CLI command:",
+      "",
       "```bash",
       "az ${1:command} -n '<name>' -g '<resource_group>'",
       "```"
@@ -99,6 +101,8 @@
     "description": "Example for Azure PowerShell",
     "body": [
       "### Configure with Azure PowerShell",
+      "",
+      "To address this issue at runtime use the following PowerShell command:",
       "",
       "```powershell",
       "${1:command} -Name '<name>' -ResourceGroupName '<resource_group>'",
@@ -136,7 +140,10 @@
     "body": [
       "### Configure with Azure Policy",
       "",
-      "To address this issue at runtime use the following policies:"
+      "To address this issue at runtime use the following policies:",
+      "",
+      "- [${1:policy}](${2:policy_link})",
+      "  `${4:policy_definition_id}`.",
     ]
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -102,6 +102,7 @@
     "NOTIN",
     "NSGs",
     "NTLM",
+    "overprovision",
     "OWASP",
     "Peerings",
     "POLICYDEFINITIONID",

--- a/data/policy-ignore.json
+++ b/data/policy-ignore.json
@@ -322,5 +322,12 @@
     ],
     "reason": "Duplicate",
     "value": "Azure.AKS.NodeAutoUpgrade"
+  },
+  {
+    "policyDefinitionIds": [
+      "/providers/Microsoft.Authorization/policyDefinitions/7bca8353-aa3b-429b-904a-9229c4385837"
+    ],
+    "reason": "Duplicate",
+    "value": "Azure.VNET.PrivateSubnet"
   }
 ]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,18 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.44.0-B0027:
+
+- Updated rules:
+  - Virtual Network:
+    - Updated documentation and promoted `Azure.VNET.PrivateSubnet` to GA by @BernieWhite.
+      [#3386](https://github.com/Azure/PSRule.Rules.Azure/issues/3386)
+      - Bumped rule set to `2025_06`.
+  - Virtual Machine Scale Sets:
+    - Updated documentation and promoted `Azure.VMSS.AutoInstanceRepairs` to GA by @BernieWhite.
+      [#3378](https://github.com/Azure/PSRule.Rules.Azure/issues/3378)
+      - Bumped rule set to `2025_06`.
+
 ## v1.44.0-B0027 (pre-release)
 
 What's changed since pre-release v1.44.0-B0011:
@@ -71,6 +83,7 @@ What's changed since pre-release v1.44.0-B0011:
     - Updated documentation and promoted `Azure.Log.Replication` to GA by @BernieWhite.
       [#3372](https://github.com/Azure/PSRule.Rules.Azure/issues/3372)
       - This rule was renamed from `Azure.LogAnalytics.Replication` to `Azure.Log.Replication` to drop the legacy name.
+      - Bumped rule set to `2025_06`.
 
 ## v1.44.0-B0011 (pre-release)
 

--- a/docs/en/rules/Azure.VMSS.AutoInstanceRepairs.md
+++ b/docs/en/rules/Azure.VMSS.AutoInstanceRepairs.md
@@ -1,4 +1,5 @@
 ---
+reviewed: 2025-05-30
 severity: Important
 pillar: Reliability
 category: RE:07 Self-preservation
@@ -7,89 +8,253 @@ resourceType: Microsoft.Compute/virtualMachineScaleSets
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VMSS.AutoInstanceRepairs/
 ---
 
-# Automatic instance repairs
+# Virtual Machine Scale Set automatic repair policy is not enabled
 
 ## SYNOPSIS
 
-Automatic instance repairs are enabled.
+Applications or infrastructure relying on a virtual machine scale sets may fail if VM instances are unhealthy.
 
 ## DESCRIPTION
 
-Enabling automatic instance repairs helps to achieve high application availability by automatically detecting and recovering unhealthy VM instances at runtime.
+Virtual Machine Scale Sets (VMSS) provide management and scaling automation for a set of virtual machine (VM) instances.
+One feature of VMSS is the ability to detect and automatically repair unhealthy VM instances.
+When enabled, _automatic instance repairs_ helps achieve reliability by maintaining a set of healthy instances.
+Automatic instance repairs does this by:
 
-The automatic instance repair feature relies on health monitoring of individual VM instances in a scale set.
-VM Instances in a scale set can be configured to emit application health status using either the Application Health extension or Load balancer health probes.
-If an VM instance is found to be unhealthy, the scale set will perform a pre-configured repair action on the unhealthy VM instance.
-Automatic instance repairs can be enabled in the Virtual Machine Scale Set model by using the `automaticRepairsPolicy` object.
+1. Monitoring the health of VM instances.
+2. Performing pre-configured repair action when an unhealthy instance is detected.
 
-See documentation references below for additional limitations and important information.
+To enable automatic instance repairs, you must:
+
+- Configure application health monitoring with either the Application Health extension or Load balancer health probes.
+- Configure the `automaticRepairsPolicy` property in the VMSS resource definition.
+  This policy configuration allows automatic repairs to be enabled, a grace time, and the repair action to be configured.
+
+See documentation references below for additional details.
 
 ## RECOMMENDATION
 
-Consider enabling automatic instance repairs to achieve high application availability by maintaining a set of healthy VM instances.
+Consider enabling automatic instance repair of unhealthy VM instances in a virtual machine scale set.
 
 ## EXAMPLES
-
-### Configure with Azure template
-
-To deploy virtual machine scale sets that pass this rule:
-
-- Set the `properties.automaticRepairsPolicy.enabled` property to `true`.
-
-For example:
-
-```json
-{
-  "type": "Microsoft.Compute/virtualMachineScaleSets",
-  "apiVersion": "2023-09-01",
-  "name": "[parameters('name')]",
-  "location": "[parameters('location')]",
-  "sku": {
-    "name": "b2ms",
-    "tier": "Standard",
-    "capacity": 1
-  },
-  "properties": {
-    "automaticRepairsPolicy": {
-      "enabled": true
-    }
-  }
-}
-```
 
 ### Configure with Bicep
 
 To deploy virtual machine scale sets that pass this rule:
 
 - Set the `properties.automaticRepairsPolicy.enabled` property to `true`.
+- Optionally:
+  - Set the `properties.automaticRepairsPolicy.gracePeriod` property to specify a grace period before repairs are initiated.
+    By default, the grace period is 10 minutes.
+    The grace period should be set to an interval that allows the instance to stabilize after initial deployment.
+  - Set the `properties.automaticRepairsPolicy.repairAction` property to specify the repair action.
+    The default repair action is `Replace`, which deletes and recreates the unhealthy instance with a new one.
+    Other repair actions include `Reimage` and `Restart`.
 
 For example:
 
 ```bicep
-resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2023-09-01' = {
+resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2024-11-01' = {
   name: name
   location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
   sku: {
-    name: 'b2ms'
+    name: 'Standard_D8ds_v6'
     tier: 'Standard'
-    capacity: 1
+    capacity: 3
   }
   properties: {
+    overprovision: true
+    upgradePolicy: {
+      mode: 'Automatic'
+    }
     automaticRepairsPolicy: {
       enabled: true
+      gracePeriod: 'PT10M'
+      repairAction: 'Replace'
+    }
+    singlePlacementGroup: true
+    virtualMachineProfile: {
+      storageProfile: {
+        osDisk: {
+          caching: 'ReadWrite'
+          createOption: 'FromImage'
+        }
+        imageReference: {
+          publisher: 'MicrosoftCblMariner'
+          offer: 'azure-linux-3'
+          sku: 'azure-linux-3-gen2-fips'
+          version: 'latest'
+        }
+      }
+      osProfile: {
+        adminUsername: adminUsername
+        computerNamePrefix: 'vmss-01'
+        linuxConfiguration: {
+          disablePasswordAuthentication: true
+          provisionVMAgent: true
+          ssh: {
+            publicKeys: [
+              {
+                path: '/home/azureuser/.ssh/authorized_keys'
+              }
+            ]
+          }
+        }
+      }
+      networkProfile: {
+        networkInterfaceConfigurations: [
+          {
+            name: 'vmss-001'
+            properties: {
+              primary: true
+              enableAcceleratedNetworking: true
+              ipConfigurations: [
+                {
+                  name: 'ipconfig1'
+                  properties: {
+                    primary: true
+                    subnet: {
+                      id: subnetId
+                    }
+                    privateIPAddressVersion: 'IPv4'
+                    loadBalancerBackendAddressPools: [
+                      {
+                        id: backendPoolId
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
     }
   }
+  zones: [
+    '1'
+    '2'
+    '3'
+  ]
 }
 ```
 
-## NOTES
+<!-- external:avm avm/res/compute/virtual-machine-scale-set automaticRepairsPolicyEnabled -->
 
-This feature for virtual machine scale sets is currently in preview.
+### Configure with Azure template
 
-In order for automatic repairs policy to work properly, ensure that all the requirements for opting in to this feature are met.
+To deploy virtual machine scale sets that pass this rule:
+
+- Set the `properties.automaticRepairsPolicy.enabled` property to `true`.
+- Optionally:
+  - Set the `properties.automaticRepairsPolicy.gracePeriod` property to specify a grace period before repairs are initiated.
+    By default, the grace period is 10 minutes.
+    The grace period should be set to an interval that allows the instance to stabilize after initial deployment.
+  - Set the `properties.automaticRepairsPolicy.repairAction` property to specify the repair action.
+    The default repair action is `Replace`, which deletes and recreates the unhealthy instance with a new one.
+    Other repair actions include `Reimage` and `Restart`.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.Compute/virtualMachineScaleSets",
+  "apiVersion": "2024-11-01",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "identity": {
+    "type": "SystemAssigned"
+  },
+  "sku": {
+    "name": "Standard_D8ds_v6",
+    "tier": "Standard",
+    "capacity": 3
+  },
+  "properties": {
+    "overprovision": true,
+    "upgradePolicy": {
+      "mode": "Automatic"
+    },
+    "automaticRepairsPolicy": {
+      "enabled": true,
+      "gracePeriod": "PT10M",
+      "repairAction": "Replace"
+    },
+    "singlePlacementGroup": true,
+    "virtualMachineProfile": {
+      "storageProfile": {
+        "osDisk": {
+          "caching": "ReadWrite",
+          "createOption": "FromImage"
+        },
+        "imageReference": {
+          "publisher": "MicrosoftCblMariner",
+          "offer": "azure-linux-3",
+          "sku": "azure-linux-3-gen2-fips",
+          "version": "latest"
+        }
+      },
+      "osProfile": {
+        "adminUsername": "[parameters('adminUsername')]",
+        "computerNamePrefix": "vmss-01",
+        "linuxConfiguration": {
+          "disablePasswordAuthentication": true,
+          "provisionVMAgent": true,
+          "ssh": {
+            "publicKeys": [
+              {
+                "path": "/home/azureuser/.ssh/authorized_keys"
+              }
+            ]
+          }
+        }
+      },
+      "networkProfile": {
+        "networkInterfaceConfigurations": [
+          {
+            "name": "vmss-001",
+            "properties": {
+              "primary": true,
+              "enableAcceleratedNetworking": true,
+              "ipConfigurations": [
+                {
+                  "name": "ipconfig1",
+                  "properties": {
+                    "primary": true,
+                    "subnet": {
+                      "id": "[parameters('subnetId')]"
+                    },
+                    "privateIPAddressVersion": "IPv4",
+                    "loadBalancerBackendAddressPools": [
+                      {
+                        "id": "[parameters('backendPoolId')]"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "zones": [
+    "1",
+    "2",
+    "3"
+  ]
+}
+```
 
 ## LINKS
 
 - [RE:07 Self-preservation](https://learn.microsoft.com/azure/well-architected/reliability/self-preservation)
 - [Automatic instance repairs](https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-instance-repairs)
+- [Using Application Health extension with Virtual Machine Scale Sets](https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-health-extension)
+- [Azure Load Balancer health probes](https://learn.microsoft.com/azure/load-balancer/load-balancer-custom-probe-overview)
+- [Configure a Virtual Machine Scale Set with an existing Azure Standard Load Balancer](https://learn.microsoft.com/azure/load-balancer/configure-vm-scale-set-portal)
 - [Azure resource deployment](https://learn.microsoft.com/azure/templates/microsoft.compute/virtualmachinescalesets#automaticrepairspolicy)

--- a/docs/en/rules/Azure.VNET.PrivateSubnet.md
+++ b/docs/en/rules/Azure.VNET.PrivateSubnet.md
@@ -196,6 +196,21 @@ For example:
 }
 ```
 
+### Configure with Azure Policy
+
+To address this issue at runtime use the following policies:
+
+- [Subnets should be private](https://github.com/Azure/azure-policy/blob/master/built-in-policies/policyDefinitions/Network/PrivateSubnetOnly_Audit.json)
+  `/providers/Microsoft.Authorization/policyDefinitions/7bca8353-aa3b-429b-904a-9229c4385837`.
+
+### Configure with Azure CLI
+
+To address this issue at runtime use the following CLI command:
+
+```bash
+az network vnet subnet update -n '<subnet_name>' -g '<resource_group>' --vnet-name '<vnet_name>' --default-outbound false
+```
+
 ## LINKS
 
 - [SE:06 Network controls](https://learn.microsoft.com/azure/well-architected/security/networking)

--- a/docs/en/rules/Azure.VNET.PrivateSubnet.md
+++ b/docs/en/rules/Azure.VNET.PrivateSubnet.md
@@ -1,4 +1,5 @@
 ---
+reviewed: 2025-05-30
 severity: Critical
 pillar: Security
 category: SE:06 Network controls
@@ -7,50 +8,124 @@ resourceType: Microsoft.Network/virtualNetworks,Microsoft.Network/virtualNetwork
 online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.VNET.PrivateSubnet/
 ---
 
-# Disable default outbound access
+# Virtual Network subnet default outbound access is enabled
 
 ## SYNOPSIS
 
-Disable default outbound access for virtual machines.
+Subnets that allow direct outbound access to the Internet may expose virtual machines to increased security risks.
 
 ## DESCRIPTION
 
-Azure virtual network (VNET) subnets support disabling default outbound Internet access.
-By default, virtual machines (VMs) have outbound connectivity to the Internet.
-Default outbound Internet access also applies to virtual machine scale sets (VMSS) configured with the uniform orchestration mode.
+By default, virtual machines (VMs) and virtual machine scale sets (VMSS) configured with the uniform orchestration mode
+have outbound connectivity to the Internet.
+However, the path that network traffic takes is determined by many factors including firewall rules and routing.
 
 When default outbound is enabled traffic to the Internet is automatically routing via a shared NAT pool.
 The IP address used by the shared NAT pool is used across multiple customers, and is subject to change.
 
-Default outbound access for new VMs and VMSS is scheduled for retirement in September 2025.
+As an additional security feature, Azure virtual network (VNET) subnets support disabling the default outbound Internet access.
+Additionally, default outbound access for new VMs and VMSS is scheduled for retirement in September 2025.
 
-Alternatively, outbound access to the Internet can be explicitly configured.
+Instead of using default outbound access, consider using an explicit method of public connectivity for virtual machines.
 Explicit outbound access has the following benefits:
 
-- **Security**: Outbound Internet access can be used to transfer data or control out of your organization.
+- **Security** &mdash; Outbound Internet access can be used to transfer data or control out of your organization.
   Controlling outbound access allows you to make an explicit choice about which workloads require this vs those that don't.
-- **Ownership and stability**: The default outbound access IP is managed by Microsoft and used by multiple customers.
-  As a result, you can't assume use the address for network security rules and the address might change unexpectedly in the future,
-  potentially causing disruptions to any configuration relying on a stable or fixed IP address.
+- **Ownership and stability** &mdash; The default outbound access IP is managed by Microsoft and used by multiple customers.
+  As a result, you can't assume use the address for network security rules and the address might change unexpectedly in
+  the future, potentially causing disruptions to any configuration relying on a stable or fixed IP address.
+  Controlling outbound access allows you to use a stable IP address or group of IP addresses that you manage.
 
 Explicit outbound access can be provided to a specific workload or application by:
 
 - Deploying a NAT gateway into the subnet where the VM or VMSS is deployed.
 - Deploying a Standard load balancer and configuring an outbound SNAT rule.
 
-A public IP address can also be attached to a specific VM instance to provide explicit outbound access.
-However, attaching a public IP address to a VM also allows inbound access from the Internet which further compromises the security of the VM.
+A public IP address can also be attached to a specific VM to provide explicit outbound access.
+However, attaching a public IP address to a VM also allows inbound access from the Internet which further compromises
+the security of the VM.
 
 To provide outbound access to multiple workloads or applications a VWAN or hub and spoke network topology can be deployed.
-See the Azure Cloud Adoption Framework (CAF) for guidance and a reference architecture for deploying network connectivity in Azure.
+See the Azure Cloud Adoption Framework (CAF) for guidance and a reference architecture for deploying network
+connectivity in Azure.
 
 Note that there are limitations to this feature, so please refer to the documentation for detailed information.
 
 ## RECOMMENDATION
 
-Consider using an explicit method of public connectivity for virtual machines.
+Consider disabling default outbound access for all subnets in a virtual network.
+Additionally, consider using an explicit method of connectivity for instances that require outbound access to the Internet.
 
 ## EXAMPLES
+
+### Configure with Bicep
+
+To configure virtual networks that pass this rule:
+
+- For each subnet in defined the `properties.subnets` property:
+  - Set the `properties.defaultOutboundAccess` property to `false`.
+
+For example:
+
+```bicep
+resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' = {
+  name: name
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+    dhcpOptions: {
+      dnsServers: [
+        '10.0.1.4'
+        '10.0.1.5'
+      ]
+    }
+    encryption: {
+      enabled: true
+      enforcement: 'AllowUnencrypted'
+    }
+    subnets: [
+      {
+        name: 'GatewaySubnet'
+        properties: {
+          addressPrefix: '10.0.0.0/24'
+          defaultOutboundAccess: false
+        }
+      }
+      {
+        name: 'snet-001'
+        properties: {
+          addressPrefix: '10.0.1.0/24'
+          defaultOutboundAccess: false
+          networkSecurityGroup: {
+            id: nsgId
+          }
+        }
+      }
+      {
+        name: 'snet-002'
+        properties: {
+          addressPrefix: '10.0.2.0/24'
+          defaultOutboundAccess: false
+          delegations: [
+            {
+              name: 'HSM'
+              properties: {
+                serviceName: 'Microsoft.HardwareSecurityModules/dedicatedHSMs'
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+<!-- external:avm avm/res/network/virtual-network subnets[*].defaultOutboundAccess -->
 
 ### Configure with Azure template
 
@@ -64,7 +139,7 @@ For example:
 ```json
 {
   "type": "Microsoft.Network/virtualNetworks",
-  "apiVersion": "2023-11-01",
+  "apiVersion": "2024-05-01",
   "name": "[parameters('name')]",
   "location": "[parameters('location')]",
   "properties": {
@@ -73,73 +148,59 @@ For example:
         "10.0.0.0/16"
       ]
     },
+    "dhcpOptions": {
+      "dnsServers": [
+        "10.0.1.4",
+        "10.0.1.5"
+      ]
+    },
+    "encryption": {
+      "enabled": true,
+      "enforcement": "AllowUnencrypted"
+    },
     "subnets": [
       {
-        "name": "subnet-A",
+        "name": "GatewaySubnet",
         "properties": {
-          "addressPrefix": "10.0.0.0/27",
+          "addressPrefix": "10.0.0.0/24",
           "defaultOutboundAccess": false
         }
       },
       {
-        "name": "subnet-B",
+        "name": "snet-001",
         "properties": {
-          "addressPrefix": "10.0.0.32/27",
-          "defaultOutboundAccess": false
+          "addressPrefix": "10.0.1.0/24",
+          "defaultOutboundAccess": false,
+          "networkSecurityGroup": {
+            "id": "[parameters('nsgId')]"
+          }
+        }
+      },
+      {
+        "name": "snet-002",
+        "properties": {
+          "addressPrefix": "10.0.2.0/24",
+          "defaultOutboundAccess": false,
+          "delegations": [
+            {
+              "name": "HSM",
+              "properties": {
+                "serviceName": "Microsoft.HardwareSecurityModules/dedicatedHSMs"
+              }
+            }
+          ]
         }
       }
     ]
   }
 }
 ```
-
-### Configure with Bicep
-
-To configure virtual networks that pass this rule:
-
-- For each subnet in defined the `properties.subnets` property:
-  - Set the `properties.defaultOutboundAccess` property to `false`.
-
-For example:
-
-```bicep
-resource vnet 'Microsoft.Network/virtualNetworks@2023-11-01' = {
-  name: name
-  location: location
-  properties: {
-    addressSpace: {
-      addressPrefixes: [
-        '10.0.0.0/16'
-      ]
-    }
-    subnets: [
-      {
-        name: 'subnet-A'
-        properties: {
-          addressPrefix: '10.0.0.0/27'
-          defaultOutboundAccess: false
-        }
-      }
-      {
-        name: 'subnet-B'
-        properties: {
-          addressPrefix: '10.0.0.32/27'
-          defaultOutboundAccess: false
-        }
-      }
-    ]
-  }
-}
-```
-
-## NOTES
-
-This feature is currently in preview.
 
 ## LINKS
 
 - [SE:06 Network controls](https://learn.microsoft.com/azure/well-architected/security/networking)
 - [Default outbound access](https://learn.microsoft.com/azure/virtual-network/ip-services/default-outbound-access)
 - [Plan for inbound and outbound internet connectivity](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/plan-for-inbound-and-outbound-internet-connectivity)
+- [What is Azure NAT Gateway?](https://learn.microsoft.com/azure/nat-gateway/nat-overview)
 - [Azure deployment reference - Virtual Network](https://learn.microsoft.com/azure/templates/microsoft.network/virtualnetworks)
 - [Azure deployment reference - Subnet](https://learn.microsoft.com/azure/templates/microsoft.network/virtualnetworks/subnets)

--- a/docs/examples/resources/vmss.bicep
+++ b/docs/examples/resources/vmss.bicep
@@ -18,14 +18,15 @@ param backendPoolId string
 @description('The admin username used for each VM instance.')
 param adminUsername string
 
-resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2024-07-01' = {
+// An example of a simple Linux VMSS with a system-assigned managed identity.
+resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2024-11-01' = {
   name: name
   location: location
   identity: {
     type: 'SystemAssigned'
   }
   sku: {
-    name: 'Standard_D8d_v5'
+    name: 'Standard_D8ds_v6'
     tier: 'Standard'
     capacity: 3
   }
@@ -33,6 +34,11 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2024-07-01' = {
     overprovision: true
     upgradePolicy: {
       mode: 'Automatic'
+    }
+    automaticRepairsPolicy: {
+      enabled: true
+      gracePeriod: 'PT10M'
+      repairAction: 'Replace'
     }
     singlePlacementGroup: true
     virtualMachineProfile: {
@@ -43,8 +49,8 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2024-07-01' = {
         }
         imageReference: {
           publisher: 'MicrosoftCblMariner'
-          offer: 'Cbl-Mariner'
-          sku: 'cbl-mariner-2-gen2'
+          offer: 'azure-linux-3'
+          sku: 'azure-linux-3-gen2-fips'
           version: 'latest'
         }
       }

--- a/docs/examples/resources/vmss.json
+++ b/docs/examples/resources/vmss.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.31.92.45157",
-      "templateHash": "18183969840754772084"
+      "version": "0.35.1.17967",
+      "templateHash": "1355273047342894691"
     }
   },
   "parameters": {
@@ -44,14 +44,14 @@
   "resources": [
     {
       "type": "Microsoft.Compute/virtualMachineScaleSets",
-      "apiVersion": "2024-07-01",
+      "apiVersion": "2024-11-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "identity": {
         "type": "SystemAssigned"
       },
       "sku": {
-        "name": "Standard_D8d_v5",
+        "name": "Standard_D8ds_v6",
         "tier": "Standard",
         "capacity": 3
       },
@@ -59,6 +59,11 @@
         "overprovision": true,
         "upgradePolicy": {
           "mode": "Automatic"
+        },
+        "automaticRepairsPolicy": {
+          "enabled": true,
+          "gracePeriod": "PT10M",
+          "repairAction": "Replace"
         },
         "singlePlacementGroup": true,
         "virtualMachineProfile": {
@@ -69,8 +74,8 @@
             },
             "imageReference": {
               "publisher": "MicrosoftCblMariner",
-              "offer": "Cbl-Mariner",
-              "sku": "cbl-mariner-2-gen2",
+              "offer": "azure-linux-3",
+              "sku": "azure-linux-3-gen2-fips",
               "version": "latest"
             }
           },

--- a/docs/examples/resources/vnet.bicep
+++ b/docs/examples/resources/vnet.bicep
@@ -30,17 +30,23 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' = {
         '10.0.1.5'
       ]
     }
+    encryption: {
+      enabled: true
+      enforcement: 'AllowUnencrypted'
+    }
     subnets: [
       {
         name: 'GatewaySubnet'
         properties: {
           addressPrefix: '10.0.0.0/24'
+          defaultOutboundAccess: false
         }
       }
       {
         name: 'snet-001'
         properties: {
           addressPrefix: '10.0.1.0/24'
+          defaultOutboundAccess: false
           networkSecurityGroup: {
             id: nsgId
           }
@@ -50,6 +56,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' = {
         name: 'snet-002'
         properties: {
           addressPrefix: '10.0.2.0/24'
+          defaultOutboundAccess: false
           delegations: [
             {
               name: 'HSM'
@@ -107,23 +114,30 @@ resource spoke 'Microsoft.Network/virtualNetworks@2024-05-01' = {
         '10.0.1.5'
       ]
     }
+    encryption: {
+      enabled: true
+      enforcement: 'AllowUnencrypted'
+    }
     subnets: [
       {
         name: 'GatewaySubnet'
         properties: {
           addressPrefix: '10.0.0.0/27'
+          defaultOutboundAccess: false
         }
       }
       {
         name: 'AzureFirewallSubnet'
         properties: {
           addressPrefix: '10.0.1.0/26'
+          defaultOutboundAccess: false
         }
       }
       {
         name: 'AzureBastionSubnet'
         properties: {
           addressPrefix: '10.0.1.64/26'
+          defaultOutboundAccess: false
         }
       }
     ]

--- a/docs/examples/resources/vnet.json
+++ b/docs/examples/resources/vnet.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "487876098704704279"
+      "version": "0.35.1.17967",
+      "templateHash": "974394744934068093"
     }
   },
   "parameters": {
@@ -49,17 +49,23 @@
             "10.0.1.5"
           ]
         },
+        "encryption": {
+          "enabled": true,
+          "enforcement": "AllowUnencrypted"
+        },
         "subnets": [
           {
             "name": "GatewaySubnet",
             "properties": {
-              "addressPrefix": "10.0.0.0/24"
+              "addressPrefix": "10.0.0.0/24",
+              "defaultOutboundAccess": false
             }
           },
           {
             "name": "snet-001",
             "properties": {
               "addressPrefix": "10.0.1.0/24",
+              "defaultOutboundAccess": false,
               "networkSecurityGroup": {
                 "id": "[parameters('nsgId')]"
               }
@@ -69,6 +75,7 @@
             "name": "snet-002",
             "properties": {
               "addressPrefix": "10.0.2.0/24",
+              "defaultOutboundAccess": false,
               "delegations": [
                 {
                   "name": "HSM",
@@ -126,23 +133,30 @@
             "10.0.1.5"
           ]
         },
+        "encryption": {
+          "enabled": true,
+          "enforcement": "AllowUnencrypted"
+        },
         "subnets": [
           {
             "name": "GatewaySubnet",
             "properties": {
-              "addressPrefix": "10.0.0.0/27"
+              "addressPrefix": "10.0.0.0/27",
+              "defaultOutboundAccess": false
             }
           },
           {
             "name": "AzureFirewallSubnet",
             "properties": {
-              "addressPrefix": "10.0.1.0/26"
+              "addressPrefix": "10.0.1.0/26",
+              "defaultOutboundAccess": false
             }
           },
           {
             "name": "AzureBastionSubnet",
             "properties": {
-              "addressPrefix": "10.0.1.64/26"
+              "addressPrefix": "10.0.1.64/26",
+              "defaultOutboundAccess": false
             }
           }
         ]

--- a/src/PSRule.Rules.Azure/rules/Azure.VMSS.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.VMSS.Rule.yaml
@@ -8,15 +8,15 @@
 #region Rules
 
 ---
-# Synopsis: Automatic instance repairs are enabled.
+# Synopsis: Application or infrastructure relying on a virtual machine scale sets may fail if VM instances are unhealthy.
 apiVersion: github.com/microsoft/PSRule/v1
 kind: Rule
 metadata:
   name: Azure.VMSS.AutoInstanceRepairs
   ref: AZR-000426
   tags:
-    release: preview
-    ruleSet: 2024_06
+    release: GA
+    ruleSet: 2025_06
     Azure.WAF/pillar: Reliability
 spec:
   type:

--- a/src/PSRule.Rules.Azure/rules/Azure.VNET.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VNET.Rule.ps1
@@ -141,7 +141,7 @@ Rule 'Azure.VNET.FirewallSubnetNAT' -Ref 'AZR-000448' -Level 'Warning' -Type 'Mi
 }
 
 # Synopsis: Disable default outbound access for virtual machines.
-Rule 'Azure.VNET.PrivateSubnet' -Ref 'AZR-000447' -Type 'Microsoft.Network/virtualNetworks', 'Microsoft.Network/virtualNetworks/subnets' -Tag @{ release = 'preview'; ruleSet = '2024_09'; 'Azure.WAF/pillar' = 'Security'; } {
+Rule 'Azure.VNET.PrivateSubnet' -Ref 'AZR-000447' -Type 'Microsoft.Network/virtualNetworks', 'Microsoft.Network/virtualNetworks/subnets' -Tag @{ release = 'GA'; ruleSet = '2025_06'; 'Azure.WAF/pillar' = 'Security'; } {
     $excludedSubnets = @('GatewaySubnet', 'AzureFirewallSubnet', 'AzureFirewallManagementSubnet', 'AzureBastionSubnet')
     if ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks') {
         $subnets = @(

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
@@ -255,7 +255,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2024_06' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 9;
+            $filteredResult.Length | Should -Be 8;
         }
 
         It 'With Azure.GA_2024_09' {
@@ -269,7 +269,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2024_09' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 11;
+            $filteredResult.Length | Should -Be 9;
         }
 
         It 'With Azure.GA_2024_12' {
@@ -283,7 +283,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2024_12' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 11;
+            $filteredResult.Length | Should -Be 9;
         }
 
         It 'With Azure.GA_2025_03' {
@@ -297,7 +297,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2025_03' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 11;
+            $filteredResult.Length | Should -Be 9;
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Updated rules:
  - Virtual Network:
    - Updated documentation and promoted `Azure.VNET.PrivateSubnet` to GA.
      - Bumped rule set to `2025_06`.
  - Virtual Machine Scale Sets:
    - Updated documentation and promoted `Azure.VMSS.AutoInstanceRepairs` to GA.
      - Bumped rule set to `2025_06`.

Fixes #3386
Fixes #3378

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section

