### PR TITLE
Updated AKS version and added June baselines #3463 #3465

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,18 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.45.0-B0104:
+
+- New features:
+  - Added June 2025 baselines `Azure.GA_2025_06` and `Azure.Preview_2025_06` by @BernieWhite.
+    [#3465](https://github.com/Azure/PSRule.Rules.Azure/issues/3465)
+    - Includes rules released before or during June 2025.
+    - Marked `Azure.GA_2025_03` and `Azure.Preview_2025_03` baselines as obsolete.
+- Updated rules:
+  - Azure Kubernetes Service:
+    - Updated `Azure.AKS.Version` to use `1.32.5` as the minimum version by @BernieWhite.
+      [#3463](https://github.com/Azure/PSRule.Rules.Azure/issues/3463)
+
 ## v1.45.0-B0104 (pre-release)
 
 What's changed since pre-release v1.45.0-B0068:

--- a/docs/concepts/about_PSRule_Azure_Configuration.md
+++ b/docs/concepts/about_PSRule_Azure_Configuration.md
@@ -50,7 +50,7 @@ Default:
 ```yaml
 # YAML: The default AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option
 configuration:
-  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.30.10
+  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.32.5
 ```
 
 Example:

--- a/docs/en/rules/Azure.AKS.NodeAutoUpgrade.md
+++ b/docs/en/rules/Azure.AKS.NodeAutoUpgrade.md
@@ -57,7 +57,7 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2024-10-01' = {
     }
   }
   properties: {
-    kubernetesVersion: '1.30.10'
+    kubernetesVersion: '1.32.5'
     enableRBAC: true
     dnsPrefix: dnsPrefix
     agentPoolProfiles: allPools
@@ -133,7 +133,7 @@ For example:
         }
     },
     "properties": {
-        "kubernetesVersion": "1.30.10",
+        "kubernetesVersion": "1.32.5",
         "enableRBAC": true,
         "dnsPrefix": "[parameters('dnsPrefix')]",
         "agentPoolProfiles": "[variables('allPools')]",

--- a/docs/en/rules/Azure.AKS.Version.md
+++ b/docs/en/rules/Azure.AKS.Version.md
@@ -66,7 +66,7 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2024-10-01' = {
     }
   }
   properties: {
-    kubernetesVersion: '1.30.10'
+    kubernetesVersion: '1.32.5'
     enableRBAC: true
     dnsPrefix: dnsPrefix
     agentPoolProfiles: allPools
@@ -145,7 +145,7 @@ For example:
         }
     },
     "properties": {
-        "kubernetesVersion": "1.30.10",
+        "kubernetesVersion": "1.32.5",
         "enableRBAC": true,
         "dnsPrefix": "[parameters('dnsPrefix')]",
         "agentPoolProfiles": "[variables('allPools')]",
@@ -210,13 +210,13 @@ az aks update -n '<name>' -g '<resource_group>' --auto-upgrade-channel 'stable'
 ```
 
 ```bash
-az aks upgrade -n '<name>' -g '<resource_group>' --kubernetes-version '1.30.10'
+az aks upgrade -n '<name>' -g '<resource_group>' --kubernetes-version '1.32.5'
 ```
 
 ### Configure with Azure PowerShell
 
 ```powershell
-Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -KubernetesVersion '1.30.10'
+Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -KubernetesVersion '1.32.5'
 ```
 
 ## NOTES

--- a/docs/examples/resources/aks.bicep
+++ b/docs/examples/resources/aks.bicep
@@ -46,7 +46,7 @@ param systemPoolMin int
 param systemPoolMax int = 3
 
 @description('The version of Kubernetes.')
-param kubernetesVersion string = '1.30.10'
+param kubernetesVersion string = '1.32.5'
 
 @description('Maximum number of pods that can run on nodes in the system pool.')
 @minValue(30)

--- a/docs/examples/resources/aks.json
+++ b/docs/examples/resources/aks.json
@@ -73,7 +73,7 @@
     },
     "kubernetesVersion": {
       "type": "string",
-      "defaultValue": "1.30.10",
+      "defaultValue": "1.32.5",
       "metadata": {
         "description": "The version of Kubernetes."
       }

--- a/docs/setup/configuring-rules.md
+++ b/docs/setup/configuring-rules.md
@@ -207,7 +207,7 @@ Default:
 ```yaml title="ps-rule.yaml"
 # YAML: The default AZURE_AKS_CLUSTER_MINIMUM_VERSION configuration option
 configuration:
-  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.30.10
+  AZURE_AKS_CLUSTER_MINIMUM_VERSION: 1.32.5
 ```
 
 Example:

--- a/src/PSRule.Rules.Azure/rules/Baseline.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Baseline.Rule.yaml
@@ -968,6 +968,7 @@ metadata:
   annotations:
     export: true
     moduleVersion: v1.42.0
+    obsolete: true
 spec:
   configuration:
     # Configure minimum AKS cluster version
@@ -1006,6 +1007,7 @@ metadata:
   annotations:
     export: true
     moduleVersion: v1.42.0
+    obsolete: true
 spec:
   configuration:
     # Configure minimum AKS cluster version
@@ -1034,3 +1036,81 @@ spec:
       - '2024_09'
       - '2024_12'
       - '2025_03'
+
+---
+# Synopsis: Include rules released June 2025 or prior for Azure GA features.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Baseline
+metadata:
+  name: Azure.GA_2025_06
+  annotations:
+    export: true
+    moduleVersion: v1.45.0
+spec:
+  configuration:
+    # Configure minimum AKS cluster version
+    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.32.5'
+  rule:
+    tag:
+      release: GA
+      ruleSet:
+      - '2020_06'
+      - '2020_09'
+      - '2020_12'
+      - '2021_03'
+      - '2021_06'
+      - '2021_09'
+      - '2021_12'
+      - '2022_03'
+      - '2022_06'
+      - '2022_09'
+      - '2022_12'
+      - '2023_03'
+      - '2023_06'
+      - '2023_09'
+      - '2023_12'
+      - '2024_03'
+      - '2024_06'
+      - '2024_09'
+      - '2024_12'
+      - '2025_03'
+      - '2025_06'
+
+---
+# Synopsis: Include rules released June 2025 or prior for Azure preview only features.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Baseline
+metadata:
+  name: Azure.Preview_2025_06
+  annotations:
+    export: true
+    moduleVersion: v1.45.0
+spec:
+  configuration:
+    # Configure minimum AKS cluster version
+    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.32.5'
+  rule:
+    tag:
+      release: preview
+      ruleSet:
+      - '2020_06'
+      - '2020_09'
+      - '2020_12'
+      - '2021_03'
+      - '2021_06'
+      - '2021_09'
+      - '2021_12'
+      - '2022_03'
+      - '2022_06'
+      - '2022_09'
+      - '2022_12'
+      - '2023_03'
+      - '2023_06'
+      - '2023_09'
+      - '2023_12'
+      - '2024_03'
+      - '2024_06'
+      - '2024_09'
+      - '2024_12'
+      - '2025_03'
+      - '2025_06'

--- a/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
@@ -40,7 +40,7 @@ spec:
     AZURE_BICEP_CHECK_TOOL: false
 
     # Configures minimum AKS cluster version.
-    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.30.10'
+    AZURE_AKS_CLUSTER_MINIMUM_VERSION: '1.32.5'
 
     # Configures the minimum allowed max pods setting per node pool.
     AZURE_AKS_POOL_MINIMUM_MAXPODS: 50

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -96,7 +96,7 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult.TargetName | Should -BeIn 'cluster-B';
 
             $ruleResult[0].Reason | Should -Not -BeNullOrEmpty;
-            $ruleResult[0].Reason | Should -BeExactly "Path Properties.kubernetesVersion: The version '1.13.8' does not match the constraint '>=1.30.10'.";
+            $ruleResult[0].Reason | Should -BeExactly "Path Properties.kubernetesVersion: The version '1.13.8' does not match the constraint '>=1.32.5'.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Baseline.Tests.ps1
@@ -299,5 +299,19 @@ Describe 'Baselines' -Tag Baseline {
             $filteredResult | Should -Not -BeNullOrEmpty;
             $filteredResult.Length | Should -Be 8;
         }
+
+        It 'With Azure.GA_2025_06' {
+            $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.GA_2025_06' -WarningAction Ignore);
+            $filteredResult = @($result | Where-Object { $_.Tag.release -in 'GA'});
+            $filteredResult | Should -Not -BeNullOrEmpty;
+            $filteredResult.Length | Should -Be 477;
+        }
+
+        It 'With Azure.Preview_2025_06' {
+            $result = @(Get-PSRule -Module PSRule.Rules.Azure -Baseline 'Azure.Preview_2025_06' -WarningAction Ignore);
+            $filteredResult = @($result | Where-Object { $_.Tag.release -in 'preview'});
+            $filteredResult | Should -Not -BeNullOrEmpty;
+            $filteredResult.Length | Should -Be 8;
+        }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -50,7 +50,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.30.10",
+                "kubernetesVersion": "1.32.5",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -210,7 +210,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.30.10",
+                "kubernetesVersion": "1.32.5",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -395,7 +395,7 @@
                 "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-03')]",
                 "maxPods": 50,
                 "type": "VirtualMachineScaleSets",
-                "orchestratorVersion": "1.30.10",
+                "orchestratorVersion": "1.32.5",
                 "osType": "Linux",
                 "enableAutoScaling": false
             }
@@ -427,7 +427,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.30.10",
+                "kubernetesVersion": "1.32.5",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -628,7 +628,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.30.10",
+                "kubernetesVersion": "1.32.5",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName5'))]",
                 "agentPoolProfiles": [
                     {
@@ -831,7 +831,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.30.10",
+                "kubernetesVersion": "1.32.5",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName6'))]",
                 "agentPoolProfiles": [
                     {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -6,7 +6,7 @@
     "ResourceName": "cluster-A",
     "Name": "cluster-A",
     "Properties": {
-      "kubernetesVersion": "1.30.10",
+      "kubernetesVersion": "1.32.5",
       "dnsPrefix": "cluster-A",
       "fqdn": "cluster-A-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -18,7 +18,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "AvailabilitySet",
-          "orchestratorVersion": "1.30.10",
+          "orchestratorVersion": "1.32.5",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -204,7 +204,7 @@
     "ParentResource": null,
     "Properties": {
       "provisioningState": "Succeeded",
-      "kubernetesVersion": "1.30.10",
+      "kubernetesVersion": "1.32.5",
       "dnsPrefix": "cluster-C",
       "fqdn": "cluster-C-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -218,7 +218,7 @@
           "maxPods": 50,
           "type": "VirtualMachineScaleSets",
           "provisioningState": "Succeeded",
-          "orchestratorVersion": "1.30.10",
+          "orchestratorVersion": "1.32.5",
           "osType": "Linux",
           "enableAutoScaling": false
         }
@@ -428,7 +428,7 @@
     "Plan": null,
     "Properties": {
       "provisioningState": "Succeeded",
-      "kubernetesVersion": "1.30.10",
+      "kubernetesVersion": "1.32.5",
       "dnsPrefix": "cluster-D",
       "fqdn": "cluster-D-nnnnnnnn.hcp.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -441,7 +441,7 @@
           "maxPods": 50,
           "type": "VirtualMachineScaleSets",
           "provisioningState": "Succeeded",
-          "orchestratorVersion": "1.30.10",
+          "orchestratorVersion": "1.32.5",
           "nodeLabels": {},
           "mode": "System",
           "osType": "Linux",
@@ -655,7 +655,7 @@
       "powerState": {
         "code": "Running"
       },
-      "orchestratorVersion": "1.30.10",
+      "orchestratorVersion": "1.32.5",
       "nodeLabels": {},
       "mode": "System",
       "osType": "Linux",
@@ -725,7 +725,7 @@
       "powerState": {
         "code": "Running"
       },
-      "kubernetesVersion": "1.30.10",
+      "kubernetesVersion": "1.32.5",
       "dnsPrefix": "cluster-F",
       "fqdn": "cluster-F-00000000.hcp.region.azmk8s.io",
       "azurePortalFQDN": "cluster-F-00000000.portal.hcp.region.azmk8s.io",
@@ -746,7 +746,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.30.10",
+          "orchestratorVersion": "1.32.5",
           "nodeLabels": {},
           "mode": "System",
           "osType": "Linux",
@@ -1018,7 +1018,7 @@
     "ResourceName": "cluster-G",
     "Name": "cluster-G",
     "Properties": {
-      "kubernetesVersion": "1.30.10",
+      "kubernetesVersion": "1.32.5",
       "dnsPrefix": "cluster-G",
       "fqdn": "cluster-G-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1030,7 +1030,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.30.10",
+          "orchestratorVersion": "1.32.5",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -1193,7 +1193,7 @@
     "ResourceName": "cluster-H",
     "Name": "cluster-H",
     "Properties": {
-      "kubernetesVersion": "1.30.10",
+      "kubernetesVersion": "1.32.5",
       "dnsPrefix": "cluster-H",
       "fqdn": "cluster-H-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1205,7 +1205,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.30.10",
+          "orchestratorVersion": "1.32.5",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": []
@@ -1372,7 +1372,7 @@
     "ResourceName": "cluster-I",
     "Name": "cluster-I",
     "Properties": {
-      "kubernetesVersion": "1.30.10",
+      "kubernetesVersion": "1.32.5",
       "dnsPrefix": "cluster-I",
       "fqdn": "cluster-I-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1390,7 +1390,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.30.10",
+          "orchestratorVersion": "1.32.5",
           "mode": "System",
           "osType": "Linux",
           "osSKU": "Ubuntu",
@@ -1413,7 +1413,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.30.10",
+          "orchestratorVersion": "1.32.5",
           "mode": "User",
           "osType": "Linux",
           "osSKU": "Ubuntu",
@@ -1582,7 +1582,7 @@
     "ResourceName": "cluster-J",
     "Name": "cluster-J",
     "Properties": {
-      "kubernetesVersion": "1.30.10",
+      "kubernetesVersion": "1.32.5",
       "dnsPrefix": "cluster-J",
       "fqdn": "cluster-J-00000000.nnn.region.azmk8s.io",
       "agentPoolProfiles": [
@@ -1594,7 +1594,7 @@
           "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
           "maxPods": 30,
           "type": "VirtualMachineScaleSets",
-          "orchestratorVersion": "1.30.10",
+          "orchestratorVersion": "1.32.5",
           "osType": "Linux",
           "enableAutoScaling": false,
           "availabilityZones": null
@@ -1767,7 +1767,7 @@
       "powerState": {
         "code": "Running"
       },
-      "kubernetesVersion": "1.30.10",
+      "kubernetesVersion": "1.32.5",
       "dnsPrefix": "cluster-K",
       "fqdn": "cluster-K-00000000.hcp.eastus.azmk8s.io",
       "azurePortalFQDN": "cluster-K-00000000.portal.hcp.eastus.azmk8s.io",
@@ -1788,7 +1788,7 @@
           "powerState": {
             "code": "Running"
           },
-          "orchestratorVersion": "1.30.10",
+          "orchestratorVersion": "1.32.5",
           "mode": "System",
           "osType": "Linux",
           "osSKU": "Ubuntu",


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.45.0-B0104:

- New features:
  - Added June 2025 baselines `Azure.GA_2025_06` and `Azure.Preview_2025_06`.
    - Includes rules released before or during June 2025.
    - Marked `Azure.GA_2025_03` and `Azure.Preview_2025_03` baselines as obsolete.
- Updated rules:
  - Azure Kubernetes Service:
    - Updated `Azure.AKS.Version` to use `1.32.5` as the minimum version.

Fixes #3463 
Fixes #3465 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
