### PR TITLE
Bump YamlDotNet to compatible version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,7 @@ updates:
           - Microsoft.PowerShell.SDK
     ignore:
       - dependency-name: gitversion.tool
+      - dependency-name: YamlDotNet # Ignore YamlDotNet updates until the next major release to avoid breaking changes in PSRule
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: github-actions
     directory: '/'

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,8 +30,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v1.48.0-B0228:
+
+- General improvements:
   - Added support for resolving filtered subnet IDs from existing virtual networks during Bicep expansion.
     [#2159](https://github.com/Azure/PSRule.Rules.Azure/issues/2159)
+- Engineering:
+  - Bump YamlDotNet to 11.2.5.
 
 ## v1.48.0-B0228 (pre-release)
 

--- a/src/PSRule.Rules.Azure.Patterns/PSRule.Rules.Azure.Patterns.csproj
+++ b/src/PSRule.Rules.Azure.Patterns/PSRule.Rules.Azure.Patterns.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Azure.Core" Version="1.60.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
     <PackageReference Include="System.Collections.Immutable" Version="10.0.9" />
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
+    <PackageReference Include="YamlDotNet" Version="11.2.5-unity-compatible-0001" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PSRule.Rules.Azure.Patterns/packages.lock.json
+++ b/src/PSRule.Rules.Azure.Patterns/packages.lock.json
@@ -85,9 +85,9 @@
       },
       "YamlDotNet": {
         "type": "Direct",
-        "requested": "[11.2.1, )",
-        "resolved": "11.2.1",
-        "contentHash": "tBt8K+korVfrjH9wyDEhiLKxbs8qoLCLIFwvYgkSUuMC9//w3z0cFQ8LQAI/5MCKq+BMil0cfRTRvPeE7eXhQw=="
+        "requested": "[11.2.5-unity-compatible-0001, )",
+        "resolved": "11.2.5-unity-compatible-0001",
+        "contentHash": "hTuH4pqV4FSfae9YDAC8dYsqseNwdgwE+Q1aEg5blGCII+Sr5OEvKSPM2LW/Ri8vtfQViYHXMqadfzFsxGkPnQ=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",

--- a/src/PSRule.Rules.Azure.Tool/packages.lock.json
+++ b/src/PSRule.Rules.Azure.Tool/packages.lock.json
@@ -617,7 +617,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.3, )",
-          "YamlDotNet": "[11.2.1, )"
+          "YamlDotNet": "[11.2.5-unity-compatible-0001, )"
         }
       }
     },

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.csproj
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.csproj
@@ -23,7 +23,7 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="All" />
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
+    <PackageReference Include="YamlDotNet" Version="11.2.5-unity-compatible-0001" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PSRule.Rules.Azure/packages.lock.json
+++ b/src/PSRule.Rules.Azure/packages.lock.json
@@ -41,9 +41,9 @@
       },
       "YamlDotNet": {
         "type": "Direct",
-        "requested": "[11.2.1, )",
-        "resolved": "11.2.1",
-        "contentHash": "tBt8K+korVfrjH9wyDEhiLKxbs8qoLCLIFwvYgkSUuMC9//w3z0cFQ8LQAI/5MCKq+BMil0cfRTRvPeE7eXhQw=="
+        "requested": "[11.2.5-unity-compatible-0001, )",
+        "resolved": "11.2.5-unity-compatible-0001",
+        "contentHash": "hTuH4pqV4FSfae9YDAC8dYsqseNwdgwE+Q1aEg5blGCII+Sr5OEvKSPM2LW/Ri8vtfQViYHXMqadfzFsxGkPnQ=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",

--- a/src/SDK/packages.lock.json
+++ b/src/SDK/packages.lock.json
@@ -43,14 +43,14 @@
       },
       "YamlDotNet": {
         "type": "Transitive",
-        "resolved": "11.2.1",
-        "contentHash": "tBt8K+korVfrjH9wyDEhiLKxbs8qoLCLIFwvYgkSUuMC9//w3z0cFQ8LQAI/5MCKq+BMil0cfRTRvPeE7eXhQw=="
+        "resolved": "11.2.5-unity-compatible-0001",
+        "contentHash": "hTuH4pqV4FSfae9YDAC8dYsqseNwdgwE+Q1aEg5blGCII+Sr5OEvKSPM2LW/Ri8vtfQViYHXMqadfzFsxGkPnQ=="
       },
       "Microsoft.PSRule.Rules.Azure.Core": {
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.3, )",
-          "YamlDotNet": "[11.2.1, )"
+          "YamlDotNet": "[11.2.5-unity-compatible-0001, )"
         }
       }
     }


### PR DESCRIPTION
## PR Summary

- Bump YamlDotNet to 11.2.5 to maintain compatibility with PSRule v2.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
