### PR TITLE
Fixed `Azure.AppGw.MinInstance` should allow 0 minimum capacity #3452

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,8 @@ What's changed since pre-release v1.45.0-B0037:
 - Bug fixes:
   - Fixed parent is missing on mocked token when expanding PE AVM module by @BernieWhite.
     [#3446](https://github.com/Azure/PSRule.Rules.Azure/issues/3446)
+  - Fixed `Azure.AppGw.MinInstance` should allow 0 minimum capacity for v2 with autoscale by @BernieWhite @mbender-ms.
+    [#3452](https://github.com/Azure/PSRule.Rules.Azure/issues/3452)
 
 ## v1.45.0-B0037 (pre-release)
 

--- a/docs/examples/resources/appgw.bicep
+++ b/docs/examples/resources/appgw.bicep
@@ -8,7 +8,7 @@ param name string
 param location string = resourceGroup().location
 
 // An example of an Application Gateway with a WAF_v2 SKU.
-resource appgw 'Microsoft.Network/applicationGateways@2024-01-01' = {
+resource appgw 'Microsoft.Network/applicationGateways@2024-07-01' = {
   name: name
   location: location
   zones: [
@@ -32,8 +32,8 @@ resource appgw 'Microsoft.Network/applicationGateways@2024-01-01' = {
       ]
     }
     autoscaleConfiguration: {
-      minCapacity: 2
-      maxCapacity: 3
+      minCapacity: 0
+      maxCapacity: 4
     }
     firewallPolicy: {
       id: waf.id
@@ -61,6 +61,37 @@ resource waf 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies
     policySettings: {
       state: 'Enabled'
       mode: 'Prevention'
+    }
+  }
+}
+
+// An example of an Application Gateway configured with a minimum instances of 2.
+resource appgw_manual 'Microsoft.Network/applicationGateways@2024-07-01' = {
+  name: name
+  location: location
+  zones: [
+    '1'
+    '2'
+    '3'
+  ]
+  properties: {
+    sku: {
+      name: 'WAF_v2'
+      tier: 'WAF_v2'
+      capacity: 2
+    }
+    sslPolicy: {
+      policyType: 'Custom'
+      minProtocolVersion: 'TLSv1_2'
+      cipherSuites: [
+        'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384'
+        'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256'
+        'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'
+        'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256'
+      ]
+    }
+    firewallPolicy: {
+      id: waf.id
     }
   }
 }

--- a/docs/examples/resources/appgw.json
+++ b/docs/examples/resources/appgw.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.30.23.60470",
-      "templateHash": "4359475365574020257"
+      "version": "0.36.1.42791",
+      "templateHash": "17115327554579347923"
     }
   },
   "parameters": {
@@ -26,7 +26,7 @@
   "resources": [
     {
       "type": "Microsoft.Network/applicationGateways",
-      "apiVersion": "2024-01-01",
+      "apiVersion": "2024-07-01",
       "name": "[parameters('name')]",
       "location": "[parameters('location')]",
       "zones": [
@@ -50,8 +50,8 @@
           ]
         },
         "autoscaleConfiguration": {
-          "minCapacity": 2,
-          "maxCapacity": 3
+          "minCapacity": 0,
+          "maxCapacity": 4
         },
         "firewallPolicy": {
           "id": "[resourceId('Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies', 'agwwaf')]"
@@ -84,6 +84,40 @@
           "mode": "Prevention"
         }
       }
+    },
+    {
+      "type": "Microsoft.Network/applicationGateways",
+      "apiVersion": "2024-07-01",
+      "name": "[parameters('name')]",
+      "location": "[parameters('location')]",
+      "zones": [
+        "1",
+        "2",
+        "3"
+      ],
+      "properties": {
+        "sku": {
+          "name": "WAF_v2",
+          "tier": "WAF_v2",
+          "capacity": 2
+        },
+        "sslPolicy": {
+          "policyType": "Custom",
+          "minProtocolVersion": "TLSv1_2",
+          "cipherSuites": [
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+          ]
+        },
+        "firewallPolicy": {
+          "id": "[resourceId('Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies', 'agwwaf')]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies', 'agwwaf')]"
+      ]
     }
   ]
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppGw.Rule.yaml
@@ -24,12 +24,12 @@ spec:
   condition:
     anyOf:
     # Applies to v1 and v2 without autoscale
-    - field: Properties.sku.capacity
+    - field: properties.sku.capacity
       greaterOrEquals: 2
 
     # Applies to v2 with autoscale
-    - field: Properties.autoscaleConfiguration.minCapacity
-      greaterOrEquals: 2
+    - field: properties.autoscaleConfiguration.minCapacity
+      greaterOrEquals: 0
 
 ---
 # Synopsis: Application Gateway should use a minimum instance size of Medium.

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AppGw.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AppGw.json
@@ -536,7 +536,7 @@
       },
       "enableHttp2": false,
       "autoscaleConfiguration": {
-        "minCapacity": 2,
+        "minCapacity": 0,
         "maxCapacity": 3
       }
     },


### PR DESCRIPTION
## PR Summary

Fixed `Azure.AppGw.MinInstance` should allow 0 minimum capacity for v2 with autoscale by @BernieWhite @mbender-ms.

This update rule, tests and add more detailed examples.

Fixes #3452

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section

