### PR TITLE
Fixes function `tryIndexFromEnd` was not found #3409

### DIFF
--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -1,5 +1,6 @@
 {
   "experimentalFeaturesEnabled": {
-    "optionalModuleNames": true
+    "optionalModuleNames": true,
+    "typedVariables": true
   }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.44.0:
+
+- Bug fixes:
+  - Fixes the function `tryIndexFromEnd` was not found by @BernieWhite.
+    [#3409](https://github.com/Azure/PSRule.Rules.Azure/issues/3409)
+
 ## v1.44.0
 
 What's changed since v1.43.0:

--- a/src/PSRule.Rules.Azure/Arm/Expressions/ExpressionHelpers.cs
+++ b/src/PSRule.Rules.Azure/Arm/Expressions/ExpressionHelpers.cs
@@ -162,7 +162,7 @@ internal static class ExpressionHelpers
     internal static bool TryIndex(object o, object index, out object value)
     {
         value = null;
-        if (o == null) return false;
+        if (IsNull(o)) return false;
 
         if (o is IMock mock)
         {
@@ -192,6 +192,23 @@ internal static class ExpressionHelpers
             return true;
 
         return TryString(index, out propertyName) && TryPropertyOrField(o, propertyName, out value);
+    }
+
+    internal static bool TryIndexFromEnd(object o, long index, out object value)
+    {
+        value = null;
+        if (IsNull(o)) return false;
+
+        if (TryArray(o, out var array))
+        {
+            if (index < 1 || index > array.Length)
+                return false;
+
+            value = array.GetValue(array.Length - index);
+            return true;
+        }
+
+        return false;
     }
 
     internal static bool TryPropertyOrField(object o, string propertyName, out object value)

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
@@ -160,6 +160,15 @@ namespace PSRule.Rules.Azure.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The index &apos;{0}&apos; for &apos;{1}&apos; is not in range of the array..
+        /// </summary>
+        internal static string ArrayIndexNotInRange {
+            get {
+                return ResourceManager.GetString("ArrayIndexNotInRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to expand the specified assignment file &apos;{0}&apos;. {1}.
         /// </summary>
         internal static string AssignmentFileExpandFailed {

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
@@ -150,6 +150,9 @@
   <data name="ArgumentsOutOfRange" xml:space="preserve">
     <value>The number of arguments '{1}' is not within the allowed range for '{0}'.</value>
   </data>
+  <data name="ArrayIndexNotInRange" xml:space="preserve">
+    <value>The index '{0}' for '{1}' is not in range of the array.</value>
+  </data>
   <data name="AssignmentFileExpandFailed" xml:space="preserve">
     <value>Unable to expand the specified assignment file '{0}'. {1}</value>
   </data>

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
@@ -711,9 +711,71 @@ public sealed class FunctionTests
         Assert.Null(Functions.TryGet(context, [testObject, "properties", "notValue"]));
         Assert.Null(Functions.TryGet(context, [testObject, "properties", "notValue", "value"]));
 
+        var testObject2 = new JArray
+        {
+            "one",
+            "two",
+        };
+
+        Assert.Equal("two", (Functions.TryGet(context, [testObject2, 1]) as JValue).Value<string>());
+
         Assert.Throws<ExpressionArgumentException>(() => Functions.TryGet(context, null));
         Assert.Throws<ExpressionArgumentException>(() => Functions.TryGet(context, []));
         Assert.Throws<ExpressionArgumentException>(() => Functions.TryGet(context, ["one"]));
+    }
+
+    [Fact]
+    [Trait(TRAIT, TRAIT_ARRAY)]
+    public void TryIndexFromEnd()
+    {
+        var context = GetContext();
+        var testArray = new JArray("one", "two", "three");
+
+        // Valid index from end
+        Assert.Equal("three", (Functions.TryIndexFromEnd(context, [testArray, 1]) as JValue).Value<string>());
+        Assert.Equal("two", (Functions.TryIndexFromEnd(context, [testArray, 2]) as JValue).Value<string>());
+        Assert.Equal("one", (Functions.TryIndexFromEnd(context, [testArray, 3]) as JValue).Value<string>());
+
+        Assert.Equal("three", Functions.TryIndexFromEnd(context, [new string[] { "one", "two", "three" }, 1]) as string);
+        Assert.Equal("two", Functions.TryIndexFromEnd(context, [new string[] { "one", "two", "three" }, 2]) as string);
+        Assert.Equal("one", Functions.TryIndexFromEnd(context, [new string[] { "one", "two", "three" }, 3]) as string);
+
+        // Invalid index from end
+        Assert.Null(Functions.TryIndexFromEnd(context, [testArray, 4]));
+        Assert.Null(Functions.TryIndexFromEnd(context, [testArray, -1]));
+        Assert.Null(Functions.TryIndexFromEnd(context, [testArray, "2"]));
+
+        // Invalid input
+        Assert.Null(Functions.TryIndexFromEnd(context, [null, 1]));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.TryIndexFromEnd(context, []));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.TryIndexFromEnd(context, ["one"]));
+    }
+
+    [Fact]
+    [Trait(TRAIT, TRAIT_ARRAY)]
+    public void IndexFromEnd()
+    {
+        var context = GetContext();
+        var testArray = new JArray("one", "two", "three");
+
+        // Valid index from end
+        Assert.Equal("three", (Functions.IndexFromEnd(context, [testArray, 1]) as JValue).Value<string>());
+        Assert.Equal("two", (Functions.IndexFromEnd(context, [testArray, 2]) as JValue).Value<string>());
+        Assert.Equal("one", (Functions.IndexFromEnd(context, [testArray, 3]) as JValue).Value<string>());
+
+        Assert.Equal("three", Functions.IndexFromEnd(context, [new string[] { "one", "two", "three" }, 1]) as string);
+        Assert.Equal("two", Functions.IndexFromEnd(context, [new string[] { "one", "two", "three" }, 2]) as string);
+        Assert.Equal("one", Functions.IndexFromEnd(context, [new string[] { "one", "two", "three" }, 3]) as string);
+
+        // Invalid index from end
+        Assert.Throws<ExpressionArgumentException>(() => Functions.IndexFromEnd(context, [testArray, 4]));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.IndexFromEnd(context, [testArray, -1]));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.IndexFromEnd(context, [testArray, "2"]));
+
+        // Invalid input
+        Assert.Throws<ExpressionArgumentException>(() => Functions.IndexFromEnd(context, [null, 1]));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.IndexFromEnd(context, []));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.IndexFromEnd(context, ["one"]));
     }
 
     #endregion Array and object

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -287,6 +287,9 @@
     <None Update="Tests.Bicep.41.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Tests.Bicep.42.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Bicep\SymbolicNameTestCases\Tests.Bicep.1.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -1315,4 +1315,29 @@ public sealed class TemplateVisitorTests : TemplateVisitorTestsBase
         Assert.StartsWith("PFA0001:", ex.InnerException.InnerException.InnerException.Message);
         Assert.EndsWith(" This is a test failure message.", ex.InnerException.InnerException.InnerException.Message);
     }
+
+    /// <summary>
+    /// Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/3409
+    /// </summary>
+    [Fact]
+    public void ProcessTemplate_WhenNullableIndexFromEnd_ShouldReturnExpectedValue()
+    {
+        _ = ProcessTemplate(GetSourcePath("Tests.Bicep.42.json"), null, out var templateContext);
+
+        Assert.True(templateContext.RootDeployment.TryOutput("firstPartOutput", out JObject firstPartOutput));
+        var firstPart = firstPartOutput["value"].Value<string>();
+        Assert.Equal("sub", firstPart);
+
+        Assert.True(templateContext.RootDeployment.TryOutput("secondPartOutput", out JObject secondPartOutput));
+        var secondPart = secondPartOutput["value"].Value<string>();
+        Assert.Equal("topic", secondPart);
+
+        Assert.True(templateContext.RootDeployment.TryOutput("lastPartOutput", out JObject lastPartOutput));
+        var lastPart = lastPartOutput["value"].Value<string>();
+        Assert.Equal("001", lastPart);
+
+        Assert.True(templateContext.RootDeployment.TryOutput("secondLastPartOutput", out JObject secondLastPartOutput));
+        var secondLastPart = secondLastPartOutput["value"].Value<string>();
+        Assert.Equal("eastus", secondLastPart);
+    }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.42.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.42.bicep
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Test case for https://github.com/Azure/PSRule.Rules.Azure/issues/3409
+
+var subscriptionName string = 'sub-topic-eastus-001'
+var firstPart string = split(subscriptionName, '-')[0]
+var secondPart string = split(subscriptionName, '-')[?1]
+var lastPart string = split(subscriptionName, '-')[^1]
+var secondLastPart string = split(subscriptionName, '-')[?^2]
+
+output firstPartOutput string = firstPart
+output secondPartOutput string = secondPart
+output lastPartOutput string = lastPart
+output secondLastPartOutput string = secondLastPart

--- a/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.42.json
+++ b/tests/PSRule.Rules.Azure.Tests/Tests.Bicep.42.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.36.1.42791",
+      "templateHash": "4431975804949625930"
+    }
+  },
+  "variables": {
+    "subscriptionName": "sub-topic-eastus-001",
+    "firstPart": "[split(variables('subscriptionName'), '-')[0]]",
+    "secondPart": "[tryGet(split(variables('subscriptionName'), '-'), 1)]",
+    "lastPart": "[indexFromEnd(split(variables('subscriptionName'), '-'), 1)]",
+    "secondLastPart": "[tryIndexFromEnd(split(variables('subscriptionName'), '-'), 2)]"
+  },
+  "resources": {},
+  "outputs": {
+    "firstPartOutput": {
+      "type": "string",
+      "value": "[variables('firstPart')]"
+    },
+    "secondPartOutput": {
+      "type": "string",
+      "value": "[variables('secondPart')]"
+    },
+    "lastPartOutput": {
+      "type": "string",
+      "value": "[variables('lastPart')]"
+    },
+    "secondLastPartOutput": {
+      "type": "string",
+      "value": "[variables('secondLastPart')]"
+    }
+  }
+}


### PR DESCRIPTION
## PR Summary

- Fixes the function `tryIndexFromEnd` was not found.

Fixes #3409

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
