### PR TITLE
Fix location check for Azure.Log.Replication #3411

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 What's changed since v1.44.0:
 
 - Bug fixes:
+  - Fixes `Azure.Log.Replication` by removing `location` check by @BernieWhite.
+    [#3411](https://github.com/Azure/PSRule.Rules.Azure/issues/3411)
   - Fixes the function `tryIndexFromEnd` was not found by @BernieWhite.
     [#3409](https://github.com/Azure/PSRule.Rules.Azure/issues/3409)
 

--- a/src/PSRule.Rules.Azure/rules/Azure.Log.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.Log.Rule.yaml
@@ -30,8 +30,6 @@ spec:
     allOf:
       - field: properties.replication.enabled
         equals: true
-      - field: properties.replication.location
-        hasValue: true
 
 ---
 # Synopsis: Azure Resource Manager (ARM) has requirements for Azure Monitor Log workspace names.

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Log.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Log.Tests.ps1
@@ -44,17 +44,16 @@ Describe 'Azure.Log' -Tag 'LogAnalytics','Log' {
 
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'workspace-a', 'workspace-b', 'workspace-c';
+            $ruleResult.TargetName | Should -BeIn 'workspace-a', 'workspace-b';
+            $ruleResult.Length | Should -Be 2;
 
             $ruleResult[0].Reason | Should -Be "Path properties.replication.enabled: The field 'properties.replication.enabled' does not exist.";
             $ruleResult[1].Reason | Should -Be "Path properties.replication.enabled: Is set to 'False'.";
-            $ruleResult[2].Reason | Should -Be "Path properties.replication.location: The field 'properties.replication.location' does not exist.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'workspace-d';
+            $ruleResult.TargetName | Should -BeIn 'workspace-d', 'workspace-c';
+            $ruleResult.Length | Should -Be 2;
         }
 
         It 'Azure.Log.ReplicaLocation' {


### PR DESCRIPTION
## PR Summary

- Fixes `Azure.Log.Replication` by removing `location` check.

Fixes #3411

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section

