### PR TITLE
fix: Add typed CIDR placeholders for unresolved address prefixes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,9 @@ What's changed since pre-release v1.48.0-B0228:
   - Container Registry:
     - Deprecated `Azure.ACR.GeoReplica` because ACR zone redundancy is automatic in supported regions.
       [#3846](https://github.com/Azure/PSRule.Rules.Azure/issues/3846)
+- Bug fixes:
+  - Fixed `cidrHost` and `cidrSubnet` failing on unresolved virtual network, subnet, and IPAM pool address prefixes by @oWretch.
+    [#3907](https://github.com/Azure/PSRule.Rules.Azure/issues/3907)
 - Engineering:
   - Bump YamlDotNet to 11.2.5.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,8 @@ What's changed since pre-release v1.48.0-B0228:
 - Bug fixes:
   - Fixed `cidrHost` and `cidrSubnet` failing on unresolved virtual network, subnet, and IPAM pool address prefixes by @oWretch.
     [#3907](https://github.com/Azure/PSRule.Rules.Azure/issues/3907)
+  - Fixed `tryGet` throwing instead of returning `null` for a property lookup against an array by @oWretch.
+    [#3907](https://github.com/Azure/PSRule.Rules.Azure/issues/3907)
 - Engineering:
   - Bump YamlDotNet to 11.2.5.
 

--- a/src/PSRule.Rules.Azure/Arm/Deployments/TemplateContext.cs
+++ b/src/PSRule.Rules.Azure/Arm/Deployments/TemplateContext.cs
@@ -219,11 +219,32 @@ internal abstract partial class DeploymentVisitor
                 return false;
 
             var resourceId = nameOrResourceId;
+            IResourceValue? symbolResource = null;
             if (_Symbols.TryGetValue(nameOrResourceId, out var symbol) && symbol != null)
-                resourceId = symbol.GetId(0);
+            {
+                symbol.TryGetResource(0, out symbolResource);
+
+                // The ID of an existing resource is expanded on demand and may not be resolvable.
+                try
+                {
+                    resourceId = symbol.GetId(0);
+                }
+                catch
+                {
+                    resourceId = null;
+                }
+            }
 
             if (resourceId != null && _ResourceIds.TryGetValue(resourceId, out resource))
                 return true;
+
+            // Fall back to the resource attached to the symbol. Existing resources are tracked as symbols
+            // but are not added as deployable resources, so they are not in the resource ID lookup.
+            if (symbolResource != null)
+            {
+                resource = symbolResource;
+                return true;
+            }
 
             // Recurse search for resource in the parent deployment by original resource ID only.
             if (Parent != null && ResourceHelper.IsResourceId(nameOrResourceId) && Parent.TryGetResource(nameOrResourceId, out resource))
@@ -240,11 +261,27 @@ internal abstract partial class DeploymentVisitor
                 return false;
 
             var ids = array.GetIds();
-            resources = new IResourceValue[ids.Length];
+            var byId = new IResourceValue[ids.Length];
+            var resolved = true;
             for (var i = 0; i < ids.Length; i++)
-                resources[i] = _ResourceIds[ids[i]];
+            {
+                if (ids[i] == null || !_ResourceIds.TryGetValue(ids[i], out var item))
+                {
+                    resolved = false;
+                    break;
+                }
+                byId[i] = item;
+            }
 
-            return true;
+            if (resolved)
+            {
+                resources = byId;
+                return true;
+            }
+
+            // Fall back to the resources attached to the symbol for existing resources.
+            resources = array.GetResources();
+            return resources.Length > 0;
         }
 
 #nullable restore

--- a/src/PSRule.Rules.Azure/Arm/Expressions/ExpressionHelpers.cs
+++ b/src/PSRule.Rules.Azure/Arm/Expressions/ExpressionHelpers.cs
@@ -236,7 +236,7 @@ internal static class ExpressionHelpers
             return true;
         }
 
-        if (o is JToken jToken && o is not JValue)
+        if (o is JToken jToken && o is not JValue && o is not JArray)
         {
             var propertyToken = jToken[propertyName];
             if (propertyToken == null)

--- a/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
+++ b/src/PSRule.Rules.Azure/Arm/Expressions/Functions.cs
@@ -1151,10 +1151,13 @@ internal static class Functions
             return full ? deployment : deployment.Properties;
 
         if (resource.Existing && !resource.Value.TryGetProperty<JObject>(PROPERTY_PROPERTIES, out _))
-            return full ? new Mock.MockResource(resource.Id) : new Mock.MockResource(resource.Id)[PROPERTY_PROPERTIES];
+        {
+            var mockResourceId = GetResourceIdOrSymbolicName(resource);
+            return full ? new Mock.MockResource(mockResourceId, resource.Type) : new Mock.MockResource(mockResourceId, resource.Type)[PROPERTY_PROPERTIES];
+        }
 
         if (!full && resource.Value.TryGetProperty<JObject>(PROPERTY_PROPERTIES, out var properties))
-            return new Mock.MockObject(properties);
+            return new Mock.MockResourceObject(properties, GetResourceIdOrSymbolicName(resource), resource.Type);
 
         return new Mock.MockObject(full ? resource.Value : new JObject());
     }
@@ -2660,9 +2663,26 @@ internal static class Functions
             resourceId = resourceIdOrSymbolicName;
 
         if (context.TryGetResource(resourceIdOrSymbolicName, out var resource) && resource != null)
-            resourceId = resource.Id;
+            resourceId = GetResourceIdOrSymbolicName(resource);
 
         return resourceId != null;
+    }
+
+    /// <summary>
+    /// Get the resource ID of a resource, falling back to the symbolic name.
+    /// The ID of an existing resource is expanded on demand and may not be resolvable, for example when
+    /// the scope of the resource depends on a value that is not known during expansion.
+    /// </summary>
+    private static string GetResourceIdOrSymbolicName(IResourceValue resource)
+    {
+        try
+        {
+            return resource.Id;
+        }
+        catch
+        {
+            return resource.SymbolicName;
+        }
     }
 
     private static int Compare(object left, object right)

--- a/src/PSRule.Rules.Azure/Arm/Mocks/Mock.cs
+++ b/src/PSRule.Rules.Azure/Arm/Mocks/Mock.cs
@@ -12,6 +12,52 @@ namespace PSRule.Rules.Azure.Arm.Mocks;
 
 internal sealed class Mock
 {
+    private const string RESOURCE_TYPE_VIRTUAL_NETWORK = "Microsoft.Network/virtualNetworks";
+    private const string RESOURCE_TYPE_SUBNET = "Microsoft.Network/virtualNetworks/subnets";
+    private const string RESOURCE_TYPE_IPAM_POOL = "Microsoft.Network/networkManagers/ipamPools";
+    private const string PATH_VIRTUAL_NETWORK_ADDRESS_PREFIXES = "addressSpace.addressPrefixes";
+    private const string PATH_SUBNET_ADDRESS_PREFIX = "addressPrefix";
+    private const string PATH_SUBNET_ADDRESS_PREFIXES = "addressPrefixes";
+    private const string PLACEHOLDER_VIRTUAL_NETWORK_CIDR = "192.0.2.0/24";
+    private const string PLACEHOLDER_SUBNET_CIDR = "192.0.2.0/28";
+
+    private static readonly MockPlaceholderDescriptor[] _ResourcePlaceholders =
+    [
+        new(RESOURCE_TYPE_VIRTUAL_NETWORK, PATH_VIRTUAL_NETWORK_ADDRESS_PREFIXES, MockPlaceholderKind.Array, [PLACEHOLDER_VIRTUAL_NETWORK_CIDR]),
+        new(RESOURCE_TYPE_SUBNET, PATH_SUBNET_ADDRESS_PREFIX, MockPlaceholderKind.String, [PLACEHOLDER_SUBNET_CIDR]),
+        new(RESOURCE_TYPE_SUBNET, PATH_SUBNET_ADDRESS_PREFIXES, MockPlaceholderKind.Array, [PLACEHOLDER_SUBNET_CIDR]),
+        new(RESOURCE_TYPE_IPAM_POOL, PATH_SUBNET_ADDRESS_PREFIXES, MockPlaceholderKind.Array, [PLACEHOLDER_VIRTUAL_NETWORK_CIDR]),
+    ];
+
+    private enum MockPlaceholderKind
+    {
+        String,
+        Array
+    }
+
+    private sealed class MockPlaceholderDescriptor(string resourceType, string propertyPath, MockPlaceholderKind kind, string[] values)
+    {
+        public string ResourceType { get; } = resourceType;
+
+        public string PropertyPath { get; } = propertyPath;
+
+        public MockPlaceholderKind Kind { get; } = kind;
+
+        private string[] Values { get; } = values;
+
+        public bool TryGetValue(bool secret, out MockValue value)
+        {
+            value = Values.Length > 0 ? new MockValue(Values[0], secret) : null!;
+            return Values.Length > 0;
+        }
+
+        public void AddValues(JArray array, bool secret)
+        {
+            for (var i = 0; i < Values.Length; i++)
+                array.Add(new MockValue(Values[i], secret));
+        }
+    }
+
     /// <summary>
     /// Mock an unknown property or value.
     /// </summary>
@@ -79,10 +125,14 @@ internal sealed class Mock
     internal sealed class MockResource : MockUnknownObject
     {
         public MockResource(string resourceId)
+            : this(resourceId, resourceType: null) { }
+
+        public MockResource(string resourceId, string? resourceType)
             : base()
         {
             ResourceId = resourceId;
-            ResourceHelper.TryResourceIdComponents(resourceId, out var subscriptionId, out var resourceGroupName, out string? resourceType, out string? name);
+            ResourceHelper.TryResourceIdComponents(resourceId, out var subscriptionId, out var resourceGroupName, out string? resourceIdType, out string? name);
+            ResourceType = resourceType ?? resourceIdType ?? string.Empty;
             if (resourceId != null)
             {
                 Add("id", new JValue(resourceId));
@@ -93,9 +143,9 @@ internal sealed class Mock
                 Add("subscriptionId", new JValue(subscriptionId));
             }
 
-            if (resourceType != null)
+            if (ResourceType.Length > 0)
             {
-                Add("type", new JValue(resourceType));
+                Add("type", new JValue(ResourceType));
             }
 
             if (name != null)
@@ -103,11 +153,13 @@ internal sealed class Mock
                 Add("name", new JValue(name));
             }
 
-            var properties = new MockResourceProperties(resourceId ?? string.Empty);
+            var properties = new MockResourceProperties(resourceId ?? string.Empty, ResourceType);
             Add("properties", properties);
         }
 
         public string ResourceId { get; }
+
+        public string ResourceType { get; }
 
         public override JToken? this[object key] { get => base[key]; set => base[key] = value; }
 
@@ -125,58 +177,142 @@ internal sealed class Mock
     internal sealed class MockResourceProperties : MockUnknownObject
     {
         private readonly string _ResourceId;
+        private readonly string _ResourceType;
 
-        public MockResourceProperties(string resourceId)
+        public MockResourceProperties(string resourceId, string resourceType)
             : base()
         {
             _ResourceId = resourceId;
+            _ResourceType = resourceType;
         }
 
         protected override JToken CreateUnknownProperty(object key)
         {
-            return key is string propertyName ? new MockResourceProperty(_ResourceId, propertyName, IsSecret) : base.CreateUnknownProperty(key);
+            return key is string propertyName ? CreateResourceProperty(_ResourceId, _ResourceType, propertyName, propertyName, IsSecret) : base.CreateUnknownProperty(key);
+        }
+    }
+
+    /// <summary>
+    /// The <c>properties</c> of a resource that is known, but may only define a subset of its properties.
+    /// Concrete properties are returned as-is, while known address properties that were not defined in the
+    /// source resolve to a typed placeholder instead of an unknown value.
+    /// </summary>
+    internal sealed class MockResourceObject : MockObject
+    {
+        private readonly string _ResourceId;
+        private readonly string _ResourceType;
+
+        public MockResourceObject(JObject value, string resourceId, string resourceType)
+            : base(value)
+        {
+            _ResourceId = resourceId;
+            _ResourceType = resourceType;
+        }
+
+        protected override JToken CreateUnknownProperty(object key)
+        {
+            return key is string propertyName ? CreateResourceProperty(_ResourceId, _ResourceType, propertyName, propertyName, IsSecret) : base.CreateUnknownProperty(key);
         }
     }
 
     internal sealed class MockResourceProperty : MockUnknownObject, IMockResourceCollection
     {
         private readonly string _ResourceId;
+        private readonly string _ResourceType;
         private readonly string _PropertyName;
+        private readonly string _PropertyPath;
         private MockResourcePropertyArray? _Array;
 
-        public MockResourceProperty(string resourceId, string propertyName, bool secret)
+        public MockResourceProperty(string resourceId, string resourceType, string propertyName, bool secret)
+            : this(resourceId, resourceType, propertyName, propertyName, secret) { }
+
+        internal MockResourceProperty(string resourceId, string resourceType, string propertyName, string propertyPath, bool secret)
             : base(secret)
         {
             _ResourceId = resourceId;
+            _ResourceType = resourceType;
             _PropertyName = propertyName;
+            _PropertyPath = propertyPath;
         }
 
         public override JToken? GetValue(TypePrimitive type)
         {
+            if (type == TypePrimitive.Array && TryGetPlaceholder(out var descriptor) && descriptor.Kind == MockPlaceholderKind.Array)
+                return ToArray();
+
             return type == TypePrimitive.Array ? ToArray() : base.GetValue(type);
+        }
+
+        public override JToken? GetValue(object key)
+        {
+            key = GetBaseObject(key);
+            if (TryGetPlaceholder(out var descriptor))
+            {
+                if (descriptor.Kind == MockPlaceholderKind.Array && key is int)
+                    return ToArray().GetValue(key);
+            }
+            return base.GetValue(key);
+        }
+
+        public override TValue? GetValue<TValue>() where TValue : default
+        {
+            if (typeof(TValue) == typeof(string) &&
+                TryGetPlaceholder(out var descriptor) &&
+                descriptor.Kind == MockPlaceholderKind.String &&
+                descriptor.TryGetValue(IsSecret, out var value) &&
+                value.Value<string>() is TValue result)
+                return result;
+
+            return base.GetValue<TValue>();
         }
 
         private MockResourcePropertyArray ToArray()
         {
-            return _Array ??= new MockResourcePropertyArray(_ResourceId, _PropertyName, IsSecret);
+            return _Array ??= new MockResourcePropertyArray(_ResourceId, _ResourceType, _PropertyName, _PropertyPath, IsSecret);
         }
 
         public MockResourcePropertyItem CreateItem()
         {
             return new MockResourcePropertyItem(_ResourceId, _PropertyName, IsSecret);
         }
+
+        protected override JToken CreateUnknownProperty(object key)
+        {
+            return key is string propertyName ? CreateResourceProperty(_ResourceId, _ResourceType, propertyName, string.Concat(_PropertyPath, ".", propertyName), IsSecret) : base.CreateUnknownProperty(key);
+        }
+
+        private bool TryGetPlaceholder(out MockPlaceholderDescriptor descriptor)
+        {
+            return TryResourcePlaceholder(_ResourceType, _PropertyPath, out descriptor);
+        }
     }
 
     internal sealed class MockResourcePropertyArray : MockArray, IMockResourceCollection
     {
         private readonly string _ResourceId;
+        private readonly string _ResourceType;
         private readonly string _PropertyName;
+        private readonly string _PropertyPath;
 
-        public MockResourcePropertyArray(string resourceId, string propertyName, bool secret)
+        public MockResourcePropertyArray(string resourceId, string resourceType, string propertyName, string propertyPath, bool secret)
             : base(secret)
         {
             _ResourceId = resourceId;
+            _ResourceType = resourceType;
             _PropertyName = propertyName;
+            _PropertyPath = propertyPath;
+
+            if (TryResourcePlaceholder(_ResourceType, _PropertyPath, out var descriptor) && descriptor.Kind == MockPlaceholderKind.Array)
+                descriptor.AddValues(this, secret);
+        }
+
+        public override JToken? GetValue(object key)
+        {
+            key = GetBaseObject(key);
+            if (key is int && TryResourcePlaceholder(_ResourceType, _PropertyPath, out var descriptor) && descriptor.TryGetValue(IsSecret, out var value))
+                return value;
+
+            return base.GetValue(key);
         }
 
         public MockResourcePropertyItem CreateItem()
@@ -359,7 +495,7 @@ internal sealed class Mock
             return type == TypePrimitive.None || type == TypePrimitive.Array ? this : null;
         }
 
-        public JToken? GetValue(object key)
+        public virtual JToken? GetValue(object key)
         {
             if (key is long l)
                 key = (int)l;
@@ -636,6 +772,35 @@ internal sealed class Mock
             return TypePrimitive.Bool;
 
         throw new NotImplementedException();
+    }
+
+    private static JToken CreateResourceProperty(string resourceId, string resourceType, string propertyName, string propertyPath, bool secret)
+    {
+        if (TryResourcePlaceholder(resourceType, propertyPath, out var descriptor))
+        {
+            if (descriptor.Kind == MockPlaceholderKind.Array)
+                return new MockResourcePropertyArray(resourceId, resourceType, propertyName, propertyPath, secret);
+
+            if (descriptor.TryGetValue(secret, out var value))
+                return value;
+        }
+        return new MockResourceProperty(resourceId, resourceType, propertyName, propertyPath, secret);
+    }
+
+    private static bool TryResourcePlaceholder(string resourceType, string propertyPath, out MockPlaceholderDescriptor descriptor)
+    {
+        descriptor = null!;
+        for (var i = 0; i < _ResourcePlaceholders.Length; i++)
+        {
+            var placeholder = _ResourcePlaceholders[i];
+            if (StringComparer.OrdinalIgnoreCase.Equals(resourceType, placeholder.ResourceType) &&
+                StringComparer.OrdinalIgnoreCase.Equals(propertyPath, placeholder.PropertyPath))
+            {
+                descriptor = placeholder;
+                return true;
+            }
+        }
+        return false;
     }
 
     private static bool TryWellKnownStringProperty(JObject o, string key, out JValue? value)

--- a/src/PSRule.Rules.Azure/Arm/Symbols/ArrayDeploymentSymbol.cs
+++ b/src/PSRule.Rules.Azure/Arm/Symbols/ArrayDeploymentSymbol.cs
@@ -15,13 +15,16 @@ namespace PSRule.Rules.Azure.Arm.Symbols;
 internal sealed class ArrayDeploymentSymbol(string name) : DeploymentSymbol(name), IDeploymentSymbol
 {
     private List<string>? _Ids;
+    private List<IResourceValue>? _Resources;
 
     public DeploymentSymbolKind Kind => DeploymentSymbolKind.Array;
 
     public void Configure(IResourceValue resource)
     {
+        _Resources ??= [];
+        _Resources.Add(resource);
         _Ids ??= [];
-        _Ids.Add(resource.Id);
+        _Ids.Add(TryResourceId(resource));
     }
 
     public string? GetId(int index)
@@ -29,9 +32,32 @@ internal sealed class ArrayDeploymentSymbol(string name) : DeploymentSymbol(name
         return _Ids?[index];
     }
 
+    public bool TryGetResource(int index, out IResourceValue? resource)
+    {
+        resource = _Resources != null && index >= 0 && index < _Resources.Count ? _Resources[index] : null;
+        return resource != null;
+    }
+
     public string[] GetIds()
     {
         return _Ids?.ToArray() ?? [];
+    }
+
+    public IResourceValue[] GetResources()
+    {
+        return _Resources?.ToArray() ?? [];
+    }
+
+    private static string TryResourceId(IResourceValue resource)
+    {
+        try
+        {
+            return resource.Id;
+        }
+        catch
+        {
+            return resource.SymbolicName;
+        }
     }
 }
 

--- a/src/PSRule.Rules.Azure/Arm/Symbols/IDeploymentSymbol.cs
+++ b/src/PSRule.Rules.Azure/Arm/Symbols/IDeploymentSymbol.cs
@@ -16,6 +16,8 @@ internal interface IDeploymentSymbol
     void Configure(IResourceValue r);
 
     string? GetId(int index);
+
+    bool TryGetResource(int index, out IResourceValue? resource);
 }
 
 #nullable restore

--- a/src/PSRule.Rules.Azure/Arm/Symbols/ObjectDeploymentSymbol.cs
+++ b/src/PSRule.Rules.Azure/Arm/Symbols/ObjectDeploymentSymbol.cs
@@ -14,6 +14,7 @@ namespace PSRule.Rules.Azure.Arm.Symbols;
 internal sealed class ObjectDeploymentSymbol : DeploymentSymbol, IDeploymentSymbol
 {
     private Func<string>? _GetId;
+    private IResourceValue? _Resource;
 
     public ObjectDeploymentSymbol(string name, IResourceValue? resource)
         : base(name)
@@ -26,12 +27,19 @@ internal sealed class ObjectDeploymentSymbol : DeploymentSymbol, IDeploymentSymb
 
     public void Configure(IResourceValue resource)
     {
+        _Resource = resource;
         _GetId = () => resource.Id;
     }
 
     public string? GetId(int index)
     {
         return _GetId == null ? null : _GetId();
+    }
+
+    public bool TryGetResource(int index, out IResourceValue? resource)
+    {
+        resource = _Resource;
+        return resource != null;
     }
 }
 

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
@@ -718,6 +718,7 @@ public sealed class FunctionTests
         };
 
         Assert.Equal("two", (Functions.TryGet(context, [testObject2, 1]) as JValue).Value<string>());
+        Assert.Null(Functions.TryGet(context, [testObject2, "addressPrefixes"]));
 
         Assert.Throws<ExpressionArgumentException>(() => Functions.TryGet(context, null));
         Assert.Throws<ExpressionArgumentException>(() => Functions.TryGet(context, []));

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/FunctionTests.cs
@@ -889,6 +889,115 @@ public sealed class FunctionTests
 
     [Fact]
     [Trait(TRAIT, TRAIT_RESOURCE)]
+    public void ReferenceWithNetworkAddressPlaceholders()
+    {
+        var context = GetContext();
+        var vnetId = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-001";
+        var subnetId = string.Concat(vnetId, "/subnets/subnet-001");
+
+        var vnet = Functions.Reference(context, [vnetId]) as Mock.MockObject;
+        Assert.NotNull(vnet);
+        var vnetPrefixes = vnet["addressSpace"]["addressPrefixes"] as Mock.MockArray;
+        Assert.NotNull(vnetPrefixes);
+        Assert.Equal("192.0.2.0/24", vnetPrefixes[0].Value<string>());
+        Assert.Equal("192.0.2.4", Functions.CidrHost(context, [vnetPrefixes[0], 3]) as string);
+        Assert.Throws<ExpressionArgumentException>(() => Functions.CidrHost(context, [vnetPrefixes, 3]));
+
+        var subnet = Functions.Reference(context, [subnetId]) as Mock.MockObject;
+        Assert.NotNull(subnet);
+        Assert.Equal("192.0.2.0/28", subnet["addressPrefix"].Value<string>());
+        var subnetPrefixes = subnet["addressPrefixes"] as Mock.MockArray;
+        Assert.NotNull(subnetPrefixes);
+        Assert.Equal("192.0.2.0/28", subnetPrefixes[0].Value<string>());
+        Assert.Equal("192.0.2.4", Functions.CidrHost(context, [subnetPrefixes[0], 3]) as string);
+
+        var subnetFull = Functions.Reference(context, [subnetId, "2025-07-01", "Full"]) as Mock.MockObject;
+        Assert.NotNull(subnetFull);
+        Assert.Throws<ExpressionArgumentException>(() => Functions.CidrHost(context, [subnetFull["id"], 3]));
+    }
+
+    [Fact]
+    [Trait(TRAIT, TRAIT_RESOURCE)]
+    public void ReferenceWithExistingNetworkAddressSymbols()
+    {
+        var context = GetContext();
+        var vnet = new ExistingResourceValue(context, "Microsoft.Network/virtualNetworks", "vnet", JObject.Parse(@"
+{
+  ""name"": ""vnet-001"",
+  ""properties"": {
+    ""ipamPoolPrefixAllocations"": []
+  }
+}"), null);
+        var subnet = new ExistingResourceValue(context, "Microsoft.Network/virtualNetworks/subnets", "vnet::subnet", JObject.Parse(@"
+{
+  ""name"": ""subnet-001"",
+  ""properties"": {
+    ""ipamPoolPrefixAllocations"": []
+  }
+}"), null);
+        var pool = new ExistingResourceValue(context, "Microsoft.Network/networkManagers/ipamPools", "networkManager::platformPool", JObject.Parse(@"
+{
+  ""name"": ""platformPool""
+}"), null);
+        context.AddSymbol(DeploymentSymbol.NewObject("vnet", vnet));
+        context.AddSymbol(DeploymentSymbol.NewObject("vnet::subnet", subnet));
+        context.AddSymbol(DeploymentSymbol.NewObject("networkManager::platformPool", pool));
+
+        var vnetProperties = Functions.Reference(context, ["vnet"]) as Mock.MockObject;
+        Assert.NotNull(vnetProperties);
+        Assert.Equal("192.0.2.0/24", vnetProperties["addressSpace"]["addressPrefixes"][0].Value<string>());
+
+        var subnetProperties = Functions.Reference(context, ["vnet::subnet"]) as Mock.MockObject;
+        Assert.NotNull(subnetProperties);
+        Assert.Equal("192.0.2.0/28", subnetProperties["addressPrefixes"][0].Value<string>());
+        Assert.Equal("192.0.2.4", Functions.CidrHost(context, [subnetProperties["addressPrefixes"][0], 3]) as string);
+
+        var poolProperties = Functions.Reference(context, ["networkManager::platformPool"]) as Mock.MockObject;
+        Assert.NotNull(poolProperties);
+        Assert.Equal("192.0.2.0/24", poolProperties["addressPrefixes"][0].Value<string>());
+        Assert.Equal("192.0.2.0/23", Functions.CidrSubnet(context, [poolProperties["addressPrefixes"][0], 23, 0]) as string);
+
+        var subnetResourceId = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-001/subnets/ApplicationGatewaySubnet";
+        var deployedSubnet = new ResourceValue(subnetResourceId, "ApplicationGatewaySubnet", "Microsoft.Network/virtualNetworks/subnets", "vnet::deployedSubnet", JObject.Parse(@"
+{
+  ""properties"": {
+    ""ipamPoolPrefixAllocations"": []
+  }
+}"), null);
+        context.AddResource(deployedSubnet);
+        context.AddSymbol(DeploymentSymbol.NewObject("vnet::deployedSubnet", deployedSubnet));
+
+        var deployedSubnetProperties = Functions.Reference(context, ["vnet::deployedSubnet"]) as Mock.MockObject;
+        Assert.NotNull(deployedSubnetProperties);
+        Assert.Equal("192.0.2.0/28", deployedSubnetProperties["addressPrefixes"][0].Value<string>());
+        Assert.Equal("192.0.2.4", Functions.CidrHost(context, [deployedSubnetProperties["addressPrefixes"][0], 3]) as string);
+    }
+
+    [Fact]
+    [Trait(TRAIT, TRAIT_RESOURCE)]
+    public void ReferenceUsesConcreteNetworkAddressProperties()
+    {
+        var context = GetContext();
+        var resourceId = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-001";
+        var resource = new ResourceValue(resourceId, "vnet-001", "Microsoft.Network/virtualNetworks", "vnet", JObject.Parse(@"
+{
+  ""properties"": {
+    ""addressSpace"": {
+      ""addressPrefixes"": [
+        ""203.0.113.0/24""
+      ]
+    }
+  }
+}"), null);
+        context.AddResource(resource);
+
+        var actual = Functions.Reference(context, [resourceId]) as Mock.MockObject;
+        Assert.NotNull(actual);
+        Assert.Equal("203.0.113.0/24", actual["addressSpace"]["addressPrefixes"][0].Value<string>());
+    }
+
+    [Fact]
+    [Trait(TRAIT, TRAIT_RESOURCE)]
     public void References()
     {
         var context = GetContext();


### PR DESCRIPTION
Fixes #3907

## Problem

When address prefixes are allocated at deployment time — for example by Azure Virtual Network Manager IPAM pools — `reference()` cannot resolve them during Bicep expansion. The unresolved property came back empty, and the empty value was then passed straight into `cidrHost()` / `cidrSubnet()`:

```
cidrSubnet(reference('networkManager::platformPool').addressPrefixes[0], 23, 0)
> The specified CIDR '' is not valid.

cidrHost(reference('vnet::subnet').addressPrefixes[0], 3)
> The specified CIDR '' is not valid.
```

This makes it impossible to validate otherwise-correct templates that use IPAM-allocated address space.

## Approach

Add a source-aware placeholder table in `Mock.cs`, keyed on **resource type + normalized property path**. When a property cannot be resolved, expansion now returns a *typed* mock value appropriate for that property rather than an empty one.

Covered today:

| Resource type | Property path | Placeholder |
| --- | --- | --- |
| `Microsoft.Network/virtualNetworks` | `addressSpace.addressPrefixes` | `["192.0.2.0/24"]` |
| `Microsoft.Network/virtualNetworks/subnets` | `addressPrefix` | `"192.0.2.0/28"` |
| `Microsoft.Network/virtualNetworks/subnets` | `addressPrefixes` | `["192.0.2.0/28"]` |
| `Microsoft.Network/networkManagers/ipamPools` | `addressPrefixes` | `["192.0.2.0/24"]` |

Placeholders use RFC 5737 TEST-NET-1 (`192.0.2.0/24`) so they are obvious in output and cannot collide with real customer address space.

The table is the extension point — other resources with inferable properties (network interfaces, firewalls, DNS resolver endpoints, and so on) can be added later by adding rows, without further changes to the expansion code.

To make this work for both `existing` and deployed resources, resource type context is now carried through symbol lookup:

- `IDeploymentSymbol` gains `TryGetResource`, implemented by `ObjectDeploymentSymbol` and `ArrayDeploymentSymbol`, so symbol-only (existing) resources retain their type.
- `MockResourceObject` supplies typed placeholders for *missing* properties on a known resource while keeping normal object semantics, so partially-known `properties` objects don't lose resource type context.
- `TemplateContext.TryGetResource` keeps the `_ResourceIds` lookup authoritative (so module/deployment references still return a `DeploymentValue`), falling back to the symbol-attached resource.

## The `cidr*()` functions stay strict

This deliberately does **not** relax `cidrHost()` / `cidrSubnet()`. Only indexed access into a placeholder array yields a CIDR string — `MockResourcePropertyArray` remains a `MockArray`. So genuine authoring mistakes still fail exactly as they do today:

- passing the wrong property, e.g. `reference('vnet').id`
- forgetting the index, e.g. `addressPrefixes` instead of `addressPrefixes[0]`
- singleton `addressPrefix` vs array `addressPrefixes` confusion

## Additional fix: `tryGet()` on arrays

While validating against a wider set of real templates, found a related expansion failure with a different shape:

```
coalesce(
  tryGet(lambdaVariables('env').value, 'addressPrefixes'),
  lambdaVariables('env').value
)
```

Here `env.value` may be either an object with an `addressPrefixes` property, or an array of CIDR strings directly. ARM/Bicep `tryGet(array, 'propertyName')` should return `null` for an invalid property lookup so `coalesce()` falls back to the array, but PSRule threw:

```
Accessed JArray values with invalid key value: "addressPrefixes". Int32 array index expected.
```

`ExpressionHelpers.TryPropertyOrField` treated any non-`JValue` `JToken`, including `JArray`, as a property bag. Excluded `JArray` from that branch so it returns `false` for an array + string property, and `Functions.TryGet()` returns `null` as intended.

## Testing

- New cases in `FunctionTests.cs` covering placeholder resolution, existing/deployed symbol resolution, that concrete values are still preferred over placeholders, and `tryGet()` returning `null` for an array.
- Full test suite green: 402 passed, 0 failed.
- Validated against real templates that previously failed expansion, including one using the `tryGet`/`coalesce` shape above; all now expand and evaluate cleanly.
