### PR TITLE
Fixed inconsistent subnets handling #3497

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v1.45.1:
+
+- Bug fixes:
+  - Fixed inconsistent handling of subnets with `Azure.VNET.SubnetNaming` and `Azure.VNET.UseNSGs` by @BernieWhite
+    [#3497](https://github.com/Azure/PSRule.Rules.Azure/issues/3497)
+
 ## v1.45.1
 
 What's changed since v1.45.0:

--- a/docs/en/rules/Azure.VNET.SubnetNaming.md
+++ b/docs/en/rules/Azure.VNET.SubnetNaming.md
@@ -1,5 +1,5 @@
 ---
-reviewed: 2025-04-25
+reviewed: 2025-08-23
 severity: Awareness
 pillar: Operational Excellence
 category: OE:04 Tools and processes
@@ -128,7 +128,13 @@ For example:
 
 ## NOTES
 
-This rule does not check if subnets names are unique.
+This rule does not check if subnets names are unique and ignores the following subnets which are predefined by Azure:
+
+- GatewaySubnet
+- AzureBastionSubnet
+- AzureFirewallSubnet
+- AzureFirewallManagementSubnet
+- RouteServerSubnet
 
 <!-- caf:note name-format -->
 

--- a/tests/PSRule.Rules.Azure.Tests/vnet.tests.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/vnet.tests.bicep
@@ -58,7 +58,7 @@ param subnets array = [
   }
 ]
 
-var subscriptionDefautTags = {
+var subscriptionDefaultTags = {
   'ffffffff-ffff-ffff-ffff-ffffffffffff': {
     role: 'Networking'
   }
@@ -102,18 +102,20 @@ var gatewaySubnet = [
     }
   }
 ]
-var definedSubnets = [for item in subnets: {
-  name: item.name
-  properties: {
-    addressPrefix: item.addressPrefix
-    networkSecurityGroup: {
-      id: resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-${item.name}')
-    }
-    routeTable: {
-      id: resourceId('Microsoft.Network/routeTables/', 'route-${item.name}')
+var definedSubnets = [
+  for item in subnets: {
+    name: item.name
+    properties: {
+      addressPrefix: item.addressPrefix
+      networkSecurityGroup: {
+        id: resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-${item.name}')
+      }
+      routeTable: {
+        id: resourceId('Microsoft.Network/routeTables/', 'route-${item.name}')
+      }
     }
   }
-}]
+]
 var allSubnets = union(gatewaySubnet, definedSubnets)
 var vnetAddressSpace = {
   addressPrefixes: addressPrefix
@@ -126,24 +128,90 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
     addressSpace: vnetAddressSpace
     subnets: allSubnets
   }
-  tags: subscriptionDefautTags[subscription().subscriptionId]
+  tags: subscriptionDefaultTags[subscription().subscriptionId]
   dependsOn: [
     nsg
   ]
 }
 
-resource nsg 'Microsoft.Network/networkSecurityGroups@2019-04-01' = [for item in subnets: if (true) {
-  name: 'nsg-${item.name}'
-  location: location
-  properties: {
-    securityRules: item.securityRules
+resource nsg 'Microsoft.Network/networkSecurityGroups@2019-04-01' = [
+  for item in subnets: if (true) {
+    name: 'nsg-${item.name}'
+    location: location
+    properties: {
+      securityRules: item.securityRules
+    }
+    dependsOn: []
   }
-  dependsOn: []
-}]
+]
 
 resource vnet_002_subnet_extra 'Microsoft.Network/virtualNetworks/subnets@2020-05-01' = {
   name: 'vnet-002/subnet-extra'
   properties: {
     addressPrefix: '10.100.0.0/24'
+  }
+}
+
+// Additional test cases for https://github.com/Azure/PSRule.Rules.Azure/issues/3497
+// Based on work provided by @SangMinhTruong
+
+resource vnet_empty 'Microsoft.Network/virtualNetworks@2024-07-01' = {
+  name: 'vnet-empty'
+  location: location
+  tags: {
+    module: 'networking'
+  }
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+  }
+}
+
+resource vnet_separate 'Microsoft.Network/virtualNetworks@2024-07-01' = {
+  name: 'vnet-separate-subnet'
+  location: location
+  tags: {
+    module: 'networking'
+  }
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+  }
+}
+
+resource subnet_separate 'Microsoft.Network/virtualNetworks/subnets@2024-07-01' = {
+  parent: vnet_separate
+  name: 'snet-separate'
+  properties: {
+    addressPrefix: '10.0.0.0/24'
+  }
+}
+
+resource vnet_embedded 'Microsoft.Network/virtualNetworks@2024-07-01' = {
+  name: 'vnet-embedded-subnet'
+  location: location
+  tags: {
+    module: 'networking'
+  }
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+    subnets: [
+      {
+        name: 'snet-embedded'
+        properties: {
+          addressPrefix: '10.0.0.0/24'
+        }
+      }
+    ]
   }
 }

--- a/tests/PSRule.Rules.Azure.Tests/vnet.tests.json
+++ b/tests/PSRule.Rules.Azure.Tests/vnet.tests.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.9.1.41621",
-      "templateHash": "16943875226754338724"
+      "version": "0.37.4.10188",
+      "templateHash": "14588740481767783361"
     }
   },
   "parameters": {
@@ -102,7 +102,7 @@
         }
       }
     ],
-    "subscriptionDefautTags": {
+    "subscriptionDefaultTags": {
       "ffffffff-ffff-ffff-ffff-ffffffffffff": {
         "role": "Networking"
       },
@@ -161,17 +161,17 @@
         "addressSpace": "[variables('vnetAddressSpace')]",
         "subnets": "[variables('allSubnets')]"
       },
-      "tags": "[variables('subscriptionDefautTags')[subscription().subscriptionId]]",
+      "tags": "[variables('subscriptionDefaultTags')[subscription().subscriptionId]]",
       "dependsOn": [
         "nsg"
       ]
     },
     {
-      "condition": "[true()]",
       "copy": {
         "name": "nsg",
         "count": "[length(parameters('subnets'))]"
       },
+      "condition": true,
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2019-04-01",
       "name": "[format('nsg-{0}', parameters('subnets')[copyIndex()].name)]",
@@ -186,6 +186,73 @@
       "name": "vnet-002/subnet-extra",
       "properties": {
         "addressPrefix": "10.100.0.0/24"
+      }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2024-07-01",
+      "name": "vnet-empty",
+      "location": "[parameters('location')]",
+      "tags": {
+        "module": "networking"
+      },
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2024-07-01",
+      "name": "vnet-separate-subnet",
+      "location": "[parameters('location')]",
+      "tags": {
+        "module": "networking"
+      },
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2024-07-01",
+      "name": "[format('{0}/{1}', 'vnet-separate-subnet', 'snet-separate')]",
+      "properties": {
+        "addressPrefix": "10.0.0.0/24"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', 'vnet-separate-subnet')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2024-07-01",
+      "name": "vnet-embedded-subnet",
+      "location": "[parameters('location')]",
+      "tags": {
+        "module": "networking"
+      },
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "snet-embedded",
+            "properties": {
+              "addressPrefix": "10.0.0.0/24"
+            }
+          }
+        ]
       }
     }
   ]


### PR DESCRIPTION
## PR Summary

- Fixed inconsistent handling of subnets with `Azure.VNET.SubnetNaming` and `Azure.VNET.UseNSGs`.

Fixes #3497

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
