### PR TITLE
Pre-release v1.45.0-B0068

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.45.0-B0068 (pre-release)
+
 What's changed since pre-release v1.45.0-B0037:
 
 - New rules:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.45.0-B0037:

- New rules:
  - App Configuration:
    - Check that App Configuration Key Values do not contain known secrets by @BernieWhite.
      [#3439](https://github.com/Azure/PSRule.Rules.Azure/issues/3439)
- Updated rules:
  - Container Registry:
    - Deprecated `Azure.ACR.ContentTrust` rule by @BernieWhite.
      [#3443](https://github.com/Azure/PSRule.Rules.Azure/issues/3443)
      - The Docker content trust feature will retire in March 2028.
      - Content trust is replaced by OCI artifact signing, which is supported by Azure Container Registry.
  - Virtual Network Gateway:
    - Updated documentation and promoted `Azure.VNG.MaintenanceConfig` to GA by @BernieWhite.
      [#3379](https://github.com/Azure/PSRule.Rules.Azure/issues/3379)
      - Bumped rule set to `2025_06`.
- Bug fixes:
  - Fixed parent is missing on mocked token when expanding PE AVM module by @BernieWhite.
    [#3446](https://github.com/Azure/PSRule.Rules.Azure/issues/3446)
  - Fixed `Azure.AppGw.MinInstance` should allow 0 minimum capacity for v2 with autoscale by @BernieWhite @mbender-ms.
    [#3452](https://github.com/Azure/PSRule.Rules.Azure/issues/3452)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
