### PR TITLE
Fixes Azure.APIM.PolicyBase reasons #3413

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,8 @@ What's changed since v1.44.0:
 - Bug fixes:
   - Fixes the function `tryIndexFromEnd` was not found by @BernieWhite.
     [#3409](https://github.com/Azure/PSRule.Rules.Azure/issues/3409)
+  - Fixes `Azure.APIM.PolicyBase` to provide detailed output when policy sections are missing by @BernieWhite.
+    [#3413](https://github.com/Azure/PSRule.Rules.Azure/issues/3413)
 
 ## v1.44.0
 

--- a/docs/en/rules/Azure.APIM.PolicyBase.md
+++ b/docs/en/rules/Azure.APIM.PolicyBase.md
@@ -1,4 +1,5 @@
 ---
+reviewed: 2025-06-19
 severity: Important
 pillar: Security
 category: Design
@@ -30,15 +31,72 @@ The _Global_ scope does not need the _base_ element because this is the peak sco
 
 ## RECOMMENDATION
 
-Consider configuring the base element for any policy element in a section.
+Consider configuring the base element for each policy section.
 
 ## EXAMPLES
+
+### Configure with Bicep
+
+To deploy API Management policies that pass this rule:
+
+- Configure an policy sub-resource.
+- Define each of the policy sections in the policy XML: `inbound`, `backend`, `outbound`, and `on-error`.
+- Configure the base element before or after any policy element in a section in `properties.value` property.
+
+For example an API policy:
+
+```bicep
+resource apiName_policy 'Microsoft.ApiManagement/service/apis/policies@2021-08-01' = {
+  parent: api
+  name: 'policy'
+  properties: {
+    value: '<policies><inbound><base /><ip-filter action=\"allow\"><address-range from=\"10.1.0.1\" to=\"10.1.0.255\" /></ip-filter></inbound><backend><base /></backend><outbound><base /></outbound><on-error><base /></on-error></policies>'
+    format: 'xml'
+  }
+}
+```
+
+Additionally you can import this from a file using the `loadTextContent` Bicep function:
+
+```bicep
+resource apiName_policy 'Microsoft.ApiManagement/service/apis/policies@2021-08-01' = {
+  parent: api
+  name: 'policy'
+  properties: {
+    value: loadTextContent('./policy.xml')
+    format: 'xml'
+  }
+}
+```
+
+Where `policy.xml` contains the policy XML:
+
+```xml
+<policies>
+  <inbound>
+    <base />
+    <ip-filter action="allow">
+      <address-range from="10.1.0.1" to="10.1.0.255" />
+    </ip-filter>
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>
+```
 
 ### Configure with Azure template
 
 To deploy API Management policies that pass this rule:
 
 - Configure an policy sub-resource.
+- Define each of the policy sections in the policy XML: `inbound`, `backend`, `outbound`, and `on-error`.
 - Configure the base element before or after any policy element in a section in `properties.value` property.
 
 For example an API policy:
@@ -58,30 +116,13 @@ For example an API policy:
 }
 ```
 
-### Configure with Bicep
-
-To deploy API Management policies that pass this rule:
-
-- Configure an policy sub-resource.
-- Configure the base element before or after any policy element in a section in `properties.value` property.
-
-For example an API policy:
-
-```bicep
-resource apiName_policy 'Microsoft.ApiManagement/service/apis/policies@2021-08-01' = {
-  parent: api
-  name: 'policy'
-  properties: {
-    value: '<policies><inbound><base /><ip-filter action=\"allow\"><address-range from=\"10.1.0.1\" to=\"10.1.0.255\" /></ip-filter></inbound><backend><base /></backend><outbound><base /></outbound><on-error><base /></on-error></policies>'
-    format: 'xml'
-  }
-}
-```
-
 ## NOTES
 
 The rule only checks against `rawxml` and `xml` policy formatted content.
 Global policies are excluded since they don't benefit from the base element.
+
+This rule will fail if the policy XML does not contain all sections.
+Check that `inbound`, `backend`, `outbound`, and `on-error` are all present.
 
 ## LINKS
 

--- a/src/PSRule.Rules.Azure/rules/Azure.APIM.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.APIM.Rule.ps1
@@ -327,11 +327,38 @@ Rule 'Azure.APIM.PolicyBase' -Ref 'AZR-000371' -Type 'Microsoft.ApiManagement/se
     $policies = GetAPIMPolicyNode -Node 'policies' -IgnoreGlobal
     foreach ($policy in $policies) {
         Write-Debug "Got policy: $($policy.OuterXml)"
-        
-        $Assert.HasField($policy.inbound, 'base').PathPrefix('inbound')
-        $Assert.HasField($policy.backend, 'base').PathPrefix('backend')
-        $Assert.HasField($policy.outbound, 'base').PathPrefix('outbound')
-        $Assert.HasField($policy.'on-error', 'base').PathPrefix('on-error')
+
+        # inbound section
+        if ($Assert.HasField($policy, 'inbound').Result) {
+            $Assert.HasField($policy.inbound, 'base').PathPrefix('inbound')
+        }
+        else {
+            $Assert.HasField($policy, 'inbound')
+        }
+
+        # outbound section
+        if ($Assert.HasField($policy, 'backend').Result) {
+            $Assert.HasField($policy.backend, 'base').PathPrefix('backend')
+        }
+        else {
+            $Assert.HasField($policy, 'backend')
+        }
+
+        # outbound section
+        if ($Assert.HasField($policy, 'outbound').Result) {
+            $Assert.HasField($policy.outbound, 'base').PathPrefix('outbound')
+        }
+        else {
+            $Assert.HasField($policy, 'outbound')
+        }
+
+        # on-error section
+        if ($Assert.HasField($policy, 'on-error').Result) {
+            $Assert.HasField($policy.'on-error', 'base').PathPrefix('on-error')
+        }
+        else {
+            $Assert.HasField($policy, 'on-error')
+        }
     }
 }
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.APIM.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.APIM.Tests.ps1
@@ -432,17 +432,18 @@ Describe 'Azure.APIM' -Tag 'APIM' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'apim-B', 'apim-C', 'api-policy-A', 'api-policy-B';
+            $ruleResult.TargetName | Should -BeIn 'apim-B', 'apim-C', 'api-policy-A', 'api-policy-B', 'api-policy-E';
+            $ruleResult.Length | Should -Be 5;
 
             $ruleResult[0].Reason | Should -BeIn "Path inbound.base: Does not exist.", "Path backend.base: Does not exist.", "Path outbound.base: Does not exist.", "Path on-error.base: Does not exist.";
             $ruleResult[1].Reason | Should -BeIn "Path inbound.base: Does not exist.", "Path backend.base: Does not exist.", "Path outbound.base: Does not exist.", "Path on-error.base: Does not exist.";
+            $ruleResult[4].Reason | Should -BeIn "Path on-error: Does not exist.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
             $ruleResult.TargetName | Should -BeIn 'apim-D', 'api-policy-C';
+            $ruleResult.Length | Should -Be 2;
         }
 
         It 'Azure.APIM.DefenderCloud' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.APIM.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.APIM.json
@@ -3296,5 +3296,29 @@
     "Sku": null,
     "Tags": null,
     "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.ApiManagement/service/apim-P/apis/api-A/policies/api-policy-E",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.ApiManagement/service/apim-B/apim-P/apis/api-A/policies/api-policy-E",
+    "Identity": null,
+    "Kind": null,
+    "Location": null,
+    "ManagedBy": null,
+    "ResourceName": "api-policy-E",
+    "Name": "api-policy-E",
+    "ExtensionResourceName": null,
+    "ParentResource": null,
+    "Plan": null,
+    "Properties": {
+      "value": "<policies><inbound><base /><ip-filter action=\"allow\"><address-range from=\"51.175.196.188\" to=\"51.175.196.188\" /></ip-filter></inbound><backend><base /></backend><outbound><base /></outbound></policies>",
+      "format": "xml"
+    },
+    "ResourceGroupName": "rg-test",
+    "Type": "Microsoft.ApiManagement/service/apis/policies",
+    "ResourceType": "Microsoft.ApiManagement/service/apis/policies",
+    "ExtensionResourceType": null,
+    "Sku": null,
+    "Tags": null,
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000"
   }
 ]


### PR DESCRIPTION
## PR Summary

- Fixes `Azure.APIM.PolicyBase` to provide detailed output when policy sections are missing.

Fixes #3413

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section

