### PR TITLE
Promote Azure.VNG.MaintenanceConfig to GA #3379

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,10 @@ What's changed since pre-release v1.45.0-B0037:
       [#3443](https://github.com/Azure/PSRule.Rules.Azure/issues/3443)
       - The Docker content trust feature will retire in March 2028.
       - Content trust is replaced by OCI artifact signing, which is supported by Azure Container Registry.
+  - Virtual Network Gateway:
+    - Updated documentation and promoted `Azure.VNG.MaintenanceConfig` to GA by @BernieWhite.
+      [#3379](https://github.com/Azure/PSRule.Rules.Azure/issues/3379)
+      - Bumped rule set to `2025_06`.
 - Bug fixes:
   - Fixed parent is missing on mocked token when expanding PE AVM module by @BernieWhite.
     [#3446](https://github.com/Azure/PSRule.Rules.Azure/issues/3446)

--- a/docs/en/rules/Azure.VNG.MaintenanceConfig.md
+++ b/docs/en/rules/Azure.VNG.MaintenanceConfig.md
@@ -1,4 +1,5 @@
 ---
+reviewed: 2025-07-03
 severity: Important
 pillar: Reliability
 category: RE:04 Target metrics
@@ -15,17 +16,48 @@ Use a customer-controlled maintenance configuration for virtual network gateways
 
 ## DESCRIPTION
 
-Virtual network gateways require regular updates to maintain and enhance their functionality, reliability, performance, and security. These updates include patching software, upgrading networking components, and decommissioning outdated hardware.
+Virtual network gateways are critical infrastructure components that require regular maintenance updates to ensure optimal
+functionality, reliability, performance, and security.
 
-By attaching virtual network gateways to a maintenance configuration, customers can schedule these updates to occur during a preferred maintenance window, ideally outside of business hours, to minimize disruptions.
+In most cases, these updates are carefully planned to minimize their impact on customer operations.
+Azure schedules updates during non-business hours in the gateway region, and customers with robust architecture
+typically experience minimal disruption to normal business activities.
+However, there might be instances where customers are affected by these updates, particularly in scenarios where:
 
-Both the VPN and ExpressRoute virtual network gateway types support customer-controlled maintenance configurations.
+- Business operations span multiple time zones.
+- Maintenance windows need to align with other regular scheduled activities.
+- Organizations require predictable maintenance schedules for compliance or operational reasons.
+
+Customer-controlled maintenance configurations*provide organizations with the ability to define specific maintenance
+windows when guest OS and service updates occur.
+These updates account for most of the maintenance items that cause concern for customers.
+Some other types of updates, including host, and critical security updates are outside the scope of customer-controlled maintenance.
 
 ## RECOMMENDATION
 
-Consider using a customer-controlled maintenance configuration to efficiently schedule updates and minimize disruptions.
+Consider using a customer-controlled maintenance configuration to predictably schedule updates and minimize disruptions.
 
 ## EXAMPLES
+
+### Configure with Bicep
+
+To configure virtual network gateways that pass this rule:
+
+- Deploy a `Microsoft.Maintenance/configurationAssignments` sub-resource (extension resource).
+- Set the `properties.maintenanceConfigurationId` property to the linked maintenance configuration resource Id.
+
+For example:
+
+```bicep
+resource config 'Microsoft.Maintenance/configurationAssignments@2023-04-01' = {
+  name: assignmentName
+  location: location
+  scope: virtualNetworkGateway
+  properties: {
+    maintenanceConfigurationId: maintenanceConfigurationId
+  }
+}
+```
 
 ### Configure with Azure template
 
@@ -51,30 +83,6 @@ For example:
   ]
 }
 ```
-
-### Configure with Bicep
-
-To configure virtual network gateways that pass this rule:
-
-- Deploy a `Microsoft.Maintenance/configurationAssignments` sub-resource (extension resource).
-- Set the `properties.maintenanceConfigurationId` property to the linked maintenance configuration resource Id.
-
-For example:
-
-```bicep
-resource config 'Microsoft.Maintenance/configurationAssignments@2023-04-01' = {
-  name: assignmentName
-  location: location
-  scope: virtualNetworkGateway
-  properties: {
-    maintenanceConfigurationId: maintenanceConfigurationId
-  }
-}
-```
-
-## NOTES
-
-This feature is currently in preview for both the VPN and ExpressRoute virtual network gateway types.
 
 ## LINKS
 

--- a/src/PSRule.Rules.Azure/rules/Azure.VNG.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VNG.Rule.ps1
@@ -27,7 +27,7 @@ Rule 'Azure.VNG.ERAvailabilityZoneSKU' -Ref 'AZR-000273' -Type 'Microsoft.Networ
 }
 
 # Synopsis: Use a customer-controlled maintenance configuration for virtual network gateways.
-Rule 'Azure.VNG.MaintenanceConfig' -Ref 'AZR-000430' -Type 'Microsoft.Network/virtualNetworkGateways' -Tag @{ release = 'preview'; ruleSet = '2024_06'; 'Azure.WAF/pillar' = 'Reliability'; } {
+Rule 'Azure.VNG.MaintenanceConfig' -Ref 'AZR-000430' -Type 'Microsoft.Network/virtualNetworkGateways' -Tag @{ release = 'GA'; ruleSet = '2025_06'; 'Azure.WAF/pillar' = 'Reliability'; } {
     $maintenanceConfig = @(GetSubResources -ResourceType 'Microsoft.Maintenance/configurationAssignments' |
         Where-Object { $_.properties.maintenanceConfigurationId })
     $Assert.GreaterOrEqual($maintenanceConfig, '.', 1).Reason($LocalizedData.VNGMaintenanceConfig, $PSRule.TargetName)

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
@@ -255,7 +255,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2024_06' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 8;
+            $filteredResult.Length | Should -Be 7;
         }
 
         It 'With Azure.GA_2024_09' {
@@ -269,7 +269,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2024_09' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 9;
+            $filteredResult.Length | Should -Be 8;
         }
 
         It 'With Azure.GA_2024_12' {
@@ -283,7 +283,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2024_12' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 9;
+            $filteredResult.Length | Should -Be 8;
         }
 
         It 'With Azure.GA_2025_03' {
@@ -297,7 +297,7 @@ Describe 'Baselines' -Tag Baseline {
             $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2025_03' -WarningAction Ignore);
             $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
             $filteredResult | Should -Not -BeNullOrEmpty;
-            $filteredResult.Length | Should -Be 9;
+            $filteredResult.Length | Should -Be 8;
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Updated documentation and promoted `Azure.VNG.MaintenanceConfig` to GA.
  - Bumped rule set to `2025_06`.

Fixes #3379

## PR Checklist

- [ ] PR has a meaningful title
- [ ] Summarized changes
- [ ] Change is not breaking
- [ ] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
