### PR TITLE
Pre-release v1.45.0-B0143

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v1.45.0-B0143 (pre-release)
+
 What's changed since pre-release v1.45.0-B0104:
 
 - New features:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.45.0-B0104:

- New features:
  - Added June 2025 baselines `Azure.GA_2025_06` and `Azure.Preview_2025_06` by @BernieWhite.
    [#3465](https://github.com/Azure/PSRule.Rules.Azure/issues/3465)
    - Includes rules released before or during June 2025.
    - Marked `Azure.GA_2025_03` and `Azure.Preview_2025_03` baselines as obsolete.
  - Added June 2025 CAF baseline `Azure.CAF_2025_06` for recent naming changes by @BernieWhite.
    [#3464](https://github.com/Azure/PSRule.Rules.Azure/issues/3464)
- Updated rules:
  - Azure Kubernetes Service:
    - Updated `Azure.AKS.Version` to use `1.32.5` as the minimum version by @BernieWhite.
      [#3463](https://github.com/Azure/PSRule.Rules.Azure/issues/3463)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
