### PR TITLE
add support for roledefinitions function

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,8 @@ What's changed since pre-release v1.48.0-B0088:
     [#3790](https://github.com/Azure/PSRule.Rules.Azure/issues/3790)
   - Added support for Bicep `resourceType` parameter metadata.
     [#1474](https://github.com/Azure/PSRule.Rules.Azure/issues/1474)
+  - Added support for the Bicep `roleDefinitions` function.
+    [#3776](https://github.com/Azure/PSRule.Rules.Azure/issues/3776)
 
 ## v1.48.0-B0088 (pre-release)
 

--- a/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
+++ b/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
@@ -48,6 +48,7 @@ internal static class Functions
 
     private const string FUNCTION_LIST_WITH_SECURE_OUTPUTS = "listOutputsWithSecureValues";
     private const string RESOURCE_TYPE_ROLE_DEFINITIONS = "Microsoft.Authorization/roleDefinitions";
+    private const string ROLE_DEFINITION_ID_PLACEHOLDER = "00000000-0000-0000-0000-000000000000";
 
     private const string FORMAT_ISO8601 = "yyyy-MM-ddTHH:mm:ssZ";
     private const string FORMAT_AZURE_DATETIME = "M/d/yyyy h:mm:ss tt";
@@ -1288,12 +1289,24 @@ internal static class Functions
         if (!ExpressionHelpers.TryString(args[0], out var roleName))
             throw ArgumentInvalidString(nameof(RoleDefinitions), PROPERTY_ROLE_NAME);
 
-        var id = SubscriptionResourceId(context, new object[] { RESOURCE_TYPE_ROLE_DEFINITIONS, roleName }) as string;
+        var id = RoleDefinitionResourceId(context, ROLE_DEFINITION_ID_PLACEHOLDER);
         return new JObject
         {
             [PROPERTY_ID] = id,
-            [PROPERTY_ROLE_DEFINITION_ID] = roleName,
+            [PROPERTY_ROLE_DEFINITION_ID] = ROLE_DEFINITION_ID_PLACEHOLDER,
         };
+    }
+
+    private static string RoleDefinitionResourceId(ITemplateContext context, string roleDefinitionId)
+    {
+        var args = new object[] { RESOURCE_TYPE_ROLE_DEFINITIONS, roleDefinitionId };
+        if (context.Deployment != null && context.Deployment.DeploymentScope == DeploymentScope.ManagementGroup)
+            return ManagementGroupResourceId(context, args) as string;
+
+        if (context.Deployment != null && context.Deployment.DeploymentScope == DeploymentScope.Tenant)
+            return TenantResourceId(context, args) as string;
+
+        return SubscriptionResourceId(context, args) as string;
     }
 
     #endregion Resource

--- a/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
+++ b/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
@@ -42,8 +42,11 @@ internal static class Functions
     private const string PROPERTY_PORT = "port";
     private const string PROPERTY_PATH = "path";
     private const string PROPERTY_QUERY = "query";
+    private const string PROPERTY_ROLE_NAME = "roleName";
+    private const string PROPERTY_ROLE_DEFINITION_ID = "roleDefinitionId";
 
     private const string FUNCTION_LIST_WITH_SECURE_OUTPUTS = "listOutputsWithSecureValues";
+    private const string RESOURCE_TYPE_ROLE_DEFINITIONS = "Microsoft.Authorization/roleDefinitions";
 
     private const string FORMAT_ISO8601 = "yyyy-MM-ddTHH:mm:ssZ";
     private const string FORMAT_AZURE_DATETIME = "M/d/yyyy h:mm:ss tt";
@@ -136,6 +139,7 @@ internal static class Functions
         new FunctionDescriptor("subscriptionResourceId", SubscriptionResourceId),
         new FunctionDescriptor("tenantResourceId", TenantResourceId),
         new FunctionDescriptor("managementGroupResourceId", ManagementGroupResourceId),
+        new FunctionDescriptor("roleDefinitions", RoleDefinitions),
 
         // Scope
         new FunctionDescriptor("resourceGroup", ResourceGroup),
@@ -1270,6 +1274,25 @@ internal static class Functions
 
         var managementGroupName = context.ManagementGroup.Name;
         return ResourceHelper.CombineResourceId(managementGroupName, resourceType, name);
+    }
+
+    /// <summary>
+    /// roleDefinitions(roleName)
+    /// </summary>
+    internal static object RoleDefinitions(ITemplateContext context, object[] args)
+    {
+        if (CountArgs(args) != 1)
+            throw ArgumentsOutOfRange(nameof(RoleDefinitions), args);
+
+        if (!ExpressionHelpers.TryString(args[0], out var roleName))
+            throw ArgumentInvalidString(nameof(RoleDefinitions), PROPERTY_ROLE_NAME);
+
+        var id = SubscriptionResourceId(context, new object[] { RESOURCE_TYPE_ROLE_DEFINITIONS, roleName }) as string;
+        return new JObject
+        {
+            [PROPERTY_ID] = id,
+            [PROPERTY_ROLE_DEFINITION_ID] = roleName,
+        };
     }
 
     #endregion Resource

--- a/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
+++ b/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
@@ -42,6 +42,7 @@ internal static class Functions
     private const string PROPERTY_PORT = "port";
     private const string PROPERTY_PATH = "path";
     private const string PROPERTY_QUERY = "query";
+    private const string PROPERTY_ID = "id";
     private const string PROPERTY_ROLE_NAME = "roleName";
     private const string PROPERTY_ROLE_DEFINITION_ID = "roleDefinitionId";
 

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/ExpressionBuilderTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/ExpressionBuilderTests.cs
@@ -156,7 +156,7 @@ public sealed class ExpressionBuilderTests
 
         var actual = Build(context, "[roleDefinitions('Contributor').id]") as JValue;
 
-        Assert.Equal("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.Authorization/roleDefinitions/Contributor", actual.Value<string>());
+        Assert.Equal("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000", actual.Value<string>());
     }
 
     private static object Build(TemplateContext context, string expression)

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/ExpressionBuilderTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/ExpressionBuilderTests.cs
@@ -154,9 +154,9 @@ public sealed class ExpressionBuilderTests
     {
         var context = GetContext();
 
-        var actual = Build(context, "[roleDefinitions('Contributor').id]") as string;
+        var actual = Build(context, "[roleDefinitions('Contributor').id]") as JValue;
 
-        Assert.Equal("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.Authorization/roleDefinitions/Contributor", actual);
+        Assert.Equal("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.Authorization/roleDefinitions/Contributor", actual.Value<string>());
     }
 
     private static object Build(TemplateContext context, string expression)

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/ExpressionBuilderTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/ExpressionBuilderTests.cs
@@ -149,6 +149,16 @@ public sealed class ExpressionBuilderTests
         Assert.NotNull(actual);
     }
 
+    [Fact]
+    public void BuildExpressionWithRoleDefinitions()
+    {
+        var context = GetContext();
+
+        var actual = Build(context, "[roleDefinitions('Contributor').id]") as string;
+
+        Assert.Equal("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.Authorization/roleDefinitions/Contributor", actual);
+    }
+
     private static object Build(TemplateContext context, string expression)
     {
         var builder = new ExpressionBuilder();

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
@@ -1004,11 +1004,22 @@ public sealed class FunctionTests
     public void RoleDefinitions()
     {
         var context = GetContext();
+        var roleDefinitionId = "00000000-0000-0000-0000-000000000000";
 
         var actual = Functions.RoleDefinitions(context, ["Contributor"]) as JObject;
         Assert.NotNull(actual);
-        Assert.Equal("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.Authorization/roleDefinitions/Contributor", actual["id"].Value<string>());
-        Assert.Equal("Contributor", actual["roleDefinitionId"].Value<string>());
+        Assert.Equal($"/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.Authorization/roleDefinitions/{roleDefinitionId}", actual["id"].Value<string>());
+        Assert.Equal(roleDefinitionId, actual["roleDefinitionId"].Value<string>());
+
+        context = GetContext();
+        context.EnterDeployment("unit-test", JObject.Parse("{ \"$schema\": \"https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#\", \"contentVersion\": \"1.0.0.0\" }"), isNested: false);
+        actual = Functions.RoleDefinitions(context, ["Contributor"]) as JObject;
+        Assert.Equal($"/providers/Microsoft.Management/managementGroups/psrule-test/providers/Microsoft.Authorization/roleDefinitions/{roleDefinitionId}", actual["id"].Value<string>());
+
+        context = GetContext();
+        context.EnterDeployment("unit-test", JObject.Parse("{ \"$schema\": \"https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#\", \"contentVersion\": \"1.0.0.0\" }"), isNested: false);
+        actual = Functions.RoleDefinitions(context, ["Contributor"]) as JObject;
+        Assert.Equal($"/providers/Microsoft.Authorization/roleDefinitions/{roleDefinitionId}", actual["id"].Value<string>());
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.RoleDefinitions(context, null));
         Assert.Throws<ExpressionArgumentException>(() => Functions.RoleDefinitions(context, []));

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
@@ -999,6 +999,23 @@ public sealed class FunctionTests
         Assert.Throws<ExpressionArgumentException>(() => Functions.ManagementGroupResourceId(context, ["Unit.Test/type", 1]));
     }
 
+    [Fact]
+    [Trait(TRAIT, TRAIT_RESOURCE)]
+    public void RoleDefinitions()
+    {
+        var context = GetContext();
+
+        var actual = Functions.RoleDefinitions(context, ["Contributor"]) as JObject;
+        Assert.NotNull(actual);
+        Assert.Equal("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.Authorization/roleDefinitions/Contributor", actual["id"].Value<string>());
+        Assert.Equal("Contributor", actual["roleDefinitionId"].Value<string>());
+
+        Assert.Throws<ExpressionArgumentException>(() => Functions.RoleDefinitions(context, null));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.RoleDefinitions(context, []));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.RoleDefinitions(context, ["Contributor", "Owner"]));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.RoleDefinitions(context, [1]));
+    }
+
     #endregion Resource
 
     #region Scope

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
@@ -1014,7 +1014,7 @@ public sealed class FunctionTests
         context = GetContext();
         context.EnterDeployment("unit-test", JObject.Parse("{ \"$schema\": \"https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#\", \"contentVersion\": \"1.0.0.0\" }"), isNested: false);
         actual = Functions.RoleDefinitions(context, ["Contributor"]) as JObject;
-        Assert.Equal($"/providers/Microsoft.Management/managementGroups/psrule-test/providers/Microsoft.Authorization/roleDefinitions/{roleDefinitionId}", actual["id"].Value<string>());
+        Assert.Equal($"/providers/Microsoft.Management/managementGroups/mg1/providers/Microsoft.Authorization/roleDefinitions/{roleDefinitionId}", actual["id"].Value<string>());
 
         context = GetContext();
         context.EnterDeployment("unit-test", JObject.Parse("{ \"$schema\": \"https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#\", \"contentVersion\": \"1.0.0.0\" }"), isNested: false);


### PR DESCRIPTION
## PR Summary

- Add support for the Bicep-emitted `roleDefinitions(...)` ARM expression function.
- Return the expected `id` and `roleDefinitionId` fields so expressions like `roleDefinitions('Contributor').id` can expand correctly.
- Add focused unit coverage for direct function evaluation and expression-builder property access.
- Update the changelog.

Fixes #3776

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section