### PR TITLE
Fix expansion issues #3393 #3394

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,6 +50,11 @@ What's changed since pre-release v1.44.0-B0027:
     - Updated documentation and promoted `Azure.VMSS.AutoInstanceRepairs` to GA by @BernieWhite.
       [#3378](https://github.com/Azure/PSRule.Rules.Azure/issues/3378)
       - Bumped rule set to `2025_06`.
+- Bug fixes:
+  - Fixed not implemented exception for deployment name in lambda expression by @BernieWhite.
+    [#3393](https://github.com/Azure/PSRule.Rules.Azure/issues/3393)
+  - Fixed incorrect parsing of double quoted string during expansion by @BernieWhite.
+    [#3394](https://github.com/Azure/PSRule.Rules.Azure/issues/3394)
 
 ## v1.44.0-B0027 (pre-release)
 

--- a/src/PSRule.Rules.Azure/Arm/Expressions/ExpressionStream.cs
+++ b/src/PSRule.Rules.Azure/Arm/Expressions/ExpressionStream.cs
@@ -131,6 +131,9 @@ internal sealed class ExpressionStream
 
         var start = Position;
         var length = 0;
+
+        SkipQuotePairs(ref length);
+
         while (!EOF)
         {
             if (!IsEscaped && Apostrophe == Current)

--- a/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
+++ b/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
@@ -2137,18 +2137,22 @@ internal static class Functions
     /// </remarks>
     internal static object Map(ITemplateContext context, object[] args)
     {
-        if (CountArgs(args) != 2)
-            throw ArgumentsOutOfRange(nameof(Map), args);
+        if (CountArgs(args) != 2) throw ArgumentsOutOfRange(nameof(Map), args);
 
         args[0] = GetExpression(context, args[0]);
-        if (!ExpressionHelpers.TryArray(args[0], out var inputArray))
-            throw ArgumentFormatInvalid(nameof(Map));
+        if (!ExpressionHelpers.TryArray(args[0], out var inputArray)) throw ArgumentFormatInvalid(nameof(Map));
 
         args[1] = GetExpression(context, args[1]);
-        if (args[1] is not LambdaExpressionFn lambda)
-            throw ArgumentFormatInvalid(nameof(Map));
+        if (args[1] is not LambdaExpressionFn lambda) throw ArgumentFormatInvalid(nameof(Map));
 
-        return lambda.Map(context, inputArray.OfType<object>().ToArray());
+        try
+        {
+            return lambda.Map(context, [.. inputArray.OfType<object>()]);
+        }
+        catch
+        {
+            throw;
+        }
     }
 
     /// <summary>
@@ -2207,8 +2211,7 @@ internal static class Functions
     internal static object ToObject(ITemplateContext context, object[] args)
     {
         var count = CountArgs(args);
-        if (count is < 2 or > 3)
-            throw ArgumentsOutOfRange(nameof(ToObject), args);
+        if (count is < 2 or > 3) throw ArgumentsOutOfRange(nameof(ToObject), args);
 
         args[0] = GetExpression(context, args[0]);
         if (!ExpressionHelpers.TryArray(args[0], out var inputArray))

--- a/src/PSRule.Rules.Azure/Data/Template/NestedTemplateContext.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/NestedTemplateContext.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using PSRule.Rules.Azure.Arm;
 using PSRule.Rules.Azure.Arm.Deployments;
 using PSRule.Rules.Azure.Arm.Expressions;
@@ -18,7 +17,7 @@ internal abstract class NestedTemplateContext(ITemplateContext context) : Resour
 
     public CopyIndexStore CopyIndex => _Inner.CopyIndex;
 
-    public DeploymentValue Deployment => throw new NotImplementedException();
+    public DeploymentValue Deployment => _Inner.Deployment;
 
     public string ScopeId => _Inner.ScopeId;
 

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/ExpressionParserTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/ExpressionParserTests.cs
@@ -216,4 +216,46 @@ public sealed class ExpressionParserTests
         Assert.Equal(ExpressionTokenType.GroupEnd, actual[10].Type);
         Assert.Equal(ExpressionTokenType.GroupEnd, actual[11].Type);
     }
+
+    [Fact]
+    public void ParseQuotingDoubles()
+    {
+        var expression = "[format('''{0}''', replace(replace(join(parameters('principalTypes'), ','), '\\\"', ''''), ',', ''','''))]";
+        var actual = ExpressionParser.Parse(expression).ToArray();
+
+        Assert.Equal(ExpressionTokenType.Element, actual[0].Type); // format
+        Assert.Equal("format", actual[0].Content);
+        Assert.Equal(ExpressionTokenType.GroupStart, actual[1].Type);
+        Assert.Equal(ExpressionTokenType.String, actual[2].Type); // '''{0}'''
+        Assert.Equal("'{0}'", actual[2].Content);
+        Assert.Equal(ExpressionTokenType.Element, actual[3].Type); // replace
+        Assert.Equal("replace", actual[3].Content);
+        Assert.Equal(ExpressionTokenType.GroupStart, actual[4].Type);
+        Assert.Equal(ExpressionTokenType.Element, actual[5].Type); // replace
+        Assert.Equal("replace", actual[5].Content);
+        Assert.Equal(ExpressionTokenType.GroupStart, actual[6].Type);
+        Assert.Equal(ExpressionTokenType.Element, actual[7].Type); // join
+        Assert.Equal("join", actual[7].Content);
+        Assert.Equal(ExpressionTokenType.GroupStart, actual[8].Type);
+        Assert.Equal(ExpressionTokenType.Element, actual[9].Type); // parameters
+        Assert.Equal("parameters", actual[9].Content);
+        Assert.Equal(ExpressionTokenType.GroupStart, actual[10].Type);
+        Assert.Equal(ExpressionTokenType.String, actual[11].Type); // 'principalTypes'
+        Assert.Equal("principalTypes", actual[11].Content);
+        Assert.Equal(ExpressionTokenType.GroupEnd, actual[12].Type);
+        Assert.Equal(ExpressionTokenType.String, actual[13].Type); // ','
+        Assert.Equal(",", actual[13].Content);
+        Assert.Equal(ExpressionTokenType.GroupEnd, actual[14].Type);
+        Assert.Equal(ExpressionTokenType.String, actual[15].Type); // '\"'
+        Assert.Equal("\\\"", actual[15].Content);
+        Assert.Equal(ExpressionTokenType.String, actual[16].Type); // ''''
+        Assert.Equal("'", actual[16].Content);
+        Assert.Equal(ExpressionTokenType.GroupEnd, actual[17].Type);
+        Assert.Equal(ExpressionTokenType.String, actual[18].Type); // ','
+        Assert.Equal(",", actual[18].Content);
+        Assert.Equal(ExpressionTokenType.String, actual[19].Type); // ''','''
+        Assert.Equal("','", actual[19].Content);
+        Assert.Equal(ExpressionTokenType.GroupEnd, actual[20].Type);
+        Assert.Equal(ExpressionTokenType.GroupEnd, actual[21].Type);
+    }
 }


### PR DESCRIPTION
## PR Summary

- Fixed not implemented exception for deployment name in lambda expression.
- Fixed incorrect parsing of double quoted string during expansion.

Fixes #3393 
Fixes #3394 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
