### PR TITLE
docs: fix typo identifer -> identifier

### DIFF
--- a/docs/commands/Export-AzRuleData.md
+++ b/docs/commands/Export-AzRuleData.md
@@ -192,7 +192,7 @@ Accept wildcard characters: False
 
 ### -Tenant
 
-Optionally filter resources by a unique Tenant identifer.
+Optionally filter resources by a unique Tenant identifier.
 
 ```yaml
 Type: String[]


### PR DESCRIPTION
One-word typo fix in `docs/commands/Export-AzRuleData.md:195`: "Optionally filter resources by a ... identifer" -> "identifier".

This is the platyPS source markdown, so the correction flows into the generated help.
