### PR TITLE
application gateway | Update Azure.AppGw.MinInstance.md to align with v2 default experience

### DIFF
--- a/docs/en/rules/Azure.AppGw.MinInstance.md
+++ b/docs/en/rules/Azure.AppGw.MinInstance.md
@@ -37,7 +37,6 @@ With zero reserved instances, the variable costs are [calculated based on actual
 Consider using Application Gateway v2 with autoscale enabled which includes two instances by default.
 Alternatively, if using manual scaling specify the number of instances to be two or more.
 
-
 ## EXAMPLES
 
 ### Configure with Azure template


### PR DESCRIPTION
Update Description and Recommendation for default creation experience for Application Gateway v2.

This pull request updates the documentation for the rule Azure.AppGw.MinInstance. The changes clarify that Application Gateway v2 is created with two instances by default and adjust recommendations accordingly, specifying that only v1 with auto-scaling disabled needs explicit configuration for two or more instances. No code changes were made—only documentation was modified for clearer guidance.

## PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
