### PR TITLE
feat(fleet): add Azure.Fleet.SecureBoot rule (AZR-000545)

### DIFF
--- a/data/resource-type-mapping.json
+++ b/data/resource-type-mapping.json
@@ -352,20 +352,20 @@
     "displayName": "Enable AKS Container insights"
   },
   {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "OE:04 Continuous integration",
-    "resourceType": "Microsoft.ContainerService/managedClusters",
-    "ruleId": "Azure.AKS.DNSPrefix",
-    "displayName": "Use valid AKS cluster DNS prefix"
-  },
-  {
     "severity": "Important",
     "pillar": "Security",
     "category": "Azure resources",
     "resourceType": "Microsoft.ContainerService/managedClusters",
     "ruleId": "Azure.AKS.DefenderProfile",
     "displayName": "Enable Defender profile"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "OE:04 Continuous integration",
+    "resourceType": "Microsoft.ContainerService/managedClusters",
+    "ruleId": "Azure.AKS.DNSPrefix",
+    "displayName": "Use valid AKS cluster DNS prefix"
   },
   {
     "severity": "Important",
@@ -632,6 +632,22 @@
     "displayName": "Kubernetes Cluster version is old"
   },
   {
+    "severity": "Important",
+    "pillar": "Cost Optimization",
+    "category": "CO:06 Usage and billing increments",
+    "resourceType": "Microsoft.Insights/scheduledQueryRules",
+    "ruleId": "Azure.Alert.HighFrequencyQuery",
+    "displayName": "Scheduled Query Alert is configured to use a high frequency query"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Cost Optimization",
+    "category": "CO:13 Personnel time",
+    "resourceType": "Microsoft.Insights/metricAlerts",
+    "ruleId": "Azure.Alert.MetricAutoMitigate",
+    "displayName": "Metric Alert requires manual mitigation"
+  },
+  {
     "severity": "Awareness",
     "pillar": "Operational Excellence",
     "category": "OE:04 Tools and processes",
@@ -657,22 +673,6 @@
   },
   {
     "severity": "Important",
-    "pillar": "Security",
-    "category": "Design",
-    "resourceType": "Microsoft.ApiManagement/service",
-    "ruleId": "Azure.APIM.CORSPolicy",
-    "displayName": "Avoid wildcards in APIM CORS policies"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "Design",
-    "resourceType": "Microsoft.ApiManagement/service/policies",
-    "ruleId": "Azure.APIM.CORSPolicy",
-    "displayName": "Avoid wildcards in APIM CORS policies"
-  },
-  {
-    "severity": "Important",
     "pillar": "Reliability",
     "category": "RE:04 Target metrics",
     "resourceType": "Microsoft.ApiManagement/service",
@@ -686,6 +686,22 @@
     "resourceType": "Microsoft.ApiManagement/service",
     "ruleId": "Azure.APIM.Ciphers",
     "displayName": "Use secure ciphers for API Management"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "Design",
+    "resourceType": "Microsoft.ApiManagement/service",
+    "ruleId": "Azure.APIM.CORSPolicy",
+    "displayName": "Avoid wildcards in APIM CORS policies"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "Design",
+    "resourceType": "Microsoft.ApiManagement/service/policies",
+    "ruleId": "Azure.APIM.CORSPolicy",
+    "displayName": "Avoid wildcards in APIM CORS policies"
   },
   {
     "severity": "Critical",
@@ -937,54 +953,6 @@
   },
   {
     "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:05 Regions and availability zones",
-    "resourceType": "Microsoft.Web/hostingEnvironments",
-    "ruleId": "Azure.ASE.AvailabilityZone",
-    "displayName": "Deploy app service environments using availability zones"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Operational Excellence",
-    "category": "Infrastructure provisioning",
-    "resourceType": "Microsoft.Web/hostingEnvironments",
-    "ruleId": "Azure.ASE.MigrateV3",
-    "displayName": "Migrate to App Service Environment v3"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "Repeatable infrastructure",
-    "resourceType": "Microsoft.Network/applicationSecurityGroups",
-    "ruleId": "Azure.ASG.Name",
-    "displayName": "Use valid ASG names"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:04 Target metrics",
-    "resourceType": "Microsoft.DesktopVirtualization/hostPools",
-    "ruleId": "Azure.AVD.ScheduleAgentUpdate",
-    "displayName": "Schedule agent updates for host pools"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Cost Optimization",
-    "category": "CO:06 Usage and billing increments",
-    "resourceType": "Microsoft.Insights/scheduledQueryRules",
-    "ruleId": "Azure.Alert.HighFrequencyQuery",
-    "displayName": "Scheduled Query Alert is configured to use a high frequency query"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Cost Optimization",
-    "category": "CO:13 Personnel time",
-    "resourceType": "Microsoft.Insights/metricAlerts",
-    "ruleId": "Azure.Alert.MetricAutoMitigate",
-    "displayName": "Metric Alert requires manual mitigation"
-  },
-  {
-    "severity": "Important",
     "pillar": "Security",
     "category": "SE:10 Monitoring and threat detection",
     "resourceType": "Microsoft.AppConfiguration/configurationStores",
@@ -1056,14 +1024,6 @@
     "displayName": "App Configuration Store replica location is not allowed"
   },
   {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:04 Target metrics",
-    "resourceType": "Microsoft.AppConfiguration/configurationStores",
-    "ruleId": "Azure.AppConfig.SKU",
-    "displayName": "Use production App Configuration SKU"
-  },
-  {
     "severity": "Critical",
     "pillar": "Security",
     "category": "SE:09 Application secrets",
@@ -1078,6 +1038,14 @@
     "resourceType": "Microsoft.AppConfiguration/configurationStores/keyValues",
     "ruleId": "Azure.AppConfig.SecretLeak",
     "displayName": "App Configuration Store key value is secret"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:04 Target metrics",
+    "resourceType": "Microsoft.AppConfiguration/configurationStores",
+    "ruleId": "Azure.AppConfig.SKU",
+    "displayName": "Use production App Configuration SKU"
   },
   {
     "severity": "Important",
@@ -1248,22 +1216,6 @@
     "displayName": "Use workspace-based App Insights resources"
   },
   {
-    "severity": "Awareness",
-    "pillar": "Performance Efficiency",
-    "category": "PE:05 Scaling and partitioning",
-    "resourceType": "Microsoft.Web/sites",
-    "ruleId": "Azure.AppService.ARRAffinity",
-    "displayName": "Disable Application Request Routing"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Performance Efficiency",
-    "category": "PE:05 Scaling and partitioning",
-    "resourceType": "Microsoft.Web/sites/slots",
-    "ruleId": "Azure.AppService.ARRAffinity",
-    "displayName": "Disable Application Request Routing"
-  },
-  {
     "severity": "Important",
     "pillar": "Reliability",
     "category": "Application design",
@@ -1278,6 +1230,22 @@
     "resourceType": "Microsoft.Web/sites/slots",
     "ruleId": "Azure.AppService.AlwaysOn",
     "displayName": "Use App Service Always On"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Performance Efficiency",
+    "category": "PE:05 Scaling and partitioning",
+    "resourceType": "Microsoft.Web/sites",
+    "ruleId": "Azure.AppService.ARRAffinity",
+    "displayName": "Disable Application Request Routing"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Performance Efficiency",
+    "category": "PE:05 Scaling and partitioning",
+    "resourceType": "Microsoft.Web/sites/slots",
+    "ruleId": "Azure.AppService.ARRAffinity",
+    "displayName": "Disable Application Request Routing"
   },
   {
     "severity": "Important",
@@ -1513,6 +1481,30 @@
   },
   {
     "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:05 Regions and availability zones",
+    "resourceType": "Microsoft.Web/hostingEnvironments",
+    "ruleId": "Azure.ASE.AvailabilityZone",
+    "displayName": "Deploy app service environments using availability zones"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Operational Excellence",
+    "category": "Infrastructure provisioning",
+    "resourceType": "Microsoft.Web/hostingEnvironments",
+    "ruleId": "Azure.ASE.MigrateV3",
+    "displayName": "Migrate to App Service Environment v3"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "Repeatable infrastructure",
+    "resourceType": "Microsoft.Network/applicationSecurityGroups",
+    "ruleId": "Azure.ASG.Name",
+    "displayName": "Use valid ASG names"
+  },
+  {
+    "severity": "Important",
     "pillar": "Security",
     "category": "Monitor",
     "resourceType": "Microsoft.Automation/automationAccounts",
@@ -1601,11 +1593,11 @@
   },
   {
     "severity": "Important",
-    "pillar": "Security",
-    "category": "Security design principles",
-    "resourceType": "Microsoft.DataProtection/backupVaults",
-    "ruleId": "Azure.BV.Immutable",
-    "displayName": "Immutability"
+    "pillar": "Reliability",
+    "category": "RE:04 Target metrics",
+    "resourceType": "Microsoft.DesktopVirtualization/hostPools",
+    "ruleId": "Azure.AVD.ScheduleAgentUpdate",
+    "displayName": "Schedule agent updates for host pools"
   },
   {
     "severity": "Awareness",
@@ -1614,6 +1606,14 @@
     "resourceType": "Microsoft.Network/bastionHosts",
     "ruleId": "Azure.Bastion.Name",
     "displayName": "Use valid names"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "Security design principles",
+    "resourceType": "Microsoft.DataProtection/backupVaults",
+    "ruleId": "Azure.BV.Immutable",
+    "displayName": "Immutability"
   },
   {
     "severity": "Awareness",
@@ -1912,20 +1912,28 @@
     "displayName": "Cosmos DB for Table account resources must use standard naming"
   },
   {
-    "severity": "Important",
+    "severity": "Critical",
     "pillar": "Security",
-    "category": "SE:08 Hardening resources",
-    "resourceType": "Microsoft.Network/dnsZones",
-    "ruleId": "Azure.DNS.DNSSEC",
-    "displayName": "DNS Zone is not signed"
+    "category": "SE:06 Network controls",
+    "resourceType": "Microsoft.Databricks/workspaces",
+    "ruleId": "Azure.Databricks.PublicAccess",
+    "displayName": "Azure Databricks workspaces should disable public network access"
   },
   {
-    "severity": "Important",
+    "severity": "Critical",
     "pillar": "Security",
-    "category": "SE:08 Hardening resources",
-    "resourceType": "Microsoft.Network/dnsZones/dnssecConfigs",
-    "ruleId": "Azure.DNS.DNSSEC",
-    "displayName": "DNS Zone is not signed"
+    "category": "SE:06 Network controls",
+    "resourceType": "Microsoft.Databricks/workspaces",
+    "ruleId": "Azure.Databricks.SecureConnectivity",
+    "displayName": "Enable secure connectivity for Databricks workspaces"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Performance Efficiency",
+    "category": "PE:03 Selecting services",
+    "resourceType": "Microsoft.Databricks/workspaces",
+    "ruleId": "Azure.Databricks.SKU",
+    "displayName": "Ensure Databricks workspaces are non-trial SKUs for production workloads"
   },
   {
     "severity": "Awareness",
@@ -1942,30 +1950,6 @@
     "resourceType": "Microsoft.DataFactory/factories",
     "ruleId": "Azure.DataFactory.Version",
     "displayName": "Use Data Factory v2"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "SE:06 Network controls",
-    "resourceType": "Microsoft.Databricks/workspaces",
-    "ruleId": "Azure.Databricks.PublicAccess",
-    "displayName": "Azure Databricks workspaces should disable public network access"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Performance Efficiency",
-    "category": "PE:03 Selecting services",
-    "resourceType": "Microsoft.Databricks/workspaces",
-    "ruleId": "Azure.Databricks.SKU",
-    "displayName": "Ensure Databricks workspaces are non-trial SKUs for production workloads"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "SE:06 Network controls",
-    "resourceType": "Microsoft.Databricks/workspaces",
-    "ruleId": "Azure.Databricks.SecureConnectivity",
-    "displayName": "Enable secure connectivity for Databricks workspaces"
   },
   {
     "severity": "Critical",
@@ -2040,22 +2024,6 @@
     "displayName": "Set Microsoft Defender for open-source relational databases to the Standard tier"
   },
   {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "SE:10 Monitoring and threat detection",
-    "resourceType": "Microsoft.Security/pricings",
-    "ruleId": "Azure.Defender.SQL",
-    "displayName": "Configure Microsoft Defender for SQL to the Standard tier"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "SE:10 Monitoring and threat detection",
-    "resourceType": "Microsoft.Security/pricings",
-    "ruleId": "Azure.Defender.SQLOnVM",
-    "displayName": "Configure Microsoft Defender for SQL Servers on machines to the Standard tier"
-  },
-  {
     "severity": "Important",
     "pillar": "Security",
     "category": "SE:12 Incident response",
@@ -2070,6 +2038,22 @@
     "resourceType": "Microsoft.Security/pricings",
     "ruleId": "Azure.Defender.Servers",
     "displayName": "Configure Microsoft Defender for Servers to the Standard tier and P2"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "SE:10 Monitoring and threat detection",
+    "resourceType": "Microsoft.Security/pricings",
+    "ruleId": "Azure.Defender.SQL",
+    "displayName": "Configure Microsoft Defender for SQL to the Standard tier"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "SE:10 Monitoring and threat detection",
+    "resourceType": "Microsoft.Security/pricings",
+    "ruleId": "Azure.Defender.SQLOnVM",
+    "displayName": "Configure Microsoft Defender for SQL Servers on machines to the Standard tier"
   },
   {
     "severity": "Critical",
@@ -2174,6 +2158,22 @@
     "resourceType": "Microsoft.DevCenter/projects",
     "ruleId": "Azure.DevBox.ProjectLimit",
     "displayName": "Limit number of Dev Boxes per user"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "SE:08 Hardening resources",
+    "resourceType": "Microsoft.Network/dnsZones",
+    "ruleId": "Azure.DNS.DNSSEC",
+    "displayName": "DNS Zone is not signed"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "SE:08 Hardening resources",
+    "resourceType": "Microsoft.Network/dnsZones/dnssecConfigs",
+    "ruleId": "Azure.DNS.DNSSEC",
+    "displayName": "DNS Zone is not signed"
   },
   {
     "severity": "Important",
@@ -2394,14 +2394,6 @@
   {
     "severity": "Important",
     "pillar": "Security",
-    "category": "SE:08 Hardening resources",
-    "resourceType": "Microsoft.AzureFleet/fleets",
-    "ruleId": "Azure.Fleet.SecureBoot",
-    "displayName": "Azure Fleet Secure Boot is not enabled"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
     "category": "SE:10 Monitoring and threat detection",
     "resourceType": "Microsoft.Cdn/profiles",
     "ruleId": "Azure.FrontDoor.Logs",
@@ -2459,14 +2451,6 @@
     "severity": "Important",
     "pillar": "Reliability",
     "category": "Health modeling",
-    "resourceType": "Microsoft.Network/Frontdoors/HealthProbeSettings",
-    "ruleId": "Azure.FrontDoor.Probe",
-    "displayName": "Use Health Probes for Front Door backends"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "Health modeling",
     "resourceType": "Microsoft.Network/frontDoors",
     "ruleId": "Azure.FrontDoor.Probe",
     "displayName": "Use Health Probes for Front Door backends"
@@ -2476,8 +2460,8 @@
     "pillar": "Reliability",
     "category": "Health modeling",
     "resourceType": "Microsoft.Network/Frontdoors/HealthProbeSettings",
-    "ruleId": "Azure.FrontDoor.ProbeMethod",
-    "displayName": "Use HEAD health probes for Front Door backends"
+    "ruleId": "Azure.FrontDoor.Probe",
+    "displayName": "Use Health Probes for Front Door backends"
   },
   {
     "severity": "Important",
@@ -2492,6 +2476,14 @@
     "pillar": "Reliability",
     "category": "Health modeling",
     "resourceType": "Microsoft.Network/Frontdoors/HealthProbeSettings",
+    "ruleId": "Azure.FrontDoor.ProbeMethod",
+    "displayName": "Use HEAD health probes for Front Door backends"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "Health modeling",
+    "resourceType": "Microsoft.Network/frontDoors",
     "ruleId": "Azure.FrontDoor.ProbePath",
     "displayName": "Use a Dedicated Health Endpoint for Front Door backends"
   },
@@ -2499,7 +2491,7 @@
     "severity": "Important",
     "pillar": "Reliability",
     "category": "Health modeling",
-    "resourceType": "Microsoft.Network/frontDoors",
+    "resourceType": "Microsoft.Network/Frontdoors/HealthProbeSettings",
     "ruleId": "Azure.FrontDoor.ProbePath",
     "displayName": "Use a Dedicated Health Endpoint for Front Door backends"
   },
@@ -2873,62 +2865,6 @@
   },
   {
     "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:05 Redundancy",
-    "resourceType": "Microsoft.DocumentDB/cassandraClusters",
-    "ruleId": "Azure.MICassandra.AvailabilityZone",
-    "displayName": "Use zone redundant Managed Instance for Apache Cassandra clusters"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:05 Redundancy",
-    "resourceType": "Microsoft.DocumentDB/cassandraClusters/dataCenters",
-    "ruleId": "Azure.MICassandra.AvailabilityZone",
-    "displayName": "Use zone redundant Managed Instance for Apache Cassandra clusters"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Cost Optimization",
-    "category": "CO:06 Usage and billing increments",
-    "resourceType": "Microsoft.MachineLearningServices/workspaces/computes",
-    "ruleId": "Azure.ML.ComputeIdleShutdown",
-    "displayName": "Configure idle shutdown for compute instances"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "Connectivity",
-    "resourceType": "Microsoft.MachineLearningServices/workspaces/computes",
-    "ruleId": "Azure.ML.ComputeVnet",
-    "displayName": "Host ML Compute in VNet"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "Authentication",
-    "resourceType": "Microsoft.MachineLearningServices/workspaces/computes",
-    "ruleId": "Azure.ML.DisableLocalAuth",
-    "displayName": "Disable local authentication on ML Compute"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "Connectivity",
-    "resourceType": "Microsoft.MachineLearningServices/workspaces",
-    "ruleId": "Azure.ML.PublicAccess",
-    "displayName": "ML Workspace has public access disabled"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "Identity and Access Management",
-    "resourceType": "Microsoft.MachineLearningServices/workspaces",
-    "ruleId": "Azure.ML.UserManagedIdentity",
-    "displayName": "Azure Machine Learning workspaces should use user-assigned managed identity"
-  },
-  {
-    "severity": "Important",
     "pillar": "Security",
     "category": "Network security and containment",
     "resourceType": "Microsoft.DBforMariaDB/servers",
@@ -3070,6 +3006,62 @@
     "resourceType": "Microsoft.DBforMariaDB/servers/virtualNetworkRules",
     "ruleId": "Azure.MariaDB.VNETRuleName",
     "displayName": "Use valid VNET rule names"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:05 Redundancy",
+    "resourceType": "Microsoft.DocumentDB/cassandraClusters",
+    "ruleId": "Azure.MICassandra.AvailabilityZone",
+    "displayName": "Use zone redundant Managed Instance for Apache Cassandra clusters"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:05 Redundancy",
+    "resourceType": "Microsoft.DocumentDB/cassandraClusters/dataCenters",
+    "ruleId": "Azure.MICassandra.AvailabilityZone",
+    "displayName": "Use zone redundant Managed Instance for Apache Cassandra clusters"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Cost Optimization",
+    "category": "CO:06 Usage and billing increments",
+    "resourceType": "Microsoft.MachineLearningServices/workspaces/computes",
+    "ruleId": "Azure.ML.ComputeIdleShutdown",
+    "displayName": "Configure idle shutdown for compute instances"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "Connectivity",
+    "resourceType": "Microsoft.MachineLearningServices/workspaces/computes",
+    "ruleId": "Azure.ML.ComputeVnet",
+    "displayName": "Host ML Compute in VNet"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "Authentication",
+    "resourceType": "Microsoft.MachineLearningServices/workspaces/computes",
+    "ruleId": "Azure.ML.DisableLocalAuth",
+    "displayName": "Disable local authentication on ML Compute"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "Connectivity",
+    "resourceType": "Microsoft.MachineLearningServices/workspaces",
+    "ruleId": "Azure.ML.PublicAccess",
+    "displayName": "ML Workspace has public access disabled"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "Identity and Access Management",
+    "resourceType": "Microsoft.MachineLearningServices/workspaces",
+    "ruleId": "Azure.ML.UserManagedIdentity",
+    "displayName": "Azure Machine Learning workspaces should use user-assigned managed identity"
   },
   {
     "severity": "Critical",
@@ -3625,46 +3617,6 @@
   },
   {
     "severity": "Important",
-    "pillar": "Security",
-    "category": "Security design principles",
-    "resourceType": "Microsoft.RecoveryServices/vaults",
-    "ruleId": "Azure.RSV.Immutable",
-    "displayName": "Immutability"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "Repeatable infrastructure",
-    "resourceType": "Microsoft.RecoveryServices/vaults",
-    "ruleId": "Azure.RSV.Name",
-    "displayName": "Use valid names"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "Design",
-    "resourceType": "Microsoft.RecoveryServices/vaults",
-    "ruleId": "Azure.RSV.ReplicationAlert",
-    "displayName": "Use geo-replicated storage"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "Design",
-    "resourceType": "Microsoft.RecoveryServices/vaults",
-    "ruleId": "Azure.RSV.StorageType",
-    "displayName": "Use geo-replicated storage"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "Design",
-    "resourceType": "Microsoft.RecoveryServices/vaults/backupconfig",
-    "ruleId": "Azure.RSV.StorageType",
-    "displayName": "Use geo-replicated storage"
-  },
-  {
-    "severity": "Important",
     "pillar": "Reliability",
     "category": "RE:05 Regions and availability zones",
     "resourceType": "Microsoft.Cache/redis",
@@ -3830,6 +3782,206 @@
     "resourceType": "Microsoft.Network/routeTables",
     "ruleId": "Azure.Route.Naming",
     "displayName": "Route tables must use standard naming"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "Security design principles",
+    "resourceType": "Microsoft.RecoveryServices/vaults",
+    "ruleId": "Azure.RSV.Immutable",
+    "displayName": "Immutability"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "Repeatable infrastructure",
+    "resourceType": "Microsoft.RecoveryServices/vaults",
+    "ruleId": "Azure.RSV.Name",
+    "displayName": "Use valid names"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "Design",
+    "resourceType": "Microsoft.RecoveryServices/vaults",
+    "ruleId": "Azure.RSV.ReplicationAlert",
+    "displayName": "Use geo-replicated storage"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "Design",
+    "resourceType": "Microsoft.RecoveryServices/vaults",
+    "ruleId": "Azure.RSV.StorageType",
+    "displayName": "Use geo-replicated storage"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "Design",
+    "resourceType": "Microsoft.RecoveryServices/vaults/backupconfig",
+    "ruleId": "Azure.RSV.StorageType",
+    "displayName": "Use geo-replicated storage"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:06 Data partitioning",
+    "resourceType": "Microsoft.Search/searchServices",
+    "ruleId": "Azure.Search.IndexSLA",
+    "displayName": "Search index update SLA minimum replicas"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "SE:05 Identity and access management",
+    "resourceType": "Microsoft.Search/searchServices",
+    "ruleId": "Azure.Search.ManagedIdentity",
+    "displayName": "Search services uses a managed identity"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "OE:04 Continuous integration",
+    "resourceType": "Microsoft.Search/searchServices",
+    "ruleId": "Azure.Search.Name",
+    "displayName": "Azure AI Search name must be valid"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "OE:04 Tools and processes",
+    "resourceType": "Microsoft.Search/searchServices",
+    "ruleId": "Azure.Search.Naming",
+    "displayName": "AI Search services must use standard naming"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:06 Data partitioning",
+    "resourceType": "Microsoft.Search/searchServices",
+    "ruleId": "Azure.Search.QuerySLA",
+    "displayName": "Search query SLA minimum replicas"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Performance Efficiency",
+    "category": "PE:02 Capacity planning",
+    "resourceType": "Microsoft.Search/searchServices",
+    "ruleId": "Azure.Search.SKU",
+    "displayName": "AI Search minimum SKU"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "Monitor",
+    "resourceType": "Microsoft.Insights/diagnosticSettings",
+    "ruleId": "Azure.ServiceBus.AuditLogs",
+    "displayName": "Audit Service Bus data plane access"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "Monitor",
+    "resourceType": "Microsoft.ServiceBus/namespaces",
+    "ruleId": "Azure.ServiceBus.AuditLogs",
+    "displayName": "Audit Service Bus data plane access"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "SE:05 Identity and access management",
+    "resourceType": "Microsoft.ServiceBus/namespaces",
+    "ruleId": "Azure.ServiceBus.DisableLocalAuth",
+    "displayName": "Use identity-based authentication for Service Bus namespaces"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:05 Redundancy",
+    "resourceType": "Microsoft.ServiceBus/namespaces",
+    "ruleId": "Azure.ServiceBus.GeoReplica",
+    "displayName": "Geo-replication"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "SE:07 Encryption",
+    "resourceType": "Microsoft.ServiceBus/namespaces",
+    "ruleId": "Azure.ServiceBus.MinTLS",
+    "displayName": "Enforce namespaces to minimum use TLS 1.2 version"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "SE:01 Security baseline",
+    "resourceType": "Microsoft.ServiceBus/namespaces",
+    "ruleId": "Azure.ServiceBus.ReplicaLocation",
+    "displayName": "Service Bus namespace replica location is not allowed"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Cost Optimization",
+    "category": "CO:14 Consolidation",
+    "resourceType": "Microsoft.ServiceBus/namespaces",
+    "ruleId": "Azure.ServiceBus.Usage",
+    "displayName": "Remove unused Service Bus namespaces"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "SE:05 Identity and access management",
+    "resourceType": "Microsoft.ServiceFabric/clusters",
+    "ruleId": "Azure.ServiceFabric.AAD",
+    "displayName": "Use Entra ID authentication with Service Fabric clusters"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "OE:04 Tools and processes",
+    "resourceType": "Microsoft.ServiceFabric/managedClusters",
+    "ruleId": "Azure.ServiceFabric.ManagedNaming",
+    "displayName": "Service Fabric managed cluster resources must use standard naming"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "OE:04 Tools and processes",
+    "resourceType": "Microsoft.ServiceFabric/clusters",
+    "ruleId": "Azure.ServiceFabric.Naming",
+    "displayName": "Service Fabric cluster resources must use standard naming"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "SE:07 Encryption",
+    "resourceType": "Microsoft.ServiceFabric/clusters",
+    "ruleId": "Azure.ServiceFabric.ProtectionLevel",
+    "displayName": "Service Fabric Cluster allows unencrypted node to node communication"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "Authentication",
+    "resourceType": "Microsoft.SignalRService/signalR",
+    "ruleId": "Azure.SignalR.ManagedIdentity",
+    "displayName": "Use managed identities for SignalR Services"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "Repeatable infrastructure",
+    "resourceType": "Microsoft.SignalRService/SignalR",
+    "ruleId": "Azure.SignalR.Name",
+    "displayName": "Use valid SignalR service names"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:04 Target metrics",
+    "resourceType": "Microsoft.SignalRService/signalR",
+    "ruleId": "Azure.SignalR.SLA",
+    "displayName": "Use an SLA for SignalR Services"
   },
   {
     "severity": "Critical",
@@ -4113,166 +4265,6 @@
   },
   {
     "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:06 Data partitioning",
-    "resourceType": "Microsoft.Search/searchServices",
-    "ruleId": "Azure.Search.IndexSLA",
-    "displayName": "Search index update SLA minimum replicas"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "SE:05 Identity and access management",
-    "resourceType": "Microsoft.Search/searchServices",
-    "ruleId": "Azure.Search.ManagedIdentity",
-    "displayName": "Search services uses a managed identity"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "OE:04 Continuous integration",
-    "resourceType": "Microsoft.Search/searchServices",
-    "ruleId": "Azure.Search.Name",
-    "displayName": "Azure AI Search name must be valid"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "OE:04 Tools and processes",
-    "resourceType": "Microsoft.Search/searchServices",
-    "ruleId": "Azure.Search.Naming",
-    "displayName": "AI Search services must use standard naming"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:06 Data partitioning",
-    "resourceType": "Microsoft.Search/searchServices",
-    "ruleId": "Azure.Search.QuerySLA",
-    "displayName": "Search query SLA minimum replicas"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Performance Efficiency",
-    "category": "PE:02 Capacity planning",
-    "resourceType": "Microsoft.Search/searchServices",
-    "ruleId": "Azure.Search.SKU",
-    "displayName": "AI Search minimum SKU"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "Monitor",
-    "resourceType": "Microsoft.Insights/diagnosticSettings",
-    "ruleId": "Azure.ServiceBus.AuditLogs",
-    "displayName": "Audit Service Bus data plane access"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "Monitor",
-    "resourceType": "Microsoft.ServiceBus/namespaces",
-    "ruleId": "Azure.ServiceBus.AuditLogs",
-    "displayName": "Audit Service Bus data plane access"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "SE:05 Identity and access management",
-    "resourceType": "Microsoft.ServiceBus/namespaces",
-    "ruleId": "Azure.ServiceBus.DisableLocalAuth",
-    "displayName": "Use identity-based authentication for Service Bus namespaces"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:05 Redundancy",
-    "resourceType": "Microsoft.ServiceBus/namespaces",
-    "ruleId": "Azure.ServiceBus.GeoReplica",
-    "displayName": "Geo-replication"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "SE:07 Encryption",
-    "resourceType": "Microsoft.ServiceBus/namespaces",
-    "ruleId": "Azure.ServiceBus.MinTLS",
-    "displayName": "Enforce namespaces to minimum use TLS 1.2 version"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "SE:01 Security baseline",
-    "resourceType": "Microsoft.ServiceBus/namespaces",
-    "ruleId": "Azure.ServiceBus.ReplicaLocation",
-    "displayName": "Service Bus namespace replica location is not allowed"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Cost Optimization",
-    "category": "CO:14 Consolidation",
-    "resourceType": "Microsoft.ServiceBus/namespaces",
-    "ruleId": "Azure.ServiceBus.Usage",
-    "displayName": "Remove unused Service Bus namespaces"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "SE:05 Identity and access management",
-    "resourceType": "Microsoft.ServiceFabric/clusters",
-    "ruleId": "Azure.ServiceFabric.AAD",
-    "displayName": "Use Entra ID authentication with Service Fabric clusters"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "OE:04 Tools and processes",
-    "resourceType": "Microsoft.ServiceFabric/managedClusters",
-    "ruleId": "Azure.ServiceFabric.ManagedNaming",
-    "displayName": "Service Fabric managed cluster resources must use standard naming"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "OE:04 Tools and processes",
-    "resourceType": "Microsoft.ServiceFabric/clusters",
-    "ruleId": "Azure.ServiceFabric.Naming",
-    "displayName": "Service Fabric cluster resources must use standard naming"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "SE:07 Encryption",
-    "resourceType": "Microsoft.ServiceFabric/clusters",
-    "ruleId": "Azure.ServiceFabric.ProtectionLevel",
-    "displayName": "Service Fabric Cluster allows unencrypted node to node communication"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "Authentication",
-    "resourceType": "Microsoft.SignalRService/signalR",
-    "ruleId": "Azure.SignalR.ManagedIdentity",
-    "displayName": "Use managed identities for SignalR Services"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "Repeatable infrastructure",
-    "resourceType": "Microsoft.SignalRService/SignalR",
-    "ruleId": "Azure.SignalR.Name",
-    "displayName": "Use valid SignalR service names"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:04 Target metrics",
-    "resourceType": "Microsoft.SignalRService/signalR",
-    "ruleId": "Azure.SignalR.SLA",
-    "displayName": "Use an SLA for SignalR Services"
-  },
-  {
-    "severity": "Important",
     "pillar": "Security",
     "category": "SE:05 Identity and access management",
     "resourceType": "Microsoft.Storage/storageAccounts",
@@ -4482,6 +4474,14 @@
   {
     "severity": "Important",
     "pillar": "Operational Excellence",
+    "category": "OE:10 Automation design",
+    "resourceType": "Microsoft.Compute/virtualMachines",
+    "ruleId": "Azure.VM.Agent",
+    "displayName": "Virtual Machine agent is not provisioned"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Operational Excellence",
     "category": "OE:07 Monitoring system",
     "resourceType": "Microsoft.Compute/virtualMachines",
     "ruleId": "Azure.VM.AMA",
@@ -4526,14 +4526,6 @@
     "resourceType": "Microsoft.Compute/availabilitySets",
     "ruleId": "Azure.VM.ASName",
     "displayName": "Use valid Availability Set names"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Operational Excellence",
-    "category": "OE:10 Automation design",
-    "resourceType": "Microsoft.Compute/virtualMachines",
-    "ruleId": "Azure.VM.Agent",
-    "displayName": "Virtual Machine agent is not provisioned"
   },
   {
     "severity": "Important",
@@ -4673,14 +4665,6 @@
   },
   {
     "severity": "Important",
-    "pillar": "Performance Efficiency",
-    "category": "Design for performance",
-    "resourceType": "Microsoft.Compute/virtualMachines",
-    "ruleId": "Azure.VM.SQLServerDisk",
-    "displayName": "Configure Premium disks or above"
-  },
-  {
-    "severity": "Important",
     "pillar": "Security",
     "category": "SE:02 Secured development lifecycle",
     "resourceType": "Microsoft.Compute/virtualMachines/extensions",
@@ -4702,6 +4686,14 @@
     "resourceType": "Microsoft.Compute/virtualMachines",
     "ruleId": "Azure.VM.ShouldNotBeStopped",
     "displayName": "Virtual Machine is stopped but still allocated"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Performance Efficiency",
+    "category": "Design for performance",
+    "resourceType": "Microsoft.Compute/virtualMachines",
+    "ruleId": "Azure.VM.SQLServerDisk",
+    "displayName": "Configure Premium disks or above"
   },
   {
     "severity": "Important",
@@ -5064,6 +5056,14 @@
     "displayName": "Migrate from legacy VPN gateway SKUs"
   },
   {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "Repeatable infrastructure",
+    "resourceType": "Microsoft.Network/virtualWans",
+    "ruleId": "Azure.vWAN.Name",
+    "displayName": "Use valid vWAN names"
+  },
+  {
     "severity": "Important",
     "pillar": "Security",
     "category": "Authentication",
@@ -5078,13 +5078,5 @@
     "resourceType": "Microsoft.SignalRService/webPubSub",
     "ruleId": "Azure.WebPubSub.SLA",
     "displayName": "Use an SLA for Web PubSub Services"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "Repeatable infrastructure",
-    "resourceType": "Microsoft.Network/virtualWans",
-    "ruleId": "Azure.vWAN.Name",
-    "displayName": "Use valid vWAN names"
   }
 ]

--- a/data/resource-type-mapping.json
+++ b/data/resource-type-mapping.json
@@ -352,20 +352,20 @@
     "displayName": "Enable AKS Container insights"
   },
   {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "Azure resources",
-    "resourceType": "Microsoft.ContainerService/managedClusters",
-    "ruleId": "Azure.AKS.DefenderProfile",
-    "displayName": "Enable Defender profile"
-  },
-  {
     "severity": "Awareness",
     "pillar": "Operational Excellence",
     "category": "OE:04 Continuous integration",
     "resourceType": "Microsoft.ContainerService/managedClusters",
     "ruleId": "Azure.AKS.DNSPrefix",
     "displayName": "Use valid AKS cluster DNS prefix"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "Azure resources",
+    "resourceType": "Microsoft.ContainerService/managedClusters",
+    "ruleId": "Azure.AKS.DefenderProfile",
+    "displayName": "Enable Defender profile"
   },
   {
     "severity": "Important",
@@ -632,22 +632,6 @@
     "displayName": "Kubernetes Cluster version is old"
   },
   {
-    "severity": "Important",
-    "pillar": "Cost Optimization",
-    "category": "CO:06 Usage and billing increments",
-    "resourceType": "Microsoft.Insights/scheduledQueryRules",
-    "ruleId": "Azure.Alert.HighFrequencyQuery",
-    "displayName": "Scheduled Query Alert is configured to use a high frequency query"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Cost Optimization",
-    "category": "CO:13 Personnel time",
-    "resourceType": "Microsoft.Insights/metricAlerts",
-    "ruleId": "Azure.Alert.MetricAutoMitigate",
-    "displayName": "Metric Alert requires manual mitigation"
-  },
-  {
     "severity": "Awareness",
     "pillar": "Operational Excellence",
     "category": "OE:04 Tools and processes",
@@ -673,22 +657,6 @@
   },
   {
     "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:04 Target metrics",
-    "resourceType": "Microsoft.ApiManagement/service",
-    "ruleId": "Azure.APIM.CertificateExpiry",
-    "displayName": "API Management uses current certificates"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "SE:07 Encryption",
-    "resourceType": "Microsoft.ApiManagement/service",
-    "ruleId": "Azure.APIM.Ciphers",
-    "displayName": "Use secure ciphers for API Management"
-  },
-  {
-    "severity": "Important",
     "pillar": "Security",
     "category": "Design",
     "resourceType": "Microsoft.ApiManagement/service",
@@ -702,6 +670,22 @@
     "resourceType": "Microsoft.ApiManagement/service/policies",
     "ruleId": "Azure.APIM.CORSPolicy",
     "displayName": "Avoid wildcards in APIM CORS policies"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:04 Target metrics",
+    "resourceType": "Microsoft.ApiManagement/service",
+    "ruleId": "Azure.APIM.CertificateExpiry",
+    "displayName": "API Management uses current certificates"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "SE:07 Encryption",
+    "resourceType": "Microsoft.ApiManagement/service",
+    "ruleId": "Azure.APIM.Ciphers",
+    "displayName": "Use secure ciphers for API Management"
   },
   {
     "severity": "Critical",
@@ -953,6 +937,54 @@
   },
   {
     "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:05 Regions and availability zones",
+    "resourceType": "Microsoft.Web/hostingEnvironments",
+    "ruleId": "Azure.ASE.AvailabilityZone",
+    "displayName": "Deploy app service environments using availability zones"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Operational Excellence",
+    "category": "Infrastructure provisioning",
+    "resourceType": "Microsoft.Web/hostingEnvironments",
+    "ruleId": "Azure.ASE.MigrateV3",
+    "displayName": "Migrate to App Service Environment v3"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "Repeatable infrastructure",
+    "resourceType": "Microsoft.Network/applicationSecurityGroups",
+    "ruleId": "Azure.ASG.Name",
+    "displayName": "Use valid ASG names"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:04 Target metrics",
+    "resourceType": "Microsoft.DesktopVirtualization/hostPools",
+    "ruleId": "Azure.AVD.ScheduleAgentUpdate",
+    "displayName": "Schedule agent updates for host pools"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Cost Optimization",
+    "category": "CO:06 Usage and billing increments",
+    "resourceType": "Microsoft.Insights/scheduledQueryRules",
+    "ruleId": "Azure.Alert.HighFrequencyQuery",
+    "displayName": "Scheduled Query Alert is configured to use a high frequency query"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Cost Optimization",
+    "category": "CO:13 Personnel time",
+    "resourceType": "Microsoft.Insights/metricAlerts",
+    "ruleId": "Azure.Alert.MetricAutoMitigate",
+    "displayName": "Metric Alert requires manual mitigation"
+  },
+  {
+    "severity": "Important",
     "pillar": "Security",
     "category": "SE:10 Monitoring and threat detection",
     "resourceType": "Microsoft.AppConfiguration/configurationStores",
@@ -1024,6 +1056,14 @@
     "displayName": "App Configuration Store replica location is not allowed"
   },
   {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:04 Target metrics",
+    "resourceType": "Microsoft.AppConfiguration/configurationStores",
+    "ruleId": "Azure.AppConfig.SKU",
+    "displayName": "Use production App Configuration SKU"
+  },
+  {
     "severity": "Critical",
     "pillar": "Security",
     "category": "SE:09 Application secrets",
@@ -1038,14 +1078,6 @@
     "resourceType": "Microsoft.AppConfiguration/configurationStores/keyValues",
     "ruleId": "Azure.AppConfig.SecretLeak",
     "displayName": "App Configuration Store key value is secret"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:04 Target metrics",
-    "resourceType": "Microsoft.AppConfiguration/configurationStores",
-    "ruleId": "Azure.AppConfig.SKU",
-    "displayName": "Use production App Configuration SKU"
   },
   {
     "severity": "Important",
@@ -1216,22 +1248,6 @@
     "displayName": "Use workspace-based App Insights resources"
   },
   {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "Application design",
-    "resourceType": "Microsoft.Web/sites",
-    "ruleId": "Azure.AppService.AlwaysOn",
-    "displayName": "Use App Service Always On"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "Application design",
-    "resourceType": "Microsoft.Web/sites/slots",
-    "ruleId": "Azure.AppService.AlwaysOn",
-    "displayName": "Use App Service Always On"
-  },
-  {
     "severity": "Awareness",
     "pillar": "Performance Efficiency",
     "category": "PE:05 Scaling and partitioning",
@@ -1246,6 +1262,22 @@
     "resourceType": "Microsoft.Web/sites/slots",
     "ruleId": "Azure.AppService.ARRAffinity",
     "displayName": "Disable Application Request Routing"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "Application design",
+    "resourceType": "Microsoft.Web/sites",
+    "ruleId": "Azure.AppService.AlwaysOn",
+    "displayName": "Use App Service Always On"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "Application design",
+    "resourceType": "Microsoft.Web/sites/slots",
+    "ruleId": "Azure.AppService.AlwaysOn",
+    "displayName": "Use App Service Always On"
   },
   {
     "severity": "Important",
@@ -1481,30 +1513,6 @@
   },
   {
     "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:05 Regions and availability zones",
-    "resourceType": "Microsoft.Web/hostingEnvironments",
-    "ruleId": "Azure.ASE.AvailabilityZone",
-    "displayName": "Deploy app service environments using availability zones"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Operational Excellence",
-    "category": "Infrastructure provisioning",
-    "resourceType": "Microsoft.Web/hostingEnvironments",
-    "ruleId": "Azure.ASE.MigrateV3",
-    "displayName": "Migrate to App Service Environment v3"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "Repeatable infrastructure",
-    "resourceType": "Microsoft.Network/applicationSecurityGroups",
-    "ruleId": "Azure.ASG.Name",
-    "displayName": "Use valid ASG names"
-  },
-  {
-    "severity": "Important",
     "pillar": "Security",
     "category": "Monitor",
     "resourceType": "Microsoft.Automation/automationAccounts",
@@ -1593,11 +1601,11 @@
   },
   {
     "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:04 Target metrics",
-    "resourceType": "Microsoft.DesktopVirtualization/hostPools",
-    "ruleId": "Azure.AVD.ScheduleAgentUpdate",
-    "displayName": "Schedule agent updates for host pools"
+    "pillar": "Security",
+    "category": "Security design principles",
+    "resourceType": "Microsoft.DataProtection/backupVaults",
+    "ruleId": "Azure.BV.Immutable",
+    "displayName": "Immutability"
   },
   {
     "severity": "Awareness",
@@ -1606,14 +1614,6 @@
     "resourceType": "Microsoft.Network/bastionHosts",
     "ruleId": "Azure.Bastion.Name",
     "displayName": "Use valid names"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "Security design principles",
-    "resourceType": "Microsoft.DataProtection/backupVaults",
-    "ruleId": "Azure.BV.Immutable",
-    "displayName": "Immutability"
   },
   {
     "severity": "Awareness",
@@ -1912,28 +1912,20 @@
     "displayName": "Cosmos DB for Table account resources must use standard naming"
   },
   {
-    "severity": "Critical",
+    "severity": "Important",
     "pillar": "Security",
-    "category": "SE:06 Network controls",
-    "resourceType": "Microsoft.Databricks/workspaces",
-    "ruleId": "Azure.Databricks.PublicAccess",
-    "displayName": "Azure Databricks workspaces should disable public network access"
+    "category": "SE:08 Hardening resources",
+    "resourceType": "Microsoft.Network/dnsZones",
+    "ruleId": "Azure.DNS.DNSSEC",
+    "displayName": "DNS Zone is not signed"
   },
   {
-    "severity": "Critical",
+    "severity": "Important",
     "pillar": "Security",
-    "category": "SE:06 Network controls",
-    "resourceType": "Microsoft.Databricks/workspaces",
-    "ruleId": "Azure.Databricks.SecureConnectivity",
-    "displayName": "Enable secure connectivity for Databricks workspaces"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Performance Efficiency",
-    "category": "PE:03 Selecting services",
-    "resourceType": "Microsoft.Databricks/workspaces",
-    "ruleId": "Azure.Databricks.SKU",
-    "displayName": "Ensure Databricks workspaces are non-trial SKUs for production workloads"
+    "category": "SE:08 Hardening resources",
+    "resourceType": "Microsoft.Network/dnsZones/dnssecConfigs",
+    "ruleId": "Azure.DNS.DNSSEC",
+    "displayName": "DNS Zone is not signed"
   },
   {
     "severity": "Awareness",
@@ -1950,6 +1942,30 @@
     "resourceType": "Microsoft.DataFactory/factories",
     "ruleId": "Azure.DataFactory.Version",
     "displayName": "Use Data Factory v2"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "SE:06 Network controls",
+    "resourceType": "Microsoft.Databricks/workspaces",
+    "ruleId": "Azure.Databricks.PublicAccess",
+    "displayName": "Azure Databricks workspaces should disable public network access"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Performance Efficiency",
+    "category": "PE:03 Selecting services",
+    "resourceType": "Microsoft.Databricks/workspaces",
+    "ruleId": "Azure.Databricks.SKU",
+    "displayName": "Ensure Databricks workspaces are non-trial SKUs for production workloads"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "SE:06 Network controls",
+    "resourceType": "Microsoft.Databricks/workspaces",
+    "ruleId": "Azure.Databricks.SecureConnectivity",
+    "displayName": "Enable secure connectivity for Databricks workspaces"
   },
   {
     "severity": "Critical",
@@ -2024,22 +2040,6 @@
     "displayName": "Set Microsoft Defender for open-source relational databases to the Standard tier"
   },
   {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "SE:12 Incident response",
-    "resourceType": "Microsoft.Security/securityContacts",
-    "ruleId": "Azure.Defender.SecurityContact",
-    "displayName": "Defender for Cloud notification contact not set"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "SE:10 Monitoring and threat detection",
-    "resourceType": "Microsoft.Security/pricings",
-    "ruleId": "Azure.Defender.Servers",
-    "displayName": "Configure Microsoft Defender for Servers to the Standard tier and P2"
-  },
-  {
     "severity": "Critical",
     "pillar": "Security",
     "category": "SE:10 Monitoring and threat detection",
@@ -2054,6 +2054,22 @@
     "resourceType": "Microsoft.Security/pricings",
     "ruleId": "Azure.Defender.SQLOnVM",
     "displayName": "Configure Microsoft Defender for SQL Servers on machines to the Standard tier"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "SE:12 Incident response",
+    "resourceType": "Microsoft.Security/securityContacts",
+    "ruleId": "Azure.Defender.SecurityContact",
+    "displayName": "Defender for Cloud notification contact not set"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "SE:10 Monitoring and threat detection",
+    "resourceType": "Microsoft.Security/pricings",
+    "ruleId": "Azure.Defender.Servers",
+    "displayName": "Configure Microsoft Defender for Servers to the Standard tier and P2"
   },
   {
     "severity": "Critical",
@@ -2158,22 +2174,6 @@
     "resourceType": "Microsoft.DevCenter/projects",
     "ruleId": "Azure.DevBox.ProjectLimit",
     "displayName": "Limit number of Dev Boxes per user"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "SE:08 Hardening resources",
-    "resourceType": "Microsoft.Network/dnsZones",
-    "ruleId": "Azure.DNS.DNSSEC",
-    "displayName": "DNS Zone is not signed"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "SE:08 Hardening resources",
-    "resourceType": "Microsoft.Network/dnsZones/dnssecConfigs",
-    "ruleId": "Azure.DNS.DNSSEC",
-    "displayName": "DNS Zone is not signed"
   },
   {
     "severity": "Important",
@@ -2394,6 +2394,14 @@
   {
     "severity": "Important",
     "pillar": "Security",
+    "category": "SE:08 Hardening resources",
+    "resourceType": "Microsoft.AzureFleet/fleets",
+    "ruleId": "Azure.Fleet.SecureBoot",
+    "displayName": "Azure Fleet Secure Boot is not enabled"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
     "category": "SE:10 Monitoring and threat detection",
     "resourceType": "Microsoft.Cdn/profiles",
     "ruleId": "Azure.FrontDoor.Logs",
@@ -2451,14 +2459,6 @@
     "severity": "Important",
     "pillar": "Reliability",
     "category": "Health modeling",
-    "resourceType": "Microsoft.Network/frontDoors",
-    "ruleId": "Azure.FrontDoor.Probe",
-    "displayName": "Use Health Probes for Front Door backends"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "Health modeling",
     "resourceType": "Microsoft.Network/Frontdoors/HealthProbeSettings",
     "ruleId": "Azure.FrontDoor.Probe",
     "displayName": "Use Health Probes for Front Door backends"
@@ -2468,8 +2468,8 @@
     "pillar": "Reliability",
     "category": "Health modeling",
     "resourceType": "Microsoft.Network/frontDoors",
-    "ruleId": "Azure.FrontDoor.ProbeMethod",
-    "displayName": "Use HEAD health probes for Front Door backends"
+    "ruleId": "Azure.FrontDoor.Probe",
+    "displayName": "Use Health Probes for Front Door backends"
   },
   {
     "severity": "Important",
@@ -2484,6 +2484,14 @@
     "pillar": "Reliability",
     "category": "Health modeling",
     "resourceType": "Microsoft.Network/frontDoors",
+    "ruleId": "Azure.FrontDoor.ProbeMethod",
+    "displayName": "Use HEAD health probes for Front Door backends"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "Health modeling",
+    "resourceType": "Microsoft.Network/Frontdoors/HealthProbeSettings",
     "ruleId": "Azure.FrontDoor.ProbePath",
     "displayName": "Use a Dedicated Health Endpoint for Front Door backends"
   },
@@ -2491,7 +2499,7 @@
     "severity": "Important",
     "pillar": "Reliability",
     "category": "Health modeling",
-    "resourceType": "Microsoft.Network/Frontdoors/HealthProbeSettings",
+    "resourceType": "Microsoft.Network/frontDoors",
     "ruleId": "Azure.FrontDoor.ProbePath",
     "displayName": "Use a Dedicated Health Endpoint for Front Door backends"
   },
@@ -2865,6 +2873,62 @@
   },
   {
     "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:05 Redundancy",
+    "resourceType": "Microsoft.DocumentDB/cassandraClusters",
+    "ruleId": "Azure.MICassandra.AvailabilityZone",
+    "displayName": "Use zone redundant Managed Instance for Apache Cassandra clusters"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:05 Redundancy",
+    "resourceType": "Microsoft.DocumentDB/cassandraClusters/dataCenters",
+    "ruleId": "Azure.MICassandra.AvailabilityZone",
+    "displayName": "Use zone redundant Managed Instance for Apache Cassandra clusters"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Cost Optimization",
+    "category": "CO:06 Usage and billing increments",
+    "resourceType": "Microsoft.MachineLearningServices/workspaces/computes",
+    "ruleId": "Azure.ML.ComputeIdleShutdown",
+    "displayName": "Configure idle shutdown for compute instances"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "Connectivity",
+    "resourceType": "Microsoft.MachineLearningServices/workspaces/computes",
+    "ruleId": "Azure.ML.ComputeVnet",
+    "displayName": "Host ML Compute in VNet"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "Authentication",
+    "resourceType": "Microsoft.MachineLearningServices/workspaces/computes",
+    "ruleId": "Azure.ML.DisableLocalAuth",
+    "displayName": "Disable local authentication on ML Compute"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "Connectivity",
+    "resourceType": "Microsoft.MachineLearningServices/workspaces",
+    "ruleId": "Azure.ML.PublicAccess",
+    "displayName": "ML Workspace has public access disabled"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "Identity and Access Management",
+    "resourceType": "Microsoft.MachineLearningServices/workspaces",
+    "ruleId": "Azure.ML.UserManagedIdentity",
+    "displayName": "Azure Machine Learning workspaces should use user-assigned managed identity"
+  },
+  {
+    "severity": "Important",
     "pillar": "Security",
     "category": "Network security and containment",
     "resourceType": "Microsoft.DBforMariaDB/servers",
@@ -3006,62 +3070,6 @@
     "resourceType": "Microsoft.DBforMariaDB/servers/virtualNetworkRules",
     "ruleId": "Azure.MariaDB.VNETRuleName",
     "displayName": "Use valid VNET rule names"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:05 Redundancy",
-    "resourceType": "Microsoft.DocumentDB/cassandraClusters",
-    "ruleId": "Azure.MICassandra.AvailabilityZone",
-    "displayName": "Use zone redundant Managed Instance for Apache Cassandra clusters"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:05 Redundancy",
-    "resourceType": "Microsoft.DocumentDB/cassandraClusters/dataCenters",
-    "ruleId": "Azure.MICassandra.AvailabilityZone",
-    "displayName": "Use zone redundant Managed Instance for Apache Cassandra clusters"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Cost Optimization",
-    "category": "CO:06 Usage and billing increments",
-    "resourceType": "Microsoft.MachineLearningServices/workspaces/computes",
-    "ruleId": "Azure.ML.ComputeIdleShutdown",
-    "displayName": "Configure idle shutdown for compute instances"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "Connectivity",
-    "resourceType": "Microsoft.MachineLearningServices/workspaces/computes",
-    "ruleId": "Azure.ML.ComputeVnet",
-    "displayName": "Host ML Compute in VNet"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "Authentication",
-    "resourceType": "Microsoft.MachineLearningServices/workspaces/computes",
-    "ruleId": "Azure.ML.DisableLocalAuth",
-    "displayName": "Disable local authentication on ML Compute"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "Connectivity",
-    "resourceType": "Microsoft.MachineLearningServices/workspaces",
-    "ruleId": "Azure.ML.PublicAccess",
-    "displayName": "ML Workspace has public access disabled"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "Identity and Access Management",
-    "resourceType": "Microsoft.MachineLearningServices/workspaces",
-    "ruleId": "Azure.ML.UserManagedIdentity",
-    "displayName": "Azure Machine Learning workspaces should use user-assigned managed identity"
   },
   {
     "severity": "Critical",
@@ -3617,6 +3625,46 @@
   },
   {
     "severity": "Important",
+    "pillar": "Security",
+    "category": "Security design principles",
+    "resourceType": "Microsoft.RecoveryServices/vaults",
+    "ruleId": "Azure.RSV.Immutable",
+    "displayName": "Immutability"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "Repeatable infrastructure",
+    "resourceType": "Microsoft.RecoveryServices/vaults",
+    "ruleId": "Azure.RSV.Name",
+    "displayName": "Use valid names"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "Design",
+    "resourceType": "Microsoft.RecoveryServices/vaults",
+    "ruleId": "Azure.RSV.ReplicationAlert",
+    "displayName": "Use geo-replicated storage"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "Design",
+    "resourceType": "Microsoft.RecoveryServices/vaults",
+    "ruleId": "Azure.RSV.StorageType",
+    "displayName": "Use geo-replicated storage"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "Design",
+    "resourceType": "Microsoft.RecoveryServices/vaults/backupconfig",
+    "ruleId": "Azure.RSV.StorageType",
+    "displayName": "Use geo-replicated storage"
+  },
+  {
+    "severity": "Important",
     "pillar": "Reliability",
     "category": "RE:05 Regions and availability zones",
     "resourceType": "Microsoft.Cache/redis",
@@ -3782,206 +3830,6 @@
     "resourceType": "Microsoft.Network/routeTables",
     "ruleId": "Azure.Route.Naming",
     "displayName": "Route tables must use standard naming"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "Security design principles",
-    "resourceType": "Microsoft.RecoveryServices/vaults",
-    "ruleId": "Azure.RSV.Immutable",
-    "displayName": "Immutability"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "Repeatable infrastructure",
-    "resourceType": "Microsoft.RecoveryServices/vaults",
-    "ruleId": "Azure.RSV.Name",
-    "displayName": "Use valid names"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "Design",
-    "resourceType": "Microsoft.RecoveryServices/vaults",
-    "ruleId": "Azure.RSV.ReplicationAlert",
-    "displayName": "Use geo-replicated storage"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "Design",
-    "resourceType": "Microsoft.RecoveryServices/vaults",
-    "ruleId": "Azure.RSV.StorageType",
-    "displayName": "Use geo-replicated storage"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "Design",
-    "resourceType": "Microsoft.RecoveryServices/vaults/backupconfig",
-    "ruleId": "Azure.RSV.StorageType",
-    "displayName": "Use geo-replicated storage"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:06 Data partitioning",
-    "resourceType": "Microsoft.Search/searchServices",
-    "ruleId": "Azure.Search.IndexSLA",
-    "displayName": "Search index update SLA minimum replicas"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "SE:05 Identity and access management",
-    "resourceType": "Microsoft.Search/searchServices",
-    "ruleId": "Azure.Search.ManagedIdentity",
-    "displayName": "Search services uses a managed identity"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "OE:04 Continuous integration",
-    "resourceType": "Microsoft.Search/searchServices",
-    "ruleId": "Azure.Search.Name",
-    "displayName": "Azure AI Search name must be valid"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "OE:04 Tools and processes",
-    "resourceType": "Microsoft.Search/searchServices",
-    "ruleId": "Azure.Search.Naming",
-    "displayName": "AI Search services must use standard naming"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:06 Data partitioning",
-    "resourceType": "Microsoft.Search/searchServices",
-    "ruleId": "Azure.Search.QuerySLA",
-    "displayName": "Search query SLA minimum replicas"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Performance Efficiency",
-    "category": "PE:02 Capacity planning",
-    "resourceType": "Microsoft.Search/searchServices",
-    "ruleId": "Azure.Search.SKU",
-    "displayName": "AI Search minimum SKU"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "Monitor",
-    "resourceType": "Microsoft.Insights/diagnosticSettings",
-    "ruleId": "Azure.ServiceBus.AuditLogs",
-    "displayName": "Audit Service Bus data plane access"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "Monitor",
-    "resourceType": "Microsoft.ServiceBus/namespaces",
-    "ruleId": "Azure.ServiceBus.AuditLogs",
-    "displayName": "Audit Service Bus data plane access"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "SE:05 Identity and access management",
-    "resourceType": "Microsoft.ServiceBus/namespaces",
-    "ruleId": "Azure.ServiceBus.DisableLocalAuth",
-    "displayName": "Use identity-based authentication for Service Bus namespaces"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:05 Redundancy",
-    "resourceType": "Microsoft.ServiceBus/namespaces",
-    "ruleId": "Azure.ServiceBus.GeoReplica",
-    "displayName": "Geo-replication"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "SE:07 Encryption",
-    "resourceType": "Microsoft.ServiceBus/namespaces",
-    "ruleId": "Azure.ServiceBus.MinTLS",
-    "displayName": "Enforce namespaces to minimum use TLS 1.2 version"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "SE:01 Security baseline",
-    "resourceType": "Microsoft.ServiceBus/namespaces",
-    "ruleId": "Azure.ServiceBus.ReplicaLocation",
-    "displayName": "Service Bus namespace replica location is not allowed"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Cost Optimization",
-    "category": "CO:14 Consolidation",
-    "resourceType": "Microsoft.ServiceBus/namespaces",
-    "ruleId": "Azure.ServiceBus.Usage",
-    "displayName": "Remove unused Service Bus namespaces"
-  },
-  {
-    "severity": "Critical",
-    "pillar": "Security",
-    "category": "SE:05 Identity and access management",
-    "resourceType": "Microsoft.ServiceFabric/clusters",
-    "ruleId": "Azure.ServiceFabric.AAD",
-    "displayName": "Use Entra ID authentication with Service Fabric clusters"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "OE:04 Tools and processes",
-    "resourceType": "Microsoft.ServiceFabric/managedClusters",
-    "ruleId": "Azure.ServiceFabric.ManagedNaming",
-    "displayName": "Service Fabric managed cluster resources must use standard naming"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "OE:04 Tools and processes",
-    "resourceType": "Microsoft.ServiceFabric/clusters",
-    "ruleId": "Azure.ServiceFabric.Naming",
-    "displayName": "Service Fabric cluster resources must use standard naming"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "SE:07 Encryption",
-    "resourceType": "Microsoft.ServiceFabric/clusters",
-    "ruleId": "Azure.ServiceFabric.ProtectionLevel",
-    "displayName": "Service Fabric Cluster allows unencrypted node to node communication"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Security",
-    "category": "Authentication",
-    "resourceType": "Microsoft.SignalRService/signalR",
-    "ruleId": "Azure.SignalR.ManagedIdentity",
-    "displayName": "Use managed identities for SignalR Services"
-  },
-  {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "Repeatable infrastructure",
-    "resourceType": "Microsoft.SignalRService/SignalR",
-    "ruleId": "Azure.SignalR.Name",
-    "displayName": "Use valid SignalR service names"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Reliability",
-    "category": "RE:04 Target metrics",
-    "resourceType": "Microsoft.SignalRService/signalR",
-    "ruleId": "Azure.SignalR.SLA",
-    "displayName": "Use an SLA for SignalR Services"
   },
   {
     "severity": "Critical",
@@ -4265,6 +4113,166 @@
   },
   {
     "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:06 Data partitioning",
+    "resourceType": "Microsoft.Search/searchServices",
+    "ruleId": "Azure.Search.IndexSLA",
+    "displayName": "Search index update SLA minimum replicas"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "SE:05 Identity and access management",
+    "resourceType": "Microsoft.Search/searchServices",
+    "ruleId": "Azure.Search.ManagedIdentity",
+    "displayName": "Search services uses a managed identity"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "OE:04 Continuous integration",
+    "resourceType": "Microsoft.Search/searchServices",
+    "ruleId": "Azure.Search.Name",
+    "displayName": "Azure AI Search name must be valid"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "OE:04 Tools and processes",
+    "resourceType": "Microsoft.Search/searchServices",
+    "ruleId": "Azure.Search.Naming",
+    "displayName": "AI Search services must use standard naming"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:06 Data partitioning",
+    "resourceType": "Microsoft.Search/searchServices",
+    "ruleId": "Azure.Search.QuerySLA",
+    "displayName": "Search query SLA minimum replicas"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Performance Efficiency",
+    "category": "PE:02 Capacity planning",
+    "resourceType": "Microsoft.Search/searchServices",
+    "ruleId": "Azure.Search.SKU",
+    "displayName": "AI Search minimum SKU"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "Monitor",
+    "resourceType": "Microsoft.Insights/diagnosticSettings",
+    "ruleId": "Azure.ServiceBus.AuditLogs",
+    "displayName": "Audit Service Bus data plane access"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "Monitor",
+    "resourceType": "Microsoft.ServiceBus/namespaces",
+    "ruleId": "Azure.ServiceBus.AuditLogs",
+    "displayName": "Audit Service Bus data plane access"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "SE:05 Identity and access management",
+    "resourceType": "Microsoft.ServiceBus/namespaces",
+    "ruleId": "Azure.ServiceBus.DisableLocalAuth",
+    "displayName": "Use identity-based authentication for Service Bus namespaces"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:05 Redundancy",
+    "resourceType": "Microsoft.ServiceBus/namespaces",
+    "ruleId": "Azure.ServiceBus.GeoReplica",
+    "displayName": "Geo-replication"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "SE:07 Encryption",
+    "resourceType": "Microsoft.ServiceBus/namespaces",
+    "ruleId": "Azure.ServiceBus.MinTLS",
+    "displayName": "Enforce namespaces to minimum use TLS 1.2 version"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "SE:01 Security baseline",
+    "resourceType": "Microsoft.ServiceBus/namespaces",
+    "ruleId": "Azure.ServiceBus.ReplicaLocation",
+    "displayName": "Service Bus namespace replica location is not allowed"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Cost Optimization",
+    "category": "CO:14 Consolidation",
+    "resourceType": "Microsoft.ServiceBus/namespaces",
+    "ruleId": "Azure.ServiceBus.Usage",
+    "displayName": "Remove unused Service Bus namespaces"
+  },
+  {
+    "severity": "Critical",
+    "pillar": "Security",
+    "category": "SE:05 Identity and access management",
+    "resourceType": "Microsoft.ServiceFabric/clusters",
+    "ruleId": "Azure.ServiceFabric.AAD",
+    "displayName": "Use Entra ID authentication with Service Fabric clusters"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "OE:04 Tools and processes",
+    "resourceType": "Microsoft.ServiceFabric/managedClusters",
+    "ruleId": "Azure.ServiceFabric.ManagedNaming",
+    "displayName": "Service Fabric managed cluster resources must use standard naming"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "OE:04 Tools and processes",
+    "resourceType": "Microsoft.ServiceFabric/clusters",
+    "ruleId": "Azure.ServiceFabric.Naming",
+    "displayName": "Service Fabric cluster resources must use standard naming"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "SE:07 Encryption",
+    "resourceType": "Microsoft.ServiceFabric/clusters",
+    "ruleId": "Azure.ServiceFabric.ProtectionLevel",
+    "displayName": "Service Fabric Cluster allows unencrypted node to node communication"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Security",
+    "category": "Authentication",
+    "resourceType": "Microsoft.SignalRService/signalR",
+    "ruleId": "Azure.SignalR.ManagedIdentity",
+    "displayName": "Use managed identities for SignalR Services"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "Repeatable infrastructure",
+    "resourceType": "Microsoft.SignalRService/SignalR",
+    "ruleId": "Azure.SignalR.Name",
+    "displayName": "Use valid SignalR service names"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Reliability",
+    "category": "RE:04 Target metrics",
+    "resourceType": "Microsoft.SignalRService/signalR",
+    "ruleId": "Azure.SignalR.SLA",
+    "displayName": "Use an SLA for SignalR Services"
+  },
+  {
+    "severity": "Important",
     "pillar": "Security",
     "category": "SE:05 Identity and access management",
     "resourceType": "Microsoft.Storage/storageAccounts",
@@ -4474,14 +4482,6 @@
   {
     "severity": "Important",
     "pillar": "Operational Excellence",
-    "category": "OE:10 Automation design",
-    "resourceType": "Microsoft.Compute/virtualMachines",
-    "ruleId": "Azure.VM.Agent",
-    "displayName": "Virtual Machine agent is not provisioned"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Operational Excellence",
     "category": "OE:07 Monitoring system",
     "resourceType": "Microsoft.Compute/virtualMachines",
     "ruleId": "Azure.VM.AMA",
@@ -4526,6 +4526,14 @@
     "resourceType": "Microsoft.Compute/availabilitySets",
     "ruleId": "Azure.VM.ASName",
     "displayName": "Use valid Availability Set names"
+  },
+  {
+    "severity": "Important",
+    "pillar": "Operational Excellence",
+    "category": "OE:10 Automation design",
+    "resourceType": "Microsoft.Compute/virtualMachines",
+    "ruleId": "Azure.VM.Agent",
+    "displayName": "Virtual Machine agent is not provisioned"
   },
   {
     "severity": "Important",
@@ -4665,6 +4673,14 @@
   },
   {
     "severity": "Important",
+    "pillar": "Performance Efficiency",
+    "category": "Design for performance",
+    "resourceType": "Microsoft.Compute/virtualMachines",
+    "ruleId": "Azure.VM.SQLServerDisk",
+    "displayName": "Configure Premium disks or above"
+  },
+  {
+    "severity": "Important",
     "pillar": "Security",
     "category": "SE:02 Secured development lifecycle",
     "resourceType": "Microsoft.Compute/virtualMachines/extensions",
@@ -4686,14 +4702,6 @@
     "resourceType": "Microsoft.Compute/virtualMachines",
     "ruleId": "Azure.VM.ShouldNotBeStopped",
     "displayName": "Virtual Machine is stopped but still allocated"
-  },
-  {
-    "severity": "Important",
-    "pillar": "Performance Efficiency",
-    "category": "Design for performance",
-    "resourceType": "Microsoft.Compute/virtualMachines",
-    "ruleId": "Azure.VM.SQLServerDisk",
-    "displayName": "Configure Premium disks or above"
   },
   {
     "severity": "Important",
@@ -5056,14 +5064,6 @@
     "displayName": "Migrate from legacy VPN gateway SKUs"
   },
   {
-    "severity": "Awareness",
-    "pillar": "Operational Excellence",
-    "category": "Repeatable infrastructure",
-    "resourceType": "Microsoft.Network/virtualWans",
-    "ruleId": "Azure.vWAN.Name",
-    "displayName": "Use valid vWAN names"
-  },
-  {
     "severity": "Important",
     "pillar": "Security",
     "category": "Authentication",
@@ -5078,5 +5078,13 @@
     "resourceType": "Microsoft.SignalRService/webPubSub",
     "ruleId": "Azure.WebPubSub.SLA",
     "displayName": "Use an SLA for Web PubSub Services"
+  },
+  {
+    "severity": "Awareness",
+    "pillar": "Operational Excellence",
+    "category": "Repeatable infrastructure",
+    "resourceType": "Microsoft.Network/virtualWans",
+    "ruleId": "Azure.vWAN.Name",
+    "displayName": "Use valid vWAN names"
   }
 ]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,10 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v1.48.0-B0228:
 
+- New rules:
+  - Azure Fleet:
+    - Added `Azure.Fleet.SecureBoot` to require Trusted Launch/Confidential VM with Secure Boot for fleet VM profiles by @l46983284-cpu.
+      [#3729](https://github.com/Azure/PSRule.Rules.Azure/issues/3729)
 - General improvements:
   - Added support for resolving filtered subnet IDs from existing virtual networks during Bicep expansion.
     [#2159](https://github.com/Azure/PSRule.Rules.Azure/issues/2159)

--- a/docs/en/rules/Azure.Fleet.SecureBoot.md
+++ b/docs/en/rules/Azure.Fleet.SecureBoot.md
@@ -1,0 +1,187 @@
+---
+reviewed: 2026-07-14
+severity: Important
+pillar: Security
+category: SE:08 Hardening resources
+resource: Azure Fleet
+resourceType: Microsoft.AzureFleet/fleets
+online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.Fleet.SecureBoot/
+---
+
+# Azure Fleet Secure Boot is not enabled
+
+## SYNOPSIS
+
+Operating systems or drivers may be maliciously modified or injected if an actor gains access to VM/ OS storage or build media.
+
+## DESCRIPTION
+
+Azure Fleet virtual machine profiles are able to run a wide range of operating systems including many distributions of Windows and Linux.
+A malicious actor may attempt to tamper or inject operating system and driver components to gain access to resources and persist between reboots.
+
+When a fleet VM instance is started, Azure is able to verify if:
+
+1. The operating system and drivers originate from a trusted source.
+2. These components are in their original unaltered state.
+
+Azure is able to perform this verification by Secure Boot and Trusted Launch features.
+These features verify the cryptographic signatures of early boot components before they start.
+
+Secure Boot and Trusted Launch are on by default for many configurations.
+However, if you are running an older configuration these features may need to be enabled.
+
+Setting the security type to `ConfidentialVM` is also acceptable.
+
+## RECOMMENDATION
+
+Consider enabling Trusted Launch or Confidential VM with Secure Boot for Azure Fleet VM profiles to protect against boot-level attacks.
+
+## EXAMPLES
+
+### Configure with Bicep
+
+To deploy an Azure Fleet that passes this rule:
+
+- Set the `properties.computeProfile.baseVirtualMachineProfile.securityProfile.securityType` property to `TrustedLaunch` or `ConfidentialVM`.
+- Set the `properties.computeProfile.baseVirtualMachineProfile.securityProfile.uefiSettings.secureBootEnabled` property to `true`.
+
+For example:
+
+```bicep
+resource windows_fleet 'Microsoft.AzureFleet/fleets@2024-11-01' = {
+  name: name
+  location: location
+  properties: {
+    computeProfile: {
+      baseVirtualMachineProfile: {
+        securityProfile: {
+          securityType: 'TrustedLaunch'
+          encryptionAtHost: true
+          uefiSettings: {
+            secureBootEnabled: true
+            vTpmEnabled: true
+          }
+        }
+        osProfile: {
+          computerNamePrefix: 'fleet'
+          adminUsername: adminUsername
+          adminPassword: secret
+        }
+        networkProfile: {
+          networkInterfaceConfigurations: [
+            {
+              name: 'netconfig'
+              properties: {
+                ipConfigurations: [
+                  {
+                    name: 'ipconfig'
+                    properties: {
+                      primary: true
+                      subnet: {
+                        id: subnetId
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+    vmSizesProfile: [
+      {
+        name: 'Standard_D8ds_v6'
+        rank: 0
+      }
+    ]
+    regularPriorityProfile: {
+      minCapacity: 1
+      capacity: 5
+      allocationStrategy: 'Prioritized'
+    }
+  }
+}
+```
+
+### Configure with Azure template
+
+To deploy an Azure Fleet that passes this rule:
+
+- Set the `properties.computeProfile.baseVirtualMachineProfile.securityProfile.securityType` property to `TrustedLaunch` or `ConfidentialVM`.
+- Set the `properties.computeProfile.baseVirtualMachineProfile.securityProfile.uefiSettings.secureBootEnabled` property to `true`.
+
+For example:
+
+```json
+{
+  "type": "Microsoft.AzureFleet/fleets",
+  "apiVersion": "2024-11-01",
+  "name": "[parameters('name')]",
+  "location": "[parameters('location')]",
+  "properties": {
+    "computeProfile": {
+      "baseVirtualMachineProfile": {
+        "securityProfile": {
+          "securityType": "TrustedLaunch",
+          "encryptionAtHost": true,
+          "uefiSettings": {
+            "secureBootEnabled": true,
+            "vTpmEnabled": true
+          }
+        },
+        "osProfile": {
+          "computerNamePrefix": "fleet",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('secret')]"
+        },
+        "networkProfile": {
+          "networkInterfaceConfigurations": [
+            {
+              "name": "netconfig",
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig",
+                    "properties": {
+                      "primary": true,
+                      "subnet": {
+                        "id": "[parameters('subnetId')]"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "vmSizesProfile": [
+      {
+        "name": "Standard_D8ds_v6",
+        "rank": 0
+      }
+    ],
+    "regularPriorityProfile": {
+      "minCapacity": 1,
+      "capacity": 5,
+      "allocationStrategy": "Prioritized"
+    }
+  }
+}
+```
+
+## NOTES
+
+Currently there are a few limitations (see documentation for up to date details), including:
+
+- A supported VM SKU and operating system is required.
+- Secure Boot and Trusted Launch is only supported on Generation 2 VM images.
+
+## LINKS
+
+- [SE:08 Hardening resources](https://learn.microsoft.com/azure/well-architected/security/harden-resources)
+- [Security: Level 2](https://learn.microsoft.com/azure/well-architected/security/maturity-model?tabs=level2)
+- [Trusted Launch for Azure virtual machines](https://learn.microsoft.com/azure/virtual-machines/trusted-launch)
+- [Azure deployment reference](https://learn.microsoft.com/azure/templates/microsoft.azurefleet/fleets#securityprofile)

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -79,6 +79,8 @@
     ReplicaInSecondaryNotFound = "A replica in a secondary region was not found."
     VMSSPublicKey = "The virtual machine scale set '{0}' should have password authentication disabled."
     FleetPublicKey = "The Azure Fleet '{0}' should have password authentication disabled."
+    FleetSecureBoot = "The Azure Fleet '{0}' should set the 'securityType' property to 'TrustedLaunch' or 'ConfidentialVM'."
+    FleetSecureBootEnabled = "The Azure Fleet '{0}' should have Secure Boot enabled."
     ACRSoftDeletePolicy = "The container registry '{0}' should have soft delete policy enabled."
     ACRSoftDeletePolicyRetention = "The container registry '{0}' should have retention period value between one to 90 days for the soft delete policy."
     ContainerRegistryAuditDiagnosticSetting = "Minimum one diagnostic setting should have ({0}) configured or category group ({1}) configured."

--- a/src/PSRule.Rules.Azure/rules/Azure.Fleet.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Fleet.Rule.ps1
@@ -13,4 +13,13 @@ Rule 'Azure.Fleet.PublicKey' -Ref 'AZR-000541' -Type 'Microsoft.AzureFleet/fleet
     Reason($LocalizedData.FleetPublicKey, $PSRule.TargetName)
 }
 
+
+# Synopsis: Azure Fleet VM profiles should use Trusted Launch with Secure Boot enabled.
+Rule 'Azure.Fleet.SecureBoot' -Ref 'AZR-000545' -Type 'Microsoft.AzureFleet/fleets' -Tag @{ release = 'GA'; ruleSet = '2026_09'; 'Azure.WAF/pillar' = 'Security'; } -Labels @{ 'Azure.WAF/maturity' = 'L2' } {
+    $Assert.In($TargetObject, 'properties.computeProfile.baseVirtualMachineProfile.securityProfile.securityType', @('TrustedLaunch', 'ConfidentialVM')).
+        Reason($LocalizedData.FleetSecureBoot, $PSRule.TargetName)
+    $Assert.HasFieldValue($TargetObject, 'properties.computeProfile.baseVirtualMachineProfile.securityProfile.uefiSettings.secureBootEnabled', $True).
+        Reason($LocalizedData.FleetSecureBootEnabled, $PSRule.TargetName)
+}
+
 #endregion Rules

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Fleet.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Fleet.Tests.ps1
@@ -53,8 +53,24 @@ Describe 'Azure.Fleet' -Tag 'Fleet' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'fleet-001';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'fleet-001', 'fleet-005';
+        }
+
+        It 'Azure.Fleet.SecureBoot' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Fleet.SecureBoot' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'fleet-001', 'fleet-002', 'fleet-003';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'fleet-004', 'fleet-005';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Fleet.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Fleet.Tests.ps1
@@ -63,14 +63,14 @@ Describe 'Azure.Fleet' -Tag 'Fleet' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'fleet-001', 'fleet-002', 'fleet-003';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'fleet-001', 'fleet-002', 'fleet-003', 'fleet-006', 'fleet-007';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'fleet-004', 'fleet-005';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'fleet-004', 'fleet-005', 'fleet-008';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Fleet.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Fleet.json
@@ -414,5 +414,255 @@
     "ResourceGroupName": "test-rg",
     "Type": "Microsoft.AzureFleet/fleets",
     "Tags": {}
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.AzureFleet/fleets/fleet-006",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.AzureFleet/fleets/fleet-006",
+    "Identity": null,
+    "Kind": null,
+    "Location": "eastus",
+    "ManagedBy": null,
+    "ResourceName": "fleet-006",
+    "Name": "fleet-006",
+    "ExtensionResourceName": null,
+    "ParentResource": null,
+    "Plan": null,
+    "Properties": {
+      "computeProfile": {
+        "baseVirtualMachineProfile": {
+          "securityProfile": {
+            "securityType": "TrustedLaunch",
+            "encryptionAtHost": true,
+            "uefiSettings": {
+              "secureBootEnabled": false,
+              "vTpmEnabled": true
+            }
+          },
+          "osProfile": {
+            "computerNamePrefix": "fleet",
+            "adminUsername": "azureuser",
+            "adminPassword": "P@ssword123!"
+          },
+          "storageProfile": {
+            "osDisk": {
+              "createOption": "FromImage",
+              "caching": "ReadWrite",
+              "managedDisk": {
+                "storageAccountType": "Premium_LRS"
+              },
+              "osType": "Windows"
+            },
+            "imageReference": {
+              "publisher": "MicrosoftWindowsServer",
+              "offer": "WindowsServer",
+              "sku": "2022-datacenter-g2",
+              "version": "latest"
+            }
+          },
+          "networkProfile": {
+            "networkInterfaceConfigurations": [
+              {
+                "name": "netconfig",
+                "properties": {
+                  "ipConfigurations": [
+                    {
+                      "name": "ipconfig",
+                      "properties": {
+                        "primary": true,
+                        "subnet": {
+                          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      "vmSizesProfile": [
+        {
+          "name": "Standard_D8ds_v6",
+          "rank": 0
+        }
+      ],
+      "regularPriorityProfile": {
+        "minCapacity": 1,
+        "capacity": 5,
+        "allocationStrategy": "Prioritized"
+      }
+    },
+    "ResourceType": "Microsoft.AzureFleet/fleets",
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.AzureFleet/fleets",
+    "Tags": {}
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.AzureFleet/fleets/fleet-007",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.AzureFleet/fleets/fleet-007",
+    "Identity": null,
+    "Kind": null,
+    "Location": "eastus",
+    "ManagedBy": null,
+    "ResourceName": "fleet-007",
+    "Name": "fleet-007",
+    "ExtensionResourceName": null,
+    "ParentResource": null,
+    "Plan": null,
+    "Properties": {
+      "computeProfile": {
+        "baseVirtualMachineProfile": {
+          "securityProfile": {
+            "uefiSettings": {
+              "secureBootEnabled": true,
+              "vTpmEnabled": true
+            }
+          },
+          "osProfile": {
+            "computerNamePrefix": "fleet",
+            "adminUsername": "azureuser",
+            "adminPassword": "P@ssword123!"
+          },
+          "storageProfile": {
+            "osDisk": {
+              "createOption": "FromImage",
+              "caching": "ReadWrite",
+              "managedDisk": {
+                "storageAccountType": "Premium_LRS"
+              },
+              "osType": "Windows"
+            },
+            "imageReference": {
+              "publisher": "MicrosoftWindowsServer",
+              "offer": "WindowsServer",
+              "sku": "2022-datacenter-g2",
+              "version": "latest"
+            }
+          },
+          "networkProfile": {
+            "networkInterfaceConfigurations": [
+              {
+                "name": "netconfig",
+                "properties": {
+                  "ipConfigurations": [
+                    {
+                      "name": "ipconfig",
+                      "properties": {
+                        "primary": true,
+                        "subnet": {
+                          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      "vmSizesProfile": [
+        {
+          "name": "Standard_D8ds_v6",
+          "rank": 0
+        }
+      ],
+      "regularPriorityProfile": {
+        "minCapacity": 1,
+        "capacity": 5,
+        "allocationStrategy": "Prioritized"
+      }
+    },
+    "ResourceType": "Microsoft.AzureFleet/fleets",
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.AzureFleet/fleets",
+    "Tags": {}
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.AzureFleet/fleets/fleet-008",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.AzureFleet/fleets/fleet-008",
+    "Identity": null,
+    "Kind": null,
+    "Location": "eastus",
+    "ManagedBy": null,
+    "ResourceName": "fleet-008",
+    "Name": "fleet-008",
+    "ExtensionResourceName": null,
+    "ParentResource": null,
+    "Plan": null,
+    "Properties": {
+      "computeProfile": {
+        "baseVirtualMachineProfile": {
+          "securityProfile": {
+            "securityType": "ConfidentialVM",
+            "encryptionAtHost": true,
+            "uefiSettings": {
+              "secureBootEnabled": true,
+              "vTpmEnabled": true
+            }
+          },
+          "osProfile": {
+            "computerNamePrefix": "fleet",
+            "adminUsername": "azureuser",
+            "adminPassword": "P@ssword123!"
+          },
+          "storageProfile": {
+            "osDisk": {
+              "createOption": "FromImage",
+              "caching": "ReadWrite",
+              "managedDisk": {
+                "storageAccountType": "Premium_LRS"
+              },
+              "osType": "Windows"
+            },
+            "imageReference": {
+              "publisher": "MicrosoftWindowsServer",
+              "offer": "WindowsServer",
+              "sku": "2022-datacenter-g2",
+              "version": "latest"
+            }
+          },
+          "networkProfile": {
+            "networkInterfaceConfigurations": [
+              {
+                "name": "netconfig",
+                "properties": {
+                  "ipConfigurations": [
+                    {
+                      "name": "ipconfig",
+                      "properties": {
+                        "primary": true,
+                        "subnet": {
+                          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      "vmSizesProfile": [
+        {
+          "name": "Standard_D8ds_v6",
+          "rank": 0
+        }
+      ],
+      "regularPriorityProfile": {
+        "minCapacity": 1,
+        "capacity": 5,
+        "allocationStrategy": "Prioritized"
+      }
+    },
+    "ResourceType": "Microsoft.AzureFleet/fleets",
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.AzureFleet/fleets",
+    "Tags": {}
   }
 ]

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Fleet.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Fleet.json
@@ -321,5 +321,98 @@
     "ResourceGroupName": "test-rg",
     "Type": "Microsoft.AzureFleet/fleets",
     "Tags": {}
+  },
+  {
+    "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.AzureFleet/fleets/fleet-005",
+    "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.AzureFleet/fleets/fleet-005",
+    "Identity": null,
+    "Kind": null,
+    "Location": "eastus",
+    "ManagedBy": null,
+    "ResourceName": "fleet-005",
+    "Name": "fleet-005",
+    "ExtensionResourceName": null,
+    "ParentResource": null,
+    "Plan": null,
+    "Properties": {
+      "computeProfile": {
+        "baseVirtualMachineProfile": {
+          "securityProfile": {
+            "securityType": "TrustedLaunch",
+            "uefiSettings": {
+              "secureBootEnabled": true,
+              "vTpmEnabled": true
+            }
+          },
+          "osProfile": {
+            "computerNamePrefix": "fleet",
+            "adminUsername": "azureuser",
+            "linuxConfiguration": {
+              "disablePasswordAuthentication": true,
+              "ssh": {
+                "publicKeys": [
+                  {
+                    "path": "/home/azureuser/.ssh/authorized_keys",
+                    "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC"
+                  }
+                ]
+              },
+              "provisionVMAgent": true
+            }
+          },
+          "storageProfile": {
+            "osDisk": {
+              "createOption": "FromImage",
+              "caching": "ReadWrite",
+              "managedDisk": {
+                "storageAccountType": "Premium_LRS"
+              }
+            },
+            "imageReference": {
+              "publisher": "MicrosoftCblMariner",
+              "offer": "Cbl-Mariner",
+              "sku": "cbl-mariner-2-gen2",
+              "version": "latest"
+            }
+          },
+          "networkProfile": {
+            "networkInterfaceConfigurations": [
+              {
+                "name": "netconfig",
+                "properties": {
+                  "ipConfigurations": [
+                    {
+                      "name": "ipconfig",
+                      "properties": {
+                        "primary": true,
+                        "subnet": {
+                          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/subnet-001"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      "vmSizesProfile": [
+        {
+          "name": "Standard_D8ds_v6",
+          "rank": 0
+        }
+      ],
+      "regularPriorityProfile": {
+        "minCapacity": 1,
+        "capacity": 5,
+        "allocationStrategy": "Prioritized"
+      }
+    },
+    "ResourceType": "Microsoft.AzureFleet/fleets",
+    "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+    "ResourceGroupName": "test-rg",
+    "Type": "Microsoft.AzureFleet/fleets",
+    "Tags": {}
   }
 ]


### PR DESCRIPTION
## PR Summary

Fixes: #3729

Adds `Azure.Fleet.SecureBoot` so Azure Fleet base VM profiles require Trusted Launch or Confidential VM with Secure Boot enabled.

Path checked:
- `properties.computeProfile.baseVirtualMachineProfile.securityProfile.securityType` ∈ `TrustedLaunch` | `ConfidentialVM`
- `properties.computeProfile.baseVirtualMachineProfile.securityProfile.uefiSettings.secureBootEnabled` = `true`

Mirrors existing `Azure.VM.SecureBoot` / `Azure.VMSS.SecureBoot` guidance for fleet profiles.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Azure/PSRule.Rules.Azure/blob/main/docs/changelog.md) has been updated with change under unreleased section