### PR TITLE
Add Dependabot configuration for .NET SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,46 +7,52 @@
 
 version: 2
 updates:
-
-# Maintain dependencies for .NET Core
-- package-ecosystem: nuget
-  directory: '/'
-  schedule:
-    interval: daily
-  labels:
-  - dependencies
-  groups:
-    # Group PowerShell packages that have inter-dependencies
-    dev-powershell:
-      update-types:
-        - minor
-        - patch
-      patterns:
-        - System.Management.Automation
-        - Microsoft.PowerShell.SDK
-  ignore:
-    - dependency-name: gitversion.tool
-
-# Maintain dependencies for GitHub Actions
-- package-ecosystem: github-actions
-  directory: '/'
-  schedule:
-    interval: daily
-  labels:
-  - ci-quality
-
-# Maintain dependencies for Python
-- package-ecosystem: pip
-  directory: '/'
-  schedule:
-    interval: daily
-  labels:
-  - ci-quality
-
-# Maintain dependencies for Dev Containers
-- package-ecosystem: devcontainers
-  directory: '/'
-  schedule:
-    interval: daily
-  labels:
-  - ci-quality
+  # Maintain dependencies for .NET Core
+  - package-ecosystem: nuget
+    directory: '/'
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+    groups:
+      # Group PowerShell packages that have inter-dependencies
+      dev-powershell:
+        update-types:
+          - minor
+          - patch
+        patterns:
+          - System.Management.Automation
+          - Microsoft.PowerShell.SDK
+    ignore:
+      - dependency-name: gitversion.tool
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+    labels:
+      - ci-quality
+  # Maintain dependencies for Python
+  - package-ecosystem: pip
+    directory: '/'
+    schedule:
+      interval: daily
+    labels:
+      - ci-quality
+  # Maintain dependencies for Dev Containers
+  - package-ecosystem: devcontainers
+    directory: '/'
+    schedule:
+      interval: daily
+    labels:
+      - ci-quality
+  - package-ecosystem: dotnet-sdk
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor


### PR DESCRIPTION
This PR adds Dependabot configuration to automatically manage .NET SDK version updates in global.json.

This configuration will:
- Monitor the global.json file for .NET SDK version updates
- Create pull requests when new SDK versions are available
- Help keep the project secure with the latest SDK patches

For more information, see: https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/