### PR TITLE
Add support for Bicep distinct and like functions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,8 @@ What's changed since pre-release v1.48.0-B0228:
 - General improvements:
   - Added support for resolving filtered subnet IDs from existing virtual networks during Bicep expansion.
     [#2159](https://github.com/Azure/PSRule.Rules.Azure/issues/2159)
+  - Added support for the Bicep `distinct` and `like` functions.
+    [#3905](https://github.com/Azure/PSRule.Rules.Azure/issues/3905)
 - Updated rules:
   - Container Registry:
     - Deprecated `Azure.ACR.GeoReplica` because ACR zone redundancy is automatic in supported regions.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,7 +35,7 @@ What's changed since pre-release v1.48.0-B0228:
 - General improvements:
   - Added support for resolving filtered subnet IDs from existing virtual networks during Bicep expansion.
     [#2159](https://github.com/Azure/PSRule.Rules.Azure/issues/2159)
-  - Added support for the Bicep `distinct` and `like` functions.
+  - Added support for the Bicep `distinct` and `like` functions by @oWretch.
     [#3905](https://github.com/Azure/PSRule.Rules.Azure/issues/3905)
 - Updated rules:
   - Container Registry:

--- a/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
+++ b/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Web;
 using System.Xml;
@@ -64,6 +65,7 @@ internal static class Functions
         new FunctionDescriptor("contains", Contains),
         new FunctionDescriptor("createArray", CreateArray),
         new FunctionDescriptor("createObject", CreateObject),
+        new FunctionDescriptor("distinct", Distinct),
         new FunctionDescriptor("empty", Empty),
         new FunctionDescriptor("first", First),
         new FunctionDescriptor("flatten", Flatten),
@@ -169,6 +171,7 @@ internal static class Functions
         // last - also in array and object
         new FunctionDescriptor("lastIndexOf", LastIndexOf),
         // length - also in array and object
+        new FunctionDescriptor("like", Like),
         new FunctionDescriptor("newGuid", NewGuid),
         new FunctionDescriptor("padLeft", PadLeft),
         new FunctionDescriptor("replace", Replace),
@@ -392,6 +395,29 @@ internal static class Functions
             properties[i] = new JProperty(name, ExpressionHelpers.GetJToken(args[i * 2 + 1]));
         }
         return new JObject(properties);
+    }
+
+    /// <summary>
+    /// distinct(arrayToModify)
+    /// </summary>
+    /// <remarks>
+    /// See <seealso href="https://learn.microsoft.com/azure/azure-resource-manager/templates/template-functions-array#distinct"/>.
+    /// </remarks>
+    internal static object Distinct(ITemplateContext context, object[] args)
+    {
+        if (CountArgs(args) != 1)
+            throw ArgumentsOutOfRange(nameof(Distinct), args);
+
+        if (!ExpressionHelpers.TryJArray(args[0], out var array))
+            throw ArgumentFormatInvalid(nameof(Distinct));
+
+        var result = new JArray();
+        for (var i = 0; i < array.Count; i++)
+        {
+            if (!result.Any(item => JToken.DeepEquals(item, array[i])))
+                result.Add(array[i].DeepClone());
+        }
+        return result;
     }
 
     /// <summary>
@@ -1963,6 +1989,15 @@ internal static class Functions
             throw ArgumentInvalidStringArray(nameof(Join), "inputArray");
 
         return string.Join(delimiter, inputArray);
+    }
+
+    internal static object Like(ITemplateContext context, object[] args)
+    {
+        if (args == null || args.Length != 2 || !ExpressionHelpers.TryString(args[0], out var stringToCheck) || !ExpressionHelpers.TryString(args[1], out var pattern))
+            throw ArgumentsOutOfRange(nameof(Like), args);
+
+        var expression = $"^{Regex.Escape(pattern).Replace("\\*", ".*")}$";
+        return Regex.IsMatch(stringToCheck, expression, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
     }
 
     internal static object NewGuid(ITemplateContext context, object[] args)

--- a/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
+++ b/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Web;
 using System.Xml;
@@ -1991,13 +1990,55 @@ internal static class Functions
         return string.Join(delimiter, inputArray);
     }
 
+    /// <summary>
+    /// Checks if the string matches a pattern that can contain the '*' wildcard.
+    /// The comparison is case-insensitive.
+    /// like(stringToCheck, pattern)
+    /// </summary>
+    /// <remarks>
+    /// See <seealso href="https://learn.microsoft.com/azure/azure-resource-manager/templates/template-functions-string#like"/>.
+    /// </remarks>
     internal static object Like(ITemplateContext context, object[] args)
     {
-        if (args == null || args.Length != 2 || !ExpressionHelpers.TryString(args[0], out var stringToCheck) || !ExpressionHelpers.TryString(args[1], out var pattern))
+        if (args == null || args.Length != 2)
             throw ArgumentsOutOfRange(nameof(Like), args);
 
-        var expression = $"^{Regex.Escape(pattern).Replace("\\*", ".*")}$";
-        return Regex.IsMatch(stringToCheck, expression, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        if (!ExpressionHelpers.TryString(args[0], out var stringToCheck))
+            throw ArgumentInvalidString(nameof(Like), "stringToCheck");
+
+        if (!ExpressionHelpers.TryString(args[1], out var pattern))
+            throw ArgumentInvalidString(nameof(Like), "pattern");
+
+        // Handle simple cases
+        if (pattern == "*")
+            return true;
+
+        if (!pattern.Contains("*"))
+            return string.Equals(stringToCheck, pattern, StringComparison.OrdinalIgnoreCase);
+
+        // Do the comparison without regex.
+        var endsWithWildcard = pattern[pattern.Length - 1] == '*';
+        var startsWithWildcard = pattern[0] == '*';
+        var parts = pattern.Split('*');
+        var currentIndex = 0;
+
+        if (!startsWithWildcard && !stringToCheck.StartsWith(parts[0], StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        foreach (var part in parts)
+        {
+            if (string.IsNullOrEmpty(part))
+                continue;
+
+            var index = stringToCheck.IndexOf(part, currentIndex, StringComparison.OrdinalIgnoreCase);
+            if (index == -1)
+                return false;
+
+            currentIndex = index + part.Length;
+        }
+
+        // Current index must be at the end of the string when we complete parsing.
+        return endsWithWildcard || currentIndex == stringToCheck.Length;
     }
 
     internal static object NewGuid(ITemplateContext context, object[] args)

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/ExpressionBuilderTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/ExpressionBuilderTests.cs
@@ -159,6 +159,26 @@ public sealed class ExpressionBuilderTests
         Assert.Equal("/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000", actual.Value<string>());
     }
 
+    [Fact]
+    public void BuildExpressionWithDistinct()
+    {
+        var context = GetContext();
+
+        var actual = Build(context, "[length(distinct(createArray('a', 'b', 'a')))]");
+
+        Assert.Equal((long)2, actual);
+    }
+
+    [Fact]
+    public void BuildExpressionWithLike()
+    {
+        var context = GetContext();
+
+        var actual = Build(context, "[like('prod-eastus-vm01', '*prod*')]");
+
+        Assert.True((bool)actual);
+    }
+
     private static object Build(TemplateContext context, string expression)
     {
         var builder = new ExpressionBuilder();

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
@@ -197,6 +197,40 @@ public sealed class FunctionTests
 
     [Fact]
     [Trait(TRAIT, TRAIT_ARRAY)]
+    public void Distinct()
+    {
+        var context = GetContext();
+
+        var actual1 = Functions.Distinct(context, [new JArray(1, 2, 2, 3, 1)]) as JArray;
+        Assert.Equal([1, 2, 3], actual1.Values<int>().ToArray());
+
+        var actual2 = Functions.Distinct(context, [new JArray("apple", "banana", "apple", "cherry")]) as JArray;
+        Assert.Equal(["apple", "banana", "cherry"], actual2.Values<string>().ToArray());
+
+        var actual3 = Functions.Distinct(context, [JArray.Parse("[ { \"name\": \"storage1\", \"type\": \"Microsoft.Storage/storageAccounts\" }, { \"name\": \"vm1\", \"type\": \"Microsoft.Compute/virtualMachines\" }, { \"name\": \"storage1\", \"type\": \"Microsoft.Storage/storageAccounts\" } ]")]) as JArray;
+        Assert.Equal(2, actual3.Count);
+        Assert.Equal("storage1", actual3[0]["name"]);
+        Assert.Equal("vm1", actual3[1]["name"]);
+
+        var actual4 = Functions.Distinct(context, [JArray.Parse("[ [ 1, 2 ], [ 2, 3 ], [ 1, 2 ] ]")]) as JArray;
+        Assert.Equal(2, actual4.Count);
+        Assert.True(JToken.DeepEquals(JArray.Parse("[ 1, 2 ]"), actual4[0]));
+        Assert.True(JToken.DeepEquals(JArray.Parse("[ 2, 3 ]"), actual4[1]));
+
+        var actual5 = Functions.Distinct(context, [new object[] { "one", "two", "one" }]) as JArray;
+        Assert.Equal(["one", "two"], actual5.Values<string>().ToArray());
+
+        var actual6 = Functions.Distinct(context, [new JArray()]) as JArray;
+        Assert.Empty(actual6);
+
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Distinct(context, null));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Distinct(context, []));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Distinct(context, [new JArray(), new JArray()]));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Distinct(context, [1]));
+    }
+
+    [Fact]
+    [Trait(TRAIT, TRAIT_ARRAY)]
     public void Empty()
     {
         var context = GetContext();
@@ -2016,6 +2050,30 @@ public sealed class FunctionTests
         Assert.Throws<ExpressionArgumentException>(() => Functions.Join(context, ["test"]));
         Assert.Throws<ExpressionArgumentException>(() => Functions.Join(context, [1, 1]));
         Assert.Throws<ExpressionArgumentException>(() => Functions.Join(context, [new int[] { 1, 2 }, 1]));
+    }
+
+    [Fact]
+    [Trait(TRAIT, TRAIT_STRING)]
+    public void Like()
+    {
+        var context = GetContext();
+
+        Assert.True((bool)Functions.Like(context, ["prod-eastus-vm01", "*prod*"]));
+        Assert.True((bool)Functions.Like(context, ["prod-eastus-vm01", "prod*"]));
+        Assert.True((bool)Functions.Like(context, ["prod-eastus-vm01", "*01"]));
+        Assert.True((bool)Functions.Like(context, ["prod-eastus-vm01", "prod-eastus-vm01"]));
+        Assert.True((bool)Functions.Like(context, ["PROD-eastus-vm01", "prod*"]));
+        Assert.True((bool)Functions.Like(context, ["prod-eastus-vm??", "prod-eastus-vm??"]));
+        Assert.False((bool)Functions.Like(context, ["prod-eastus-vm01", "*westus*"]));
+        Assert.False((bool)Functions.Like(context, ["prod-eastus-vm01", "prod"]));
+        Assert.False((bool)Functions.Like(context, ["prod-eastus-vm01", "prod-eastus-vm??"]));
+
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Like(context, null));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Like(context, []));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Like(context, ["prod-eastus-vm01"]));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Like(context, ["prod-eastus-vm01", "*prod*", "extra"]));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Like(context, [1, "*prod*"]));
+        Assert.Throws<ExpressionArgumentException>(() => Functions.Like(context, ["prod-eastus-vm01", 1]));
     }
 
     [Fact]

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
@@ -2064,9 +2064,16 @@ public sealed class FunctionTests
         Assert.True((bool)Functions.Like(context, ["prod-eastus-vm01", "prod-eastus-vm01"]));
         Assert.True((bool)Functions.Like(context, ["PROD-eastus-vm01", "prod*"]));
         Assert.True((bool)Functions.Like(context, ["prod-eastus-vm??", "prod-eastus-vm??"]));
+        Assert.True((bool)Functions.Like(context, ["prod-eastus-vm01", "prod-*-vm01"]));
+        Assert.True((bool)Functions.Like(context, ["PROD-eastus-vm01", "prod-eastus-vm01"]));
+        Assert.True((bool)Functions.Like(context, ["PROD-eastus-vm01", "prod-**-vm01"]));
+
         Assert.False((bool)Functions.Like(context, ["prod-eastus-vm01", "*westus*"]));
         Assert.False((bool)Functions.Like(context, ["prod-eastus-vm01", "prod"]));
         Assert.False((bool)Functions.Like(context, ["prod-eastus-vm01", "prod-eastus-vm??"]));
+        Assert.False((bool)Functions.Like(context, ["vm01-eastus-prod", "prod-*-vm01"]));
+        Assert.False((bool)Functions.Like(context, ["prod-eastus-vm01", "prod-*-vm"]));
+        Assert.False((bool)Functions.Like(context, ["prod-eastus-vm01", "od-*-vm01"]));
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.Like(context, null));
         Assert.Throws<ExpressionArgumentException>(() => Functions.Like(context, []));


### PR DESCRIPTION
## PR Summary

- Add support for the ARM/Bicep runtime `distinct(...)` function in expression expansion.
- Add support for the ARM/Bicep runtime `like(...)` function in expression expansion.
- Add direct function coverage and expression builder coverage for both functions.
- Update the changelog.

Fixes #3905

## Validation

- `dotnet test tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj --filter "FullyQualifiedName~Arm.Expressions.FunctionTests|FullyQualifiedName~Arm.Expressions.ExpressionBuilderTests" /p:EnableSourceControlManagerQueries=false /p:PublishRepositoryUrl=false /p:EmbedUntrackedSources=false`
- Built Release module output as `1.48.0-B0230`.
- Installed locally over current-user `1.48.0-B0228`.
- Validated template expansion resolves `distinct(...)` and `like(...)` through the installed module.