### PR TITLE
Check Event Grid namespaces use a minimum of TLS 1.2 #3354

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 What's changed since pre-release v1.45.0-B0068:
 
 - New rules:
+  - Event Grid:
+    - Check namespaces use a minimum of TLS 1.2 by @BernieWhite.
+      [#3354](https://github.com/Azure/PSRule.Rules.Azure/issues/3354)
   - Monitor Alerts:
     - Check that metric alerts are configured to automatically mitigate by @BernieWhite.
       [#3457](https://github.com/Azure/PSRule.Rules.Azure/issues/3457)

--- a/docs/en/rules/Azure.EventGrid.DomainTLS.md
+++ b/docs/en/rules/Azure.EventGrid.DomainTLS.md
@@ -51,6 +51,8 @@ resource domain 'Microsoft.EventGrid/domains@2025-02-15' = {
 }
 ```
 
+<!-- external:avm avm/res/event-grid/domain minimumTlsVersionAllowed -->
+
 ### Configure with Azure template
 
 To deploy domains that pass this rule:
@@ -76,7 +78,7 @@ For example:
 
 ## LINKS
 
-- [SE:07 Encryption](https://learn.microsoft.com/azure/well-architected/security/encryption#data-in-transit)
+- [SE:07 Encryption](https://learn.microsoft.com/azure/well-architected/security/encryption)
 - [Enforce a minimum required version of Transport Layer Security (TLS) for an Event Grid topic, domain, or subscription](https://learn.microsoft.com/azure/event-grid/transport-layer-security-enforce-minimum-version)
 - [Preparing for TLS 1.2 in Microsoft Azure](https://azure.microsoft.com/updates/azuretls12/)
 - [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.eventgrid/domains)

--- a/docs/en/rules/Azure.EventGrid.NamespaceTLS.md
+++ b/docs/en/rules/Azure.EventGrid.NamespaceTLS.md
@@ -1,14 +1,14 @@
 ---
-reviewed: 2025-03-28
+reviewed: 2025-07-07
 severity: Critical
 pillar: Security
 category: SE:07 Encryption
-resource: Event Grid Topic
-resourceType: Microsoft.EventGrid/topics
-online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.EventGrid.TopicTLS/
+resource: Event Grid Namespace
+resourceType: Microsoft.EventGrid/namespaces
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.EventGrid.NamespaceTLS/
 ---
 
-# Event Grid Topic accepts insecure TLS versions
+# Event Grid Namespace accepts insecure TLS versions
 
 ## SYNOPSIS
 
@@ -16,7 +16,7 @@ Weak or deprecated transport protocols for client-server communication introduce
 
 ## DESCRIPTION
 
-The minimum version of TLS that Event Grid Topics accept is configurable.
+The minimum version of TLS that Event Grid Namespaces accept is configurable.
 Older TLS versions are no longer considered secure by industry standards, such as PCI DSS.
 
 Azure lets you disable outdated protocols and require connections to use a minimum of TLS 1.2.
@@ -32,33 +32,30 @@ Configure the minimum supported TLS version to be 1.2. Also consider enforcing t
 
 ### Configure with Bicep
 
-To deploy topics that pass this rule:
+To deploy namespaces that pass this rule:
 
 - Set the `properties.minimumTlsVersionAllowed` property to `1.2`.
 
 For example:
 
 ```bicep
-resource topic 'Microsoft.EventGrid/topics@2025-02-15' = {
+resource namespace 'Microsoft.EventGrid/namespaces@2025-02-15' = {
   name: name
   location: location
   identity: {
     type: 'SystemAssigned'
   }
   properties: {
-    disableLocalAuth: true
     publicNetworkAccess: 'Disabled'
     minimumTlsVersionAllowed: '1.2'
-    inputSchema: 'CloudEventSchemaV1_0'
+    isZoneRedundant: true
   }
 }
 ```
 
-<!-- external:avm avm/res/event-grid/topic minimumTlsVersionAllowed -->
-
 ### Configure with Azure template
 
-To deploy topics that pass this rule:
+To deploy namespaces that pass this rule:
 
 - Set the `properties.minimumTlsVersionAllowed` property to `1.2`.
 
@@ -66,7 +63,7 @@ For example:
 
 ```json
 {
-  "type": "Microsoft.EventGrid/topics",
+  "type": "Microsoft.EventGrid/namespaces",
   "apiVersion": "2025-02-15",
   "name": "[parameters('name')]",
   "location": "[parameters('location')]",
@@ -74,10 +71,9 @@ For example:
     "type": "SystemAssigned"
   },
   "properties": {
-    "disableLocalAuth": true,
     "publicNetworkAccess": "Disabled",
     "minimumTlsVersionAllowed": "1.2",
-    "inputSchema": "CloudEventSchemaV1_0"
+    "isZoneRedundant": true
   }
 }
 ```
@@ -85,6 +81,5 @@ For example:
 ## LINKS
 
 - [SE:07 Encryption](https://learn.microsoft.com/azure/well-architected/security/encryption)
-- [Enforce a minimum required version of Transport Layer Security (TLS) for an Event Grid topic, domain, or subscription](https://learn.microsoft.com/azure/event-grid/transport-layer-security-enforce-minimum-version)
 - [Preparing for TLS 1.2 in Microsoft Azure](https://azure.microsoft.com/updates/azuretls12/)
-- [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.eventgrid/topics)
+- [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.eventgrid/namespaces)

--- a/docs/en/rules/Azure.EventGrid.TopicPublicAccess.md
+++ b/docs/en/rules/Azure.EventGrid.TopicPublicAccess.md
@@ -26,31 +26,6 @@ To limit access to Event Grid topics and domains, disable public access.
 
 ## EXAMPLES
 
-### Configure with Azure template
-
-To deploy Event Grid Topics that pass this rule:
-
-- Set the `properties.publicNetworkAccess` property to `Disabled`.
-
-For example:
-
-```json
-{
-  "type": "Microsoft.EventGrid/topics",
-  "apiVersion": "2022-06-15",
-  "name": "[parameters('name')]",
-  "location": "[parameters('location')]",
-  "identity": {
-    "type": "SystemAssigned"
-  },
-  "properties": {
-    "disableLocalAuth": true,
-    "publicNetworkAccess": "Disabled",
-    "inputSchema": "CloudEventSchemaV1_0"
-  }
-}
-```
-
 ### Configure with Bicep
 
 To deploy Event Grid Topics that pass this rule:
@@ -75,6 +50,31 @@ resource eventGrid 'Microsoft.EventGrid/topics@2022-06-15' = {
 ```
 
 <!-- external:avm avm/res/event-grid/topic publicNetworkAccess -->
+
+### Configure with Azure template
+
+To deploy Event Grid Topics that pass this rule:
+
+- Set the `properties.publicNetworkAccess` property to `Disabled`.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.EventGrid/topics",
+  "apiVersion": "2022-06-15",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "identity": {
+    "type": "SystemAssigned"
+  },
+  "properties": {
+    "disableLocalAuth": true,
+    "publicNetworkAccess": "Disabled",
+    "inputSchema": "CloudEventSchemaV1_0"
+  }
+}
+```
 
 ## LINKS
 

--- a/docs/examples/resources/eventgrid.bicep
+++ b/docs/examples/resources/eventgrid.bicep
@@ -53,3 +53,17 @@ resource systemTopic 'Microsoft.EventGrid/systemTopics@2025-02-15' = {
     topicType: 'Microsoft.Storage.StorageAccounts'
   }
 }
+
+// An example of an Event Grid Namespace with public access disabled, and zone redundancy enabled.
+resource namespace 'Microsoft.EventGrid/namespaces@2025-02-15' = {
+  name: name
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    publicNetworkAccess: 'Disabled'
+    minimumTlsVersionAllowed: '1.2'
+    isZoneRedundant: true
+  }
+}

--- a/docs/examples/resources/eventgrid.json
+++ b/docs/examples/resources/eventgrid.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.34.44.8038",
-      "templateHash": "6907948879870980207"
+      "version": "0.36.1.42791",
+      "templateHash": "6161631745636090470"
     }
   },
   "parameters": {
@@ -70,6 +70,20 @@
       "properties": {
         "source": "[parameters('storageId')]",
         "topicType": "Microsoft.Storage.StorageAccounts"
+      }
+    },
+    {
+      "type": "Microsoft.EventGrid/namespaces",
+      "apiVersion": "2025-02-15",
+      "name": "[parameters('name')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "publicNetworkAccess": "Disabled",
+        "minimumTlsVersionAllowed": "1.2",
+        "isZoneRedundant": true
       }
     }
   ]

--- a/src/PSRule.Rules.Azure/rules/Azure.EventGrid.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Azure.EventGrid.Rule.yaml
@@ -83,7 +83,7 @@ spec:
     equals: true
 
 ---
-# Synopsis: Event Grid topics should reject TLS versions older than 1.2.
+# Synopsis: Weak or deprecated transport protocols for client-server communication introduce security vulnerabilities.
 apiVersion: github.com/microsoft/PSRule/v1
 kind: Rule
 metadata:
@@ -101,7 +101,7 @@ spec:
     version: '>=1.2'
 
 ---
-# Synopsis: Event Grid domains should reject TLS versions older than 1.2.
+# Synopsis: Weak or deprecated transport protocols for client-server communication introduce security vulnerabilities.
 apiVersion: github.com/microsoft/PSRule/v1
 kind: Rule
 metadata:
@@ -114,6 +114,24 @@ metadata:
 spec:
   type:
   - Microsoft.EventGrid/domains
+  condition:
+    field: properties.minimumTlsVersionAllowed
+    version: '>=1.2'
+
+---
+# Synopsis: Weak or deprecated transport protocols for client-server communication introduce security vulnerabilities.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Azure.EventGrid.NamespaceTLS
+  ref: AZR-000493
+  tags:
+    release: GA
+    ruleSet: 2025_06
+    Azure.WAF/pillar: Security
+spec:
+  type:
+    - Microsoft.EventGrid/namespaces
   condition:
     field: properties.minimumTlsVersionAllowed
     version: '>=1.2'

--- a/tests/PSRule.Rules.Azure.Tests/Azure.EventGrid.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.EventGrid.Tests.ps1
@@ -115,6 +115,22 @@ Describe 'Azure.EventGrid' -Tag 'EventGrid' {
             $ruleResult.TargetName | Should -BeIn 'domain-B';
             $ruleResult.Length | Should -Be 1;
         }
+
+        It 'Azure.EventGrid.NamespaceTLS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.EventGrid.NamespaceTLS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.TargetName | Should -BeIn 'namespace-B';
+            $ruleResult.Length | Should -Be 1;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.TargetName | Should -BeIn 'namespace-A';
+            $ruleResult.Length | Should -Be 1;
+        }
     }
 
     Context 'With Template' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.EventGrid.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.EventGrid.json
@@ -39,12 +39,8 @@
       "name": "Basic"
     },
     "Location": "region",
-    "ManagedBy": null,
     "ResourceName": "topic-B",
     "Name": "topic-B",
-    "ExtensionResourceName": null,
-    "ParentResource": null,
-    "Plan": null,
     "Properties": {
       "provisioningState": "Succeeded",
       "endpoint": "https://topic-B.region-1.eventgrid.azure.net/api/events",
@@ -61,9 +57,6 @@
     "ResourceGroupName": "rg-test",
     "Type": "Microsoft.EventGrid/topics",
     "ResourceType": "Microsoft.EventGrid/topics",
-    "ExtensionResourceType": null,
-    "Sku": null,
-    "Tags": null,
     "SubscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   {
@@ -79,12 +72,8 @@
       "name": "Basic"
     },
     "Location": "region",
-    "ManagedBy": null,
     "ResourceName": "topic-C",
     "Name": "topic-C",
-    "ExtensionResourceName": null,
-    "ParentResource": null,
-    "Plan": null,
     "Properties": {
       "provisioningState": "Succeeded",
       "endpoint": "https://topic-C.region-1.eventgrid.azure.net/api/events",
@@ -97,9 +86,6 @@
     "ResourceGroupName": "rg-test",
     "Type": "Microsoft.EventGrid/topics",
     "ResourceType": "Microsoft.EventGrid/topics",
-    "ExtensionResourceType": null,
-    "Sku": null,
-    "Tags": null,
     "SubscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   {
@@ -110,14 +96,9 @@
       "TenantId": "00000000-0000-0000-0000-000000000000",
       "Type": "SystemAssigned"
     },
-    "Kind": null,
     "Location": "region",
-    "ManagedBy": null,
     "ResourceName": "domain-A",
     "Name": "domain-A",
-    "ExtensionResourceName": null,
-    "ParentResource": null,
-    "Plan": null,
     "Properties": {
       "provisioningState": "Succeeded",
       "endpoint": "https://domain-A.region-1.eventgrid.azure.net/api/events",
@@ -128,9 +109,6 @@
     "ResourceGroupName": "rg-test",
     "Type": "Microsoft.EventGrid/domains",
     "ResourceType": "Microsoft.EventGrid/domains",
-    "ExtensionResourceType": null,
-    "Sku": null,
-    "Tags": null,
     "SubscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   {
@@ -141,14 +119,9 @@
       "TenantId": "00000000-0000-0000-0000-000000000000",
       "Type": "SystemAssigned"
     },
-    "Kind": null,
     "Location": "region",
-    "ManagedBy": null,
     "ResourceName": "domain-B",
     "Name": "domain-B",
-    "ExtensionResourceName": null,
-    "ParentResource": null,
-    "Plan": null,
     "Properties": {
       "provisioningState": "Succeeded",
       "endpoint": "https://domain-B.region-1.eventgrid.azure.net/api/events",
@@ -161,9 +134,51 @@
     "ResourceGroupName": "rg-test",
     "Type": "Microsoft.EventGrid/domains",
     "ResourceType": "Microsoft.EventGrid/domains",
-    "ExtensionResourceType": null,
-    "Sku": null,
-    "Tags": null,
     "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  {
+    "properties": {
+      "provisioningState": "Succeeded",
+      "topicsConfiguration": {
+        "hostname": "namespace-A.eastus-1.eventgrid.azure.net"
+      },
+      "isZoneRedundant": true,
+      "publicNetworkAccess": "Disabled",
+      "inboundIpRules": [],
+      "minimumTlsVersionAllowed": "1.2"
+    },
+    "sku": {
+      "name": "Standard",
+      "capacity": 1
+    },
+    "identity": {
+      "type": "None"
+    },
+    "location": "eastus",
+    "tags": {},
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.EventGrid/namespaces/namespace-A",
+    "name": "namespace-A",
+    "type": "Microsoft.EventGrid/namespaces"
+  },
+  {
+    "properties": {
+      "provisioningState": "Succeeded",
+      "topicsConfiguration": {
+        "hostname": "namespace-A.region-1.eventgrid.azure.net"
+      },
+      "inboundIpRules": []
+    },
+    "sku": {
+      "name": "Standard",
+      "capacity": 1
+    },
+    "identity": {
+      "type": "None"
+    },
+    "location": "region",
+    "tags": {},
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.EventGrid/namespaces/namespace-B",
+    "name": "namespace-B",
+    "type": "Microsoft.EventGrid/namespaces"
   }
 ]


### PR DESCRIPTION
## PR Summary

- Check namespaces use a minimum of TLS 1.2.

Fixes #3354

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
