### PR TITLE
Surface Bicep restore errors during timeout

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -58,9 +58,6 @@ What's changed since v1.47.0:
   - Virtual Machine:
     - Check that virtual machines have Secure Boot enabled by @coder999999999.
       [#3728](https://github.com/Azure/PSRule.Rules.Azure/issues/3728)
-- Bug fixes:
-  - Improved Bicep expansion errors to surface captured CLI restore failures during timeout windows instead of always falling back to the generic timeout message.
-    [#2896](https://github.com/Azure/PSRule.Rules.Azure/issues/2896)
   - Virtual Machine Scale Sets:
     - Check that virtual machine scale sets have Secure Boot enabled by @coder999999999.
       [#3730](https://github.com/Azure/PSRule.Rules.Azure/issues/3730)
@@ -76,6 +73,9 @@ What's changed since v1.47.0:
 - Engineering
   - Improved documentation for expansion internals with a high-level flow diagram and code references by @BernieWhite.
     [#3715](https://github.com/Azure/PSRule.Rules.Azure/issues/3715)
+- Bug fixes:
+  - Improved Bicep expansion errors to surface captured CLI restore failures during timeout windows instead of always falling back to the generic timeout message.
+    [#2896](https://github.com/Azure/PSRule.Rules.Azure/issues/2896)
 
 ## v1.47.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -58,6 +58,9 @@ What's changed since v1.47.0:
   - Virtual Machine:
     - Check that virtual machines have Secure Boot enabled by @coder999999999.
       [#3728](https://github.com/Azure/PSRule.Rules.Azure/issues/3728)
+- Bug fixes:
+  - Improved Bicep expansion errors to surface captured CLI restore failures during timeout windows instead of always falling back to the generic timeout message.
+    [#2896](https://github.com/Azure/PSRule.Rules.Azure/issues/2896)
   - Virtual Machine Scale Sets:
     - Check that virtual machine scale sets have Secure Boot enabled by @coder999999999.
       [#3730](https://github.com/Azure/PSRule.Rules.Azure/issues/3730)

--- a/src/PSRule.Rules.Azure/Data/Bicep/BicepHelper.cs
+++ b/src/PSRule.Rules.Azure/Data/Bicep/BicepHelper.cs
@@ -399,7 +399,7 @@ internal sealed class BicepHelper
         {
             if (!bicep.WaitForExit(out var exitCode) || exitCode != 0)
             {
-                var error = bicep.HasExited ? bicep.GetError() : PSRuleResources.BicepCompileTimeout;
+                var error = GetCompileErrorMessage(bicep);
                 throw new BicepCompileException(string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.BicepCompileError, bicep.Version, path, error), null, path, bicep.Version);
             }
 
@@ -417,6 +417,12 @@ internal sealed class BicepHelper
         {
             bicep.Dispose();
         }
+    }
+
+    internal static string GetCompileErrorMessage(BicepProcess bicep)
+    {
+        var error = bicep.GetError();
+        return string.IsNullOrWhiteSpace(error) ? PSRuleResources.BicepCompileTimeout : error;
     }
 
     private static JObject ReadJsonFile(string path)

--- a/tests/PSRule.Rules.Azure.Tests/BicepHelperTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/BicepHelperTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using PSRule.Rules.Azure.Data.Bicep;
+using PSRule.Rules.Azure.Resources;
+
+namespace PSRule.Rules.Azure;
+
+public sealed class BicepHelperTests
+{
+    [Fact]
+    public void GetCompileErrorMessage_WhenTimedOutWithErrorOutput_ReturnsCapturedError()
+    {
+        using var process = StartProcess("[Console]::Error.WriteLine('Error BCP192: Unauthorized'); [Console]::Error.Flush(); Start-Sleep -Seconds 10");
+        using var bicep = new BicepHelper.BicepProcess(process, timeout: 1);
+
+        var completed = bicep.WaitForExit(out var exitCode);
+
+        Assert.False(completed);
+        Assert.Equal(-1, exitCode);
+        Assert.True(SpinWait.SpinUntil(() => bicep.GetError().Contains("Error BCP192: Unauthorized", StringComparison.Ordinal), TimeSpan.FromSeconds(2)));
+        Assert.False(process.HasExited);
+        Assert.Contains("Error BCP192: Unauthorized", BicepHelper.GetCompileErrorMessage(bicep), StringComparison.Ordinal);
+
+        StopProcess(process);
+    }
+
+    [Fact]
+    public void GetCompileErrorMessage_WhenTimedOutWithoutErrorOutput_ReturnsTimeoutMessage()
+    {
+        using var process = StartProcess("Start-Sleep -Seconds 10");
+        using var bicep = new BicepHelper.BicepProcess(process, timeout: 1);
+
+        var completed = bicep.WaitForExit(out var exitCode);
+
+        Assert.False(completed);
+        Assert.Equal(-1, exitCode);
+        Assert.Equal(PSRuleResources.BicepCompileTimeout, BicepHelper.GetCompileErrorMessage(bicep));
+
+        StopProcess(process);
+    }
+
+    [Fact]
+    public void GetCompileErrorMessage_WhenProcessExitsWithErrorOutput_ReturnsCapturedError()
+    {
+        using var process = StartProcess("[Console]::Error.WriteLine('Error BCP192: Unauthorized'); [Console]::Error.Flush(); exit 1");
+        using var bicep = new BicepHelper.BicepProcess(process, timeout: 5);
+
+        var completed = bicep.WaitForExit(out var exitCode);
+
+        Assert.True(completed);
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Error BCP192: Unauthorized", BicepHelper.GetCompileErrorMessage(bicep), StringComparison.Ordinal);
+    }
+
+    private static Process StartProcess(string command)
+    {
+        var encodedCommand = Convert.ToBase64String(Encoding.Unicode.GetBytes(command));
+        var startInfo = new ProcessStartInfo(GetPowerShellExecutable(), $"-NoLogo -NoProfile -EncodedCommand {encodedCommand}")
+        {
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        return Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start PowerShell test process.");
+    }
+
+    private static string GetPowerShellExecutable()
+    {
+        return OperatingSystem.IsWindows() ? "pwsh.exe" : "pwsh";
+    }
+
+    private static void StopProcess(Process process)
+    {
+        if (process.HasExited)
+            return;
+
+        process.Kill(entireProcessTree: true);
+        process.WaitForExit();
+    }
+}


### PR DESCRIPTION
## PR Summary

Improve Bicep expansion error handling so PSRule surfaces captured Bicep CLI error output during timeout windows instead of always falling back to the generic timeout message.

This helps diagnose failures like private ACR module restore errors, including `BCP192` and authorization failures, which were previously masked by the timeout text.

Changes in this PR:

- Update Bicep compilation error selection to prefer captured stderr when a build times out
- Keep the existing generic timeout message as a fallback when no CLI error output is available
- Add focused regression tests for:
  - timeout with captured error output
  - timeout without error output
  - normal process exit with error output

Fixes #2896

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
