### PR TITLE
fix: Resolve outputs from modules deployed to a different scope

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,10 @@ What's changed since pre-release v1.48.0-B0228:
 - General improvements:
   - Added support for resolving filtered subnet IDs from existing virtual networks during Bicep expansion.
     [#2159](https://github.com/Azure/PSRule.Rules.Azure/issues/2159)
+- Bug fixes:
+  - Fixed expansion failing with `Hash must be finalized before the hash value is retrieved` when an object output
+    from a cross-scope module is used by a string function such as `guid`.
+    [#3909](https://github.com/Azure/PSRule.Rules.Azure/issues/3909)
 - Updated rules:
   - Container Registry:
     - Deprecated `Azure.ACR.GeoReplica` because ACR zone redundancy is automatic in supported regions.

--- a/src/PSRule.Rules.Azure/Arm/Deployments/DeploymentVisitor.cs
+++ b/src/PSRule.Rules.Azure/Arm/Deployments/DeploymentVisitor.cs
@@ -599,16 +599,26 @@ internal abstract partial class DeploymentVisitor : ResourceManagerVisitor
             return context.Deployment.DeploymentScope;
         }
 
+        // Handle special case for cross-scope deployments which set an explicit scope, such as a nested management group.
+        ResolveScopeProperty(context, resource, out var scopeTenant, out var scopeManagementGroup, out var scopeSubscriptionId, out var scopeResourceGroupName);
+        if (scopeTenant != null)
+        {
+            managementGroup = null;
+            subscriptionId = null;
+            resourceGroupName = null;
+            return DeploymentScope.Tenant;
+        }
+
         // Handle special case for cross-scope deployments which may have an alternative subscription or resource group set.
         subscriptionId = ResolveDeploymentScopeProperty(context, resource, PROPERTY_SUBSCRIPTION_ID, contextValue:
-            context.Deployment.DeploymentScope == DeploymentScope.Subscription ||
-            context.Deployment.DeploymentScope == DeploymentScope.ResourceGroup ? context.Subscription.SubscriptionId : null);
+            scopeSubscriptionId ?? (context.Deployment.DeploymentScope == DeploymentScope.Subscription ||
+            context.Deployment.DeploymentScope == DeploymentScope.ResourceGroup ? context.Subscription.SubscriptionId : null));
 
         resourceGroupName = ResolveDeploymentScopeProperty(context, resource, PROPERTY_RESOURCE_GROUP, contextValue:
-            context.Deployment.DeploymentScope == DeploymentScope.ResourceGroup ? context.ResourceGroup.Name : null);
+            scopeResourceGroupName ?? (context.Deployment.DeploymentScope == DeploymentScope.ResourceGroup ? context.ResourceGroup.Name : null));
 
         managementGroup = ResolveDeploymentScopeProperty(context, resource, PROPERTY_MANAGEMENT_GROUP, contextValue:
-            context.Deployment.DeploymentScope == DeploymentScope.ManagementGroup ? context.ManagementGroup.Name : null);
+            scopeManagementGroup ?? (context.Deployment.DeploymentScope == DeploymentScope.ManagementGroup ? context.ManagementGroup.Name : null));
 
         // Update the deployment scope.
         if (context.Deployment.DeploymentScope == DeploymentScope.ResourceGroup || resourceGroupName != null)
@@ -625,6 +635,23 @@ internal abstract partial class DeploymentVisitor : ResourceManagerVisitor
         }
 
         return context.Deployment.DeploymentScope;
+    }
+
+    /// <summary>
+    /// Get the target scope components from an explicit <c>scope</c> property set on the resource.
+    /// </summary>
+    private static void ResolveScopeProperty(TemplateContext context, JObject resource, out string tenant, out string managementGroup, out string subscriptionId, out string resourceGroupName)
+    {
+        tenant = null;
+        managementGroup = null;
+        subscriptionId = null;
+        resourceGroupName = null;
+
+        var scopeId = context.ExpandProperty<string>(resource, PROPERTY_SCOPE);
+        if (string.IsNullOrEmpty(scopeId))
+            return;
+
+        ResourceHelper.ResourceIdComponents(scopeId, out tenant, out managementGroup, out subscriptionId, out resourceGroupName, out _, out _);
     }
 
     private static string ResolveDeploymentScopeProperty(TemplateContext context, JObject resource, string propertyName, string contextValue)

--- a/src/PSRule.Rules.Azure/Arm/Expressions/ExpressionHelpers.cs
+++ b/src/PSRule.Rules.Azure/Arm/Expressions/ExpressionHelpers.cs
@@ -970,12 +970,10 @@ internal static class ExpressionHelpers
             if (GetStringForMock(args[i], out var s) || TryString(args[i], out s))
             {
                 var b = Encoding.UTF8.GetBytes(s);
-                if (i == args.Length - 1)
-                    algorithm.TransformFinalBlock(b, 0, b.Length);
-                else
-                    algorithm.TransformBlock(b, 0, b.Length, null, 0);
+                algorithm.TransformBlock(b, 0, b.Length, null, 0);
             }
         }
+        algorithm.TransformFinalBlock([], 0, 0);
         return algorithm.Hash;
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/ExpressionHelpersTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Arm/Expressions/ExpressionHelpersTests.cs
@@ -29,6 +29,17 @@ public sealed class ExpressionHelpersTests
         Assert.Equal("9c7543ad4767e2", ExpressionHelpers.GetUniqueString(["test", "1234"]));
     }
 
+    /// <summary>
+    /// The hash must still be finalized when the last argument can not be converted to a string.
+    /// </summary>
+    [Fact]
+    public void GetUnique_WhenLastArgumentIsNotAString_ShouldNotThrow()
+    {
+        Assert.Equal("0b0d0856d2b1e9", ExpressionHelpers.GetUniqueString(["test", "123", null]));
+        Assert.Equal("0b0d0856d2b1e9", ExpressionHelpers.GetUniqueString(["test", "123", new JObject()]));
+        Assert.NotNull(ExpressionHelpers.GetUniqueString([]));
+    }
+
     [Theory]
     [InlineData(null, null)]
     [InlineData("test", "test")]

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/BicepSymbolicNameTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/BicepSymbolicNameTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Linq;
 using Newtonsoft.Json.Linq;
 using PSRule.Rules.Azure.Arm.Deployments;
 
@@ -76,5 +77,28 @@ public sealed class BicepSymbolicNameTests : TemplateVisitorTestsBase
             "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/ps-rule-test-rg/providers/Microsoft.Web/sites/example1-webapp",
             "/subscriptions/ffffffff-ffff-ffff-ffff-ffffffffffff/resourceGroups/ps-rule-test-rg/providers/Microsoft.Web/sites/example2-webapp"
         ], actual);
+    }
+
+    /// <summary>
+    /// A string sourced from an object typed module output must resolve to a string when
+    /// passed into a nested deployment and consumed by <c>guid()</c>.
+    /// </summary>
+    [Fact]
+    public void ProcessTemplate_WhenObjectOutputPropertyUsedInGuid_ShouldResolveUniqueNames()
+    {
+        var resources = ProcessTemplate(GetSourcePath("Bicep/SymbolicNameTestCases/Tests.Bicep.6.json"), null, out _);
+
+        var actual = resources.Where(r => r["type"].Value<string>() == "Microsoft.Authorization/roleAssignments").ToArray();
+        Assert.Equal(2, actual.Length);
+        Assert.NotEqual(actual[0]["name"].Value<string>(), actual[1]["name"].Value<string>());
+
+        // The role definition ID is sourced from an object typed output of a module deployed to a child management group.
+        foreach (var assignment in actual)
+        {
+            Assert.StartsWith(
+                "/providers/Microsoft.Management/managementGroups/mg-intermediate-root/providers/Microsoft.Authorization/roleDefinitions/",
+                assignment["properties"]["roleDefinitionId"].Value<string>());
+        }
+        System.Console.WriteLine("DUMP0: " + actual[0].ToString());
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.6.assignments.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.6.assignments.bicep
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+targetScope = 'managementGroup'
+
+type roleAssignmentInput = {
+  principalId: string
+  roleDefinitionId: string
+}
+
+param roleAssignments roleAssignmentInput[]
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for assignment in roleAssignments: {
+    name: guid(managementGroup().id, assignment.principalId, assignment.roleDefinitionId)
+    properties: {
+      principalId: assignment.principalId
+      principalType: 'ServicePrincipal'
+      roleDefinitionId: assignment.roleDefinitionId
+    }
+  }
+]

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.6.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.6.bicep
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+targetScope = 'managementGroup'
+
+resource intermediateRoot 'Microsoft.Management/managementGroups@2023-04-01' = {
+  scope: tenant()
+  name: 'mg-intermediate-root'
+  properties: {
+    displayName: 'Intermediate Root'
+  }
+}
+
+// A string sourced from an object typed module output must resolve to a string when
+// passed into a nested deployment and consumed by guid().
+module customRoles './Tests.Bicep.6.child.bicep' = {
+  name: 'customRoles'
+  scope: intermediateRoot
+}
+
+module roleAssignments './Tests.Bicep.6.assignments.bicep' = {
+  name: 'roleAssignments'
+  scope: intermediateRoot
+  params: {
+    roleAssignments: [
+      {
+        principalId: '00000000-0000-0000-0000-000000000001'
+        roleDefinitionId: customRoles.outputs.policyReader.id
+      }
+      {
+        principalId: '00000000-0000-0000-0000-000000000002'
+        roleDefinitionId: customRoles.outputs.policyReader.id
+      }
+    ]
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.6.child.bicep
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.6.child.bicep
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+targetScope = 'managementGroup'
+
+// Child module that returns an object typed output containing a resource id.
+resource roleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: guid('policyReader', managementGroup().id)
+  properties: {
+    roleName: 'Policy Reader'
+    description: 'Read only access to policy.'
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: [
+          'Microsoft.Authorization/policyAssignments/read'
+        ]
+      }
+    ]
+    assignableScopes: [
+      managementGroup().id
+    ]
+  }
+}
+
+output policyReader object = {
+  id: roleDefinition.id
+  name: roleDefinition.name
+}

--- a/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.6.json
+++ b/tests/PSRule.Rules.Azure.Tests/Bicep/SymbolicNameTestCases/Tests.Bicep.6.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.46.1.21595",
+      "templateHash": "9941330578015568133"
+    }
+  },
+  "resources": {
+    "intermediateRoot": {
+      "type": "Microsoft.Management/managementGroups",
+      "apiVersion": "2023-04-01",
+      "scope": "/",
+      "name": "mg-intermediate-root",
+      "properties": {
+        "displayName": "Intermediate Root"
+      }
+    },
+    "customRoles": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "customRoles",
+      "scope": "[format('Microsoft.Management/managementGroups/{0}', 'mg-intermediate-root')]",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.46.1.21595",
+              "templateHash": "14189568142377701359"
+            }
+          },
+          "resources": {
+            "roleDefinition": {
+              "type": "Microsoft.Authorization/roleDefinitions",
+              "apiVersion": "2022-04-01",
+              "name": "[guid('policyReader', managementGroup().id)]",
+              "properties": {
+                "roleName": "Policy Reader",
+                "description": "Read only access to policy.",
+                "type": "CustomRole",
+                "permissions": [
+                  {
+                    "actions": [
+                      "Microsoft.Authorization/policyAssignments/read"
+                    ]
+                  }
+                ],
+                "assignableScopes": [
+                  "[managementGroup().id]"
+                ]
+              }
+            }
+          },
+          "outputs": {
+            "policyReader": {
+              "type": "object",
+              "value": {
+                "id": "[extensionResourceId(managementGroup().id, 'Microsoft.Authorization/roleDefinitions', guid('policyReader', managementGroup().id))]",
+                "name": "[guid('policyReader', managementGroup().id)]"
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "intermediateRoot"
+      ]
+    },
+    "roleAssignments": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "roleAssignments",
+      "scope": "[format('Microsoft.Management/managementGroups/{0}', 'mg-intermediate-root')]",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "roleAssignments": {
+            "value": [
+              {
+                "principalId": "00000000-0000-0000-0000-000000000001",
+                "roleDefinitionId": "[reference('customRoles').outputs.policyReader.value.id]"
+              },
+              {
+                "principalId": "00000000-0000-0000-0000-000000000002",
+                "roleDefinitionId": "[reference('customRoles').outputs.policyReader.value.id]"
+              }
+            ]
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.46.1.21595",
+              "templateHash": "11034777190322056821"
+            }
+          },
+          "definitions": {
+            "roleAssignmentInput": {
+              "type": "object",
+              "properties": {
+                "principalId": {
+                  "type": "string"
+                },
+                "roleDefinitionId": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "parameters": {
+            "roleAssignments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/roleAssignmentInput"
+              }
+            }
+          },
+          "resources": {
+            "roleAssignment": {
+              "copy": {
+                "name": "roleAssignment",
+                "count": "[length(parameters('roleAssignments'))]"
+              },
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(managementGroup().id, parameters('roleAssignments')[copyIndex()].principalId, parameters('roleAssignments')[copyIndex()].roleDefinitionId)]",
+              "properties": {
+                "principalId": "[parameters('roleAssignments')[copyIndex()].principalId]",
+                "principalType": "ServicePrincipal",
+                "roleDefinitionId": "[parameters('roleAssignments')[copyIndex()].roleDefinitionId]"
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "customRoles",
+        "intermediateRoot"
+      ]
+    }
+  }
+}

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -320,6 +320,9 @@
     <None Update="Tests.Bicep.43.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Bicep\SymbolicNameTestCases\Tests.Bicep.6.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Bicep\SymbolicNameTestCases\Tests.Bicep.1.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Problem

Template expansion fails with `Hash must be finalized before the hash value is retrieved` when an object output from a module deployed to a different scope is used in a string function such as `guid()`.

Fixes #3909

## Root cause

Two defects, one masking the other.

**Cross-scope resource IDs (primary).** `DeploymentVisitor.GetDeploymentScope` resolved the `subscriptionId`, `resourceGroup`, and `managementGroup` properties of a deployment resource but ignored the `scope` property. For a module with `scope: someManagementGroup`, the nested deployment was registered under its real scope while the symbol resolved against the *parent* context scope. The two IDs disagreed, so `TemplateContext.TryGetResource()` returned false, `reference()` fell back to a synthetic mock, and `.outputs.x.value.id` collapsed to a null value.

**Hash finalization (secondary).** `ExpressionHelpers.GetUnique` only called `TransformFinalBlock` when the *physically last* argument was string-convertible. The unresolved value above landed in the last position, so the hash was never finalized and `algorithm.Hash` threw.

## Changes

- `GetDeploymentScope` now parses an explicit `scope` property via `ResourceHelper.ResourceIdComponents`, covering management group, subscription, resource group, and tenant scopes. Explicit scope takes precedence over the inherited parent context.
- `GetUnique` always uses `TransformBlock` in the loop and calls `TransformFinalBlock([], 0, 0)` once afterwards. SHA-256 output depends only on the concatenated byte stream, not how it is split across blocks, so this is byte-identical for every input that previously succeeded.

Both fixes ship together deliberately. Fixing hash finalization alone would turn the exception into silently duplicate `guid()` values, because the unresolved argument is skipped rather than reported.

## Tests

- `ExpressionHelpersTests.GetUnique_WhenLastArgumentIsNotAString_ShouldNotThrow` — null last argument, object last argument, empty args.
- `BicepSymbolicNameTests.ProcessTemplate_WhenObjectOutputPropertyUsedInGuid_ShouldResolveUniqueNames` with fixture `Tests.Bicep.6*` — a parent template creating a child management group, deploying a custom role definition module and a role assignment module to it with `scope:`. Asserts distinct resource names and that each `roleDefinitionId` resolves under the child management group.

Full `PSRule.Rules.Azure.Tests` suite passes (401/401). Also verified end to end against the real-world template that surfaced the issue: 10 role assignments, 10 distinct names, module outputs resolving to real role definition IDs.